### PR TITLE
State-sync debugging infrastructure, desync root-cause fixes, and executor failover

### DIFF
--- a/.claude/skills/debug-desync/SKILL.md
+++ b/.claude/skills/debug-desync/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: debug-desync
+description: Root-cause a SnakeTron state-sync bug (phantom death, drift, ghost game, desync report) from captured traces — replay them deterministically, find the first divergent tick, and turn the bug into a local failing test. Use whenever a sync issue is reported from prod or observed in dev.
+---
+
+# Debugging a state-sync issue from traces
+
+Read DEBUGGING.md at the repo root first — it explains the four sync
+primitives (fingerprints, TickHash probes, stream_seq, flight recorders) and
+the full runbook. This skill is the condensed procedure.
+
+## 1. Collect evidence
+
+- Server trace: `traces/game_<id>_server_*.jsonl` (or `$SNAKETRON_TRACE_DIR`).
+- Client trace: `traces/game_<id>_client_<user>_*.jsonl` — auto-uploaded on
+  detected desyncs; otherwise ask the reporter to run
+  `window.snaketronDebug.downloadTrace()` in the browser console.
+- If you only have one side, proceed anyway — a server trace alone can prove
+  or rule out engine nondeterminism; a client trace alone shows what the
+  client actually received.
+
+## 2. Analyze
+
+```bash
+cargo run --bin trace_rca -- <server_trace> [<client_trace>]      # human report
+cargo run --bin trace_rca -- <server_trace> <client_trace> --json # machine-readable
+```
+
+Trust the verdict as a starting hypothesis, then verify against the report
+details:
+
+- `TRANSPORT_LOSS`: check `missing_stream_seqs` — which messages, at what
+  tick. Then ask: did the client detect the gap (`Note` records) and resync?
+  If not, the detection/resync path is the bug, not the loss itself.
+- `ENGINE_NONDETERMINISM`: same inputs produced different states. Use the
+  first divergent tick to bisect the engine logic (`common/src/game_state.rs
+  tick_forward`, event application order, native-vs-WASM differences). This
+  is the most serious verdict.
+- `CLOCK_DRIFT`: client tick computation off; check `Clock` records and
+  command reschedule deltas.
+- Phantom-death report: look at command latency — a command whose
+  `command_id_server.tick` > `command_id_client.tick` was rescheduled because
+  it arrived past the 500 ms committed-lag window; the client showed the turn
+  at the requested tick, the server executed it later.
+
+## 3. Freeze the bug as a test
+
+```bash
+cargo run --bin trace_rca -- <server_trace> --emit-test server/tests/repro_<desc>.rs
+cargo test -p server --test repro_<desc>
+```
+
+Commit the trace fixture and the test with the fix.
+
+## 4. Fix and generalize
+
+After fixing, extend the chaos suite
+(`server/tests/sync_equivalence_test.rs`) with the failure shape you found —
+that suite simulates lossy/latent/jittery transport in-process and is the
+regression barrier for this bug class. `cargo test -p server` must be green.
+
+## Live-system spot checks
+
+- Client sync health in the browser console:
+  `JSON.parse(engine.getSyncStatusJson())` — gap counts, probe mismatches,
+  `needs_resync`.
+- Server logs: grep for `lagged`, `gap`, `resync`, `channel full` — every
+  loss path now logs loudly.

--- a/.github/workflows/github-action-test-simple-game.yml
+++ b/.github/workflows/github-action-test-simple-game.yml
@@ -51,9 +51,15 @@ jobs:
           cargo test --all --no-run
 
   test:
-    name: Run Simple Game Test
+    name: Run Tests (bus=${{ matrix.bus }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both game-bus transports must pass the full suite (see
+        # STREAMS_MIGRATION.md).
+        bus: [pubsub, streams]
     
     services:
       postgres:
@@ -128,10 +134,11 @@ jobs:
           DATABASE_URL: postgres://snaketron:snaketron@localhost:5432/snaketron
           TEST_DATABASE_URL: postgres://snaketron:snaketron@localhost:5432/postgres
           REDIS_URL: redis://localhost:6379
+          SNAKETRON_BUS: ${{ matrix.bus }}
           RUST_LOG: info
           RUST_BACKTRACE: 1
         run: |
-          echo "Running all tests..."
+          echo "Running all tests with SNAKETRON_BUS=${{ matrix.bus }}..."
           cargo test --all -- --nocapture --test-threads=1
           
       - name: Upload test results

--- a/.github/workflows/github-action-test-simple-game.yml
+++ b/.github/workflows/github-action-test-simple-game.yml
@@ -12,6 +12,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  # Compile-only guard: every test binary in the workspace must build, even the
+  # ones that are not executed in CI. Without this, test targets that fail to
+  # compile silently provide zero coverage (see DEBUGGING.md postmortem).
+  compile-tests:
+    name: Compile All Test Targets
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache dependencies
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ". -> target"
+          cache-on-failure: true
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq protobuf-compiler libprotobuf-dev
+          protoc --version
+
+      - name: Compile all test targets (no run)
+        env:
+          RUST_BACKTRACE: 1
+        run: |
+          echo "Compiling every test target in the workspace..."
+          cargo test --all --no-run
+
   test:
     name: Run Simple Game Test
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ client/web/dist
 states
 .DS_Store
 replays/
+
+# Sync flight-recorder traces (see DEBUGGING.md)
+traces/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,11 @@ SnakeTron is a multiplayer Snake game built with a Rust backend and WebAssembly 
 ## Project Structure
 - The _old directory can be fully ignored for all purposes
 
+## Debugging State Sync
+- Read DEBUGGING.md before touching anything related to game-state synchronization, event delivery, or client prediction. It documents the sync primitives (state fingerprints, TickHash heartbeats, stream_seq transport sequencing, flight-recorder traces) and the trace-to-local-repro workflow.
+- For a reported desync/phantom-death/ghost-game issue, use the debug-desync skill (.claude/skills/debug-desync).
+- The chaos suite server/tests/sync_equivalence_test.rs is the regression barrier for sync bugs: any change to the engine, executor publishing, or client reconciliation must keep it green.
+
 ## Development Notes
 - When developing migrations, just update the V1 migration, instead of adding a new one. And then, when necessary to run tests, clear / restart the db docker container before running them if necessary.
 - When modifying Snake position vectors, always remember to use the compressed Snake representation where the snake vector contains the head, turns, and tail, rather than every point of the logical snake. The logic is described in the code at @common/src/snake.rs in the `step_forward` function. For example, a straight snake of length 5 should have only 2 positions in the body vector, not 5.

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -1,0 +1,250 @@
+# Debugging State Synchronization
+
+This document is the runbook for diagnosing and fixing state-sync bugs — the
+class of issue where the client's view of a game diverges from the server's
+(phantom deaths, drifting snakes, ghost games that keep running after the
+backend stopped). It covers the observability primitives built into the game,
+the trace capture pipeline, and the workflow for turning an unreproducible
+production report into a local failing test.
+
+## The sync architecture in one paragraph
+
+The authoritative game runs in a server-side executor
+([game_executor.rs](server/src/game_executor.rs)) that advances a shared
+`GameEngine` by wall clock and publishes every event over Redis pub/sub.
+WebSocket servers hold replicas ([replication.rs](server/src/replication.rs))
+that apply those events and forward them to clients. The client runs the same
+engine compiled to WASM: its **committed** state advances only when server
+events arrive; its **predicted** state (what the player sees) is rebuilt from
+committed and free-runs ahead on the local clock, bounded by a prediction cap.
+Player commands are scheduled optimistically at the client's predicted tick and
+confirmed by the server, which may reschedule them to a later tick if they
+arrive after the committed-lag window (500 ms) has passed.
+
+Every hop in that pipeline is asynchronous and, before this infrastructure
+existed, silently lossy. The primitives below make loss and divergence
+*observable and self-healing* instead of silent.
+
+## The four primitives
+
+### 1. State fingerprints (`GameState::sync_hash`)
+
+[common/src/fingerprint.rs](common/src/fingerprint.rs) — a deterministic
+64-bit digest of everything gameplay-critical (snakes, food, scores, status,
+tick). Two states with equal hashes at the same tick are gameplay-equivalent.
+Excludes the RNG, in-flight command queue, and cosmetic fields, so it can be
+compared across server (native) and client (WASM) builds.
+
+### 2. TickHash heartbeat (`GameEvent::TickHash`)
+
+Every `TICK_HASH_INTERVAL_TICKS` (10 ticks ≈ 1 s) the executor broadcasts its
+committed hash + server timestamp. This one small message does three jobs:
+
+- **Divergence detection** — the client recomputes its own committed hash at
+  that tick and compares. Two consecutive mismatches ⇒ automatic resync.
+- **Liveness** — it arrives even when nothing is happening in the game, so
+  "no message for 3 s" now reliably means the stream is dead, and the client
+  shows a reconnect banner instead of simulating a ghost game.
+- **Clock reference** — `server_ts_ms` gives the client a continuous drift
+  signal.
+
+### 3. Transport sequencing (`GameEventMessage.stream_seq`)
+
+The executor stamps every published message with a per-game, strictly
+monotonic sequence number. Every consumer (replica, client engine) checks
+contiguity: a gap means messages were lost (Redis pub/sub is at-most-once) and
+triggers an automatic snapshot resync instead of silent divergence. Duplicates
+and stale messages are skipped instead of double-applied. This replaces the
+expensive "send a full snapshot every few seconds" workaround with resyncs
+that happen only when something was actually lost.
+
+Client-side health lives in `GameEngine::sync_status()` (gap counts, missed
+messages, probe results, `needs_resync`) and is surfaced to the UI via
+`GameClient.getSyncStatusJson()`.
+
+### 4. Flight recorders (traces)
+
+Both sides continuously record what their engine observed, in the shared
+JSONL format of [common/src/trace.rs](common/src/trace.rs):
+
+- **Server** — every game writes `traces/game_<id>_server_<ts>.jsonl`: the
+  initial state *including the RNG seed* (the deterministic replay anchor),
+  every command received, every message published, periodic fingerprints.
+  Append-and-flush, so a crashed game still leaves a readable trace.
+- **Client** — a ring buffer (last ~20k records) of every message received,
+  every command sent, clock-sync samples, and anomaly notes. Downloadable via
+  `window.snaketronDebug.downloadTrace()`, and auto-uploaded to
+  `POST /api/debug/client-trace` the first time a desync is detected in a
+  game.
+
+A server trace + a client trace for the same game is a complete, replayable
+record of the bug from both perspectives.
+
+## The workflow: from prod report to local failing test
+
+Someone reports "I died but I never hit the wall" or "the game froze but kept
+playing". You cannot reproduce it locally. Do this:
+
+1. **Get the traces.** Server: `traces/game_<id>_server_*.jsonl` on the
+   executor host (or wherever `SNAKETRON_TRACE_DIR` points). Client: the
+   auto-uploaded `game_<id>_client_<user>_*.jsonl` next to it — desyncs
+   upload themselves; for other reports ask the player to run
+   `window.snaketronDebug.downloadTrace()`.
+
+2. **Run the analyzer.**
+
+   ```bash
+   cargo run --bin trace_rca -- game_42_server.jsonl game_42_client_7.jsonl
+   ```
+
+   It replays both traces deterministically through the real engine and
+   cross-diffs them, printing a `DivergenceReport`:
+   - the **first divergent tick** and the state difference at that tick,
+   - **missing stream_seq ranges** (transport loss, and at which hop),
+   - **command latency**: when each input left the client vs. when the server
+     scheduled it, and whether it got rescheduled to a later tick,
+   - **clock drift** over the session,
+   - a **verdict**: `TRANSPORT_LOSS`, `ENGINE_NONDETERMINISM`, `CLOCK_DRIFT`,
+     or `IN_SYNC`.
+
+3. **Interpret the verdict.**
+   - `TRANSPORT_LOSS` — messages were dropped before reaching the client.
+     The client should have detected the gap and resynced; if it didn't,
+     that's the bug. Look at which hop lost them (server trace has
+     `EventOut`, client has `EventIn` — the diff names the missing ranges).
+   - `ENGINE_NONDETERMINISM` — same inputs, different states: a real logic
+     bug in the shared engine (native vs WASM, or event-application order).
+     This is the highest-severity verdict; the replay gives you the exact
+     first divergent tick to bisect.
+   - `CLOCK_DRIFT` — the client's tick computation was off; commands were
+     scheduled at the wrong ticks. Check the `Clock` samples.
+   - Phantom-death reports specifically: check the command-latency section —
+     a turn that left the client at predicted tick N but was scheduled by the
+     server at N+k (because it arrived > 500 ms late) is the classic cause;
+     the player saw the turn happen, the authoritative snake didn't turn.
+
+4. **Freeze it as a test.**
+
+   ```bash
+   cargo run --bin trace_rca -- game_42_server.jsonl --emit-test server/tests/repro_game_42.rs
+   ```
+
+   This writes a test that replays the trace and asserts on the divergence —
+   a permanent local reproduction of the prod bug. Fix the code until the
+   test's expectation changes to "deterministic", then keep the test.
+
+5. **Verify the fix against the whole class**, not just the instance: the
+   chaos suite ([sync_equivalence_test.rs](server/tests/sync_equivalence_test.rs))
+   drives a simulated client over a lossy, latent, jittery transport and
+   asserts detection + resync. Add the newly discovered failure shape there.
+
+## Monitoring signals worth alerting on
+
+All of these are cheap counters already tracked in `SyncStatus` (client) and
+logs (server):
+
+| Signal | Meaning | Healthy |
+|---|---|---|
+| TickHash mismatch rate | real divergence happening in prod | ~0 |
+| stream gap incidents / game | Redis pub/sub or broadcast loss | ~0 |
+| resync requests / game | self-healing frequency (masking loss) | < 1 |
+| commands rescheduled (server tick > client tick) | inputs arriving past the lag window | rare |
+| watchdog activations | dead streams noticed by clients | ~0 |
+| clock drift magnitude | client tick computation quality | < half a tick |
+
+A rising resync rate with a flat mismatch rate means the transport is losing
+messages but detection is working — degraded, not broken. Mismatches without
+gaps mean engine nondeterminism — page someone.
+
+## Root causes found and fixed (2026-07)
+
+Thirteen distinct defects were confirmed by a multi-agent audit (each verified
+by an independent 3-lens panel against the code). The fixes landed together
+with this infrastructure; the chaos suite and the replay harness lock each one
+in:
+
+| Defect | Fix |
+|---|---|
+| Events labeled with the pre-step tick, applied by clients one movement-step early — permanent body-geometry forks (e.g. snake grows a tick early). Found *empirically* by the replay harness's lossless-equivalence test | `run_until` labels events with the post-step tick ([game_engine.rs](common/src/game_engine.rs)) |
+| One `broadcast Lagged` or one malformed payload permanently killed a partition's whole event/command feed (`?` in `ChannelReceiver::recv`) | Lagged/malformed are logged and skipped; only shutdown ends the task ([pubsub_manager.rs](server/src/pubsub_manager.rs)) |
+| `FilteredEventReceiver` swallowed Lagged with a warning — clients silently lost N events forever | Lagged surfaces to the WS forwarder, which resyncs the client with a fresh watermarked snapshot ([replication.rs](server/src/replication.rs), [ws_server.rs](server/src/ws_server.rs)) |
+| Replica caught up at most ONE tick per received event (`if` vs `while`) — every mid-game join snapshot was geometrically wrong | Loop until the event's tick ([replication.rs](server/src/replication.rs)) |
+| Join race: state read before broadcast subscription — events in between were lost undetectably | Subscribe first; stream_seq watermark filter dedups the overlap ([replication.rs](server/src/replication.rs)) |
+| No loss detection anywhere (engine `sequence` was duplicated/fabricated and unusable) | Executor-assigned `stream_seq` + gap detection at replica and client + auto-resync |
+| Ghost games: prediction free-ran on wall clock forever; silent forward-loop exits; DB-fallback join with no live feed | Bounded prediction cap (engine), client liveness watchdog + reconnect overlay, loud logging + final snapshots on dead feeds |
+| `clockSync.reset()` on every WS close snapped the time base to zero drift until 3 new Pongs | `reset()` carries the last drift estimate forward ([clockSync.ts](client/web/utils/clockSync.ts)) |
+| One clock spike poisoned `last_command_tick` forever — all later commands scheduled in the far future (snake stops responding) | Ratchet bounded to predicted + 8 ticks ([game_engine.rs](common/src/game_engine.rs)) |
+| `HashSet` iteration order made multi-death respawn processing nondeterministic across native/WASM | Deaths processed in sorted order ([game_state.rs](common/src/game_state.rs)) |
+| Redis PING timeout `?`-exited the cluster singleton without stopping the service — zombie executor + split-brain duplicate games | Timeout takes the step-down path ([cluster_singleton.rs](server/src/cluster_singleton.rs)) |
+| Executor lease loss cancelled every in-flight game permanently; a lost `GameCreated` message meant a game that never started | Full failover path: 3 s lease with a 60 % grace window for *transient* renewal errors (a Redis blip no longer cancels games — safety proof in `renew_error_should_step_down`), Lua own-lease reclaim after blips, stored snapshots refreshed at TickHash cadence, and `resume_partition_games` on executor (re)start restarts every non-complete game from replica or stored-snapshot state. Snapshots re-anchor `stream_seq` watermarks at every hop (`FilteredEventReceiver`, replica, client), so a restarted executor's new stream is adopted instead of filtered as stale ([game_executor.rs](server/src/game_executor.rs), [cluster_singleton.rs](server/src/cluster_singleton.rs), [replication.rs](server/src/replication.rs)) |
+
+Known, intentionally unfixed (documented behavior):
+
+- **Command rebasing past the 500 ms window** — a turn arriving after the
+  committed-lag window is rescheduled later than the player saw it. This is
+  inherent to the current netcode model; it is now *measurable* (trace_rca
+  reports per-command tick deltas) rather than invisible. Eliminating it
+  requires input-delay or rollback netcode — an architectural decision.
+- **Executor failover loses the dead window** — commands sent while no
+  executor held the partition are dropped (clients see the reconnect overlay
+  and the resumed game fast-forwards to wall-clock time). Bounded by the ~3 s
+  lease + claim jitter; games whose executor stays dead longer than the 5-min
+  stored-snapshot TTL are not resumable.
+
+## Why these bugs reached production (postmortem)
+
+The three reported symptoms all trace to the same root pattern: **every hop
+could silently drop messages, nothing checked for loss, and the client had no
+way to notice it had diverged.**
+
+1. **Phantom wall deaths** — commands arriving after the 500 ms committed-lag
+   window are rescheduled to a later tick; the client had already executed
+   them at the requested tick. The turn happened on screen, not on the
+   server. Locally RTT ≈ 0, so the window never expired — prod-only by
+   construction. (Clock-sync error has the same effect via mis-stamped
+   command ticks.)
+2. **Cumulative drift needing periodic snapshots** — Redis pub/sub is
+   at-most-once; the broadcast fan-out drops messages when a receiver lags
+   (and one error path ended forwarding entirely, silently); nothing checked
+   `sequence` contiguity, so every lost event became permanent divergence.
+   Periodic snapshots masked the loss instead of detecting it.
+3. **Ghost games** — the predicted state free-ran on the local clock with no
+   bound and no liveness check, so a dead backend looked like a live game.
+
+Why tests never caught it:
+
+- Several game-flow test binaries (`solo_game_test`, `duel_game_test`,
+  `simple_game_test`, plus the terminal crate's tests) **did not even
+  compile** on the main branch — the suites most likely to exercise these
+  flows were dead code, so a green-looking local run never covered them.
+  (Since repaired: all pass again, and CI runs `cargo test --all --no-run`
+  so a test binary can never silently rot out of coverage again. Note:
+  running these against a Redis shared with a live dev server causes
+  cross-talk — pub/sub channels are global across Redis DBs — so stop the
+  dev `snaketron-server` container before running them.)
+- All integration tests ran over **perfect in-memory transports** — the
+  lossy/laggy paths (Redis reconnects, broadcast lag, ALB idle timeouts)
+  never executed in CI.
+- **No test ever compared the client-path state against the server-path
+  state.** The engine is shared, but the client drives it through a
+  different call sequence (`process_server_event` + `rebuild_predicted_state`
+  vs `run_until`); their equivalence was assumed, never asserted.
+- **Local dev is structurally incapable of reproducing the triggers**: one
+  process, localhost Redis, ~0 ms RTT, no proxy timeouts. Solo games in prod
+  still traverse the full multi-hop relay — which is why "even solo games"
+  broke in prod only.
+- Error paths logged-and-continued (or logged-and-died) — loss was invisible
+  by design.
+
+What now guards each gap: the chaos suite simulates loss/latency/jitter/silence
+in-process on every `cargo test`; fingerprint probes make divergence
+observable in prod within ~1 s; stream sequencing makes loss detectable at
+every hop; traces make any surviving bug replayable offline.
+
+## Environment variables
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SNAKETRON_TRACE_DIR` | `./traces` | Where server + uploaded client traces go |
+| `SNAKETRON_TRACE_DISABLE` | unset | `1` disables the server flight recorder |
+| `SNAKETRON_TRACE_MAX_FILES` | `200` | Trace-dir rotation limit |

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -248,3 +248,4 @@ every hop; traces make any surviving bug replayable offline.
 | `SNAKETRON_TRACE_DIR` | `./traces` | Where server + uploaded client traces go |
 | `SNAKETRON_TRACE_DISABLE` | unset | `1` disables the server flight recorder |
 | `SNAKETRON_TRACE_MAX_FILES` | `200` | Trace-dir rotation limit |
+| `SNAKETRON_BUS` | `streams` | Game-critical transport: `streams` (default) or `pubsub` fallback (see STREAMS_MIGRATION.md). On `streams`, the gap/resync counters should sit at ~0 — nonzero values there mean a transport bug |

--- a/STREAMS_MIGRATION.md
+++ b/STREAMS_MIGRATION.md
@@ -1,0 +1,193 @@
+# Valkey Streams Migration
+
+**Status: IMPLEMENTED — streams is the default.** The game-critical
+transport is configurable via `SNAKETRON_BUS=pubsub|streams` (default
+`streams`; set `pubsub` to fall back to the previous transport). The seam is
+`server/src/game_bus.rs` (`GameBus`); the full server suite passes under both
+configs (CI runs a matrix over both); dedicated streams tests cover zero-loss
+under a paused consumer, reconnect resume via CLIENT KILL, ordering, tail
+anchoring, and trimming; measured delivery latency is p50 ~1.3 ms / p99
+~3.6 ms — within ~0.2 ms of Pub/Sub and ~300x faster than the abandoned 2025
+implementation. The sections below record the assessment, the design rules,
+and the operational rollout guidance.
+
+## Rollout constraint: the flip is per-process, not per-fleet
+
+`SNAKETRON_BUS` selects the transport for one process. Publishers on one
+transport are invisible to consumers on the other, so a **mixed fleet during
+a rolling restart silently partitions cross-server traffic** (a pubsub-mode
+WS server's commands never reach a streams-mode executor). Flip the whole
+fleet at once: set the new value everywhere, then restart all servers
+together (a brief maintenance window), or scale to a single server for the
+flip. The failover/resume machinery (stored snapshots + resume-on-start)
+recovers in-flight games across the restart. If zero-downtime flips ever
+matter, add a transitional dual-publish mode first.
+
+## Why the old Streams implementation was slow (git archaeology)
+
+The 2025-07 Streams era (commits `61a5c31`…`67c0798`, replaced by Pub/Sub in
+`0f7ee58`) was slow for reasons that are all fixable usage errors, not
+properties of Streams. Ranked by measured impact:
+
+1. **Ten blocking readers multiplexed on ONE connection.** All 10
+   `PartitionReplica` loops issued `XREAD … BLOCK 100` on clones of a single
+   `ConnectionManager` (one TCP socket). Redis parks the *connection* during a
+   blocking read, so an event for partition P waited for up to nine other
+   partitions' reads to time out first: ~400–500 ms expected, ~900 ms worst.
+   This alone was 1–6 game ticks of lag and matches the "339ms+" measurement
+   in the `0f7ee58` commit message.
+2. **The publisher was queued behind its own parked reader.** The executor's
+   `XADD`s shared a connection with its own `XREADGROUP … BLOCK 100` loop, so
+   the first event of every tick burst waited out the BLOCK timeout *before
+   even reaching Redis*.
+3. **Per-WebSocket `XREAD` loops starting from ID `0`** over untrimmed
+   streams (until `e077485`): unbounded catch-up work per join, and every
+   client's blocking loop parked the shared WS connection that inputs were
+   published on — a ~100 ms input-latency floor.
+4. **100 ms BLOCK quantization + `COUNT 10` batches + one `XACK` round trip
+   per message**, on a game whose tick was 100–300 ms.
+5. **No trimming, ever** (`XTRIM`/`MAXLEN` appear nowhere in history), and
+   consumer groups whose recovery half (XPENDING/XAUTOCLAIM) was never built
+   — all the cost of groups, none of the benefit.
+
+Used correctly — **a dedicated connection per blocking reader, `XREAD BLOCK`
+as a push-like wait (it wakes on write, it is not a poll), start at `$`/last
+delivered ID, `MAXLEN ~` trimming, no consumer groups** — Streams deliver in
+~1 RTT, comparable to Pub/Sub's <5 ms, while keeping an ordered, replayable
+log.
+
+## What Streams solve, and what they don't
+
+The current tree already detects and heals transport loss (stream_seq gap
+detection → snapshot resync at replica and client; TickHash divergence
+probes). Streams make most of that machinery *structurally unnecessary on the
+server side* instead of load-bearing:
+
+| Problem | Pub/Sub today | With Streams |
+|---|---|---|
+| Message lost on subscriber reconnect/blip | Lost; gap detected; snapshot resync | Not lost — reader resumes `XREAD` from last-delivered ID |
+| Slow consumer (broadcast `Lagged`, mpsc full) | Messages dropped; loud logs; resync | Real backpressure — the reader simply reads later; nothing drops |
+| Subscribe/join race | Subscribe-first ordering + watermark filter | Position-based reads; race-free by construction |
+| Replica cold start with dead executor | Stored-snapshot fallback | Same, plus optional `XRANGE` catch-up from the snapshot's stream position |
+| Client (WebSocket) hop loss | stream_seq gap → RequestResync | **Unchanged** — Streams end at the server; keep client resync |
+| Engine nondeterminism / phantom deaths | TickHash probes, trace RCA | **Unchanged** — not a transport problem |
+
+Code simplification is real but modest: the resync/self-heal paths remain as
+defense-in-depth (and as *verification* — their counters should flatline on
+Streams), but they stop being the thing correctness depends on. The bigger
+win is operational: no more mystery loss class at all.
+
+## Configurable backend vs rewrite: make it configurable
+
+A rewrite is not warranted. The current architecture is already
+message-passing with snapshot anchors, and the whole game-critical surface is
+funneled through one API: `publish_event` / `publish_snapshot` /
+`publish_command` / `request_partition_snapshots` /
+`subscribe_to_partition → PartitionSubscription` (mpsc receivers). Both
+backends can implement that seam; consumers (executor, replicas) don't change.
+
+Two deliberate scope choices:
+
+- **Only game-critical traffic migrates.** Chat, lobby updates, user counts,
+  and matchmaking notifications are loss-tolerant fan-out — they stay on
+  Pub/Sub under either setting. This keeps the migration surface small.
+- **Dispatch by enum, not trait object.** Two variants behind a config flag;
+  no `async_trait`/dyn issues:
+
+```rust
+// server/src/message_bus.rs
+pub enum MessageBus {
+    PubSub(PubSubBus),   // current PubSubManager partition paths, moved
+    Streams(StreamsBus), // new
+}
+```
+
+`stream_seq` stays in the message payload under both backends: it is the
+end-to-end integrity check reaching the browser, the bridge across a backend
+flip, and the metric that proves the Streams backend works (gap counters go
+to zero).
+
+## Streams backend design (the anti-sluggish rules)
+
+Topology: three streams per partition —
+`snaketron:stream:events:{p}`, `…:commands:{p}`, `…:snapreq:{p}`.
+Same serde-JSON payloads as today in a single `data` field.
+
+1. **Publishers** use the shared non-blocking `ConnectionManager`. `XADD`
+   with approximate trimming: `MAXLEN ~ 8192` (events; several minutes of
+   backlog at game rates), `~ 1024` (commands), `~ 64` (snapreq). Publishers
+   never share a connection with a blocking reader.
+2. **One reader task per partition subscription, with its own dedicated
+   connection.** A single command watches all three streams:
+   `XREAD BLOCK 5000 COUNT 512 STREAMS ev cmd req <id1> <id2> <id3>`.
+   BLOCK is a liveness checkpoint, not a poll interval — Redis wakes the
+   reader the moment any watched stream gets an entry. Sub-ms delivery.
+3. **No consumer groups, no XACK.** Every consumer is fan-out (replicas) or a
+   lease-guarded singleton (executor command intake); each tracks its own
+   last-delivered ID in memory. On reader restart within a process: resume
+   from last ID → zero loss. On process restart: start at `$` and rely on the
+   existing snapshot anchoring (snapshots re-anchor watermarks at every hop —
+   this machinery already exists and is tested).
+4. **Backpressure instead of drops**: the reader forwards into the existing
+   bounded mpsc; when full it `send().await`s (pausing reads) rather than
+   `try_send`-and-drop.
+5. `store_snapshot` / `get_stored_snapshot` (plain KV) are backend-independent
+   and shared; executor failover/resume works identically under both.
+
+Dependency: one Cargo feature flag (`redis = { …, features = [… "streams"] }`).
+
+## Migration phases
+
+**Phase 0 — dead-code cleanup (optional, 30 min).** Remove
+`server/proto/stream_exchange.proto` (never referenced; pre-Redis scaffolding)
+and the stubbed `game_relay.proto`/`grpc_server.rs` relay (every handler is a
+`not yet implemented` warn, no live call site), plus their `build.rs` entries.
+Avoids confusion between "gRPC streaming" and "Redis Streams".
+
+**Phase 1 — extract the seam (mechanical, no behavior change).**
+Create `MessageBus` enum; move the partition-scoped methods out of
+`PubSubManager` into `PubSubBus` (delegating to the existing code);
+`subscribe_to_channel` (chat/lobby/counters) stays where it is. Plumb
+`SNAKETRON_BUS` (initially defaulting to `pubsub`; flipped to `streams` after validation) through `main.rs` → `game_server.rs` /
+`replication.rs` (the only construction sites). Exit gate: entire existing
+suite green with default config.
+
+**Phase 2 — implement `StreamsBus`.**
+Per the design above. Tests (real Valkey via test-deps, unique key prefixes to
+avoid dev-server cross-talk):
+- publish→consume round trip across all three streams;
+- *the headline test*: pause the consumer mid-game, publish N events, resume —
+  assert **zero** stream_seq gaps (this exact scenario loses messages on
+  Pub/Sub and is why resync exists);
+- trimming bounds respected under sustained publishing;
+- reader reconnect resumes from last ID;
+- latency smoke: p99 XADD→delivery < 10 ms at game-like rates (guards against
+  ever re-introducing the old blocking-read mistakes).
+
+**Phase 3 — wire consumers.** Executor and replication construct
+subscriptions via the bus; they already consume `PartitionSubscription`, so
+this is small. Run the chaos suite and full server suite under both configs
+(CI matrix: `SNAKETRON_BUS=pubsub` and `=streams` for the server test job).
+
+**Phase 4 — measure with the trace infra.** The flight recorders already
+timestamp every publish (`EventOut`) and receipt (`EventIn`); run identical
+bot games under each backend and compare delivery-latency distributions from
+the traces (`trace_rca --json`). Acceptance: Streams p99 within ~2 ms of
+Pub/Sub. This is the empirical answer to "are Streams fast enough now" —
+measured on this game, not assumed.
+
+**Phase 5 — rollout and (later) simplification.** Default stays `pubsub`;
+flip staging to `streams`; watch the SyncStatus counters
+(`stream_gap_count`, resync rate, `Lagged` warnings — all should go to ~0),
+then flip prod. After confidence: consider relaxing the stored-snapshot
+refresh cadence and demoting the gap-driven snapshot-request path to
+cold-start only. Keep the Pub/Sub backend as the escape hatch until Streams
+has weeks of clean counters; remove it only when the flag has become dead
+weight.
+
+## Effort estimate
+
+Phases 1–3 are one focused PR each (the seam extraction is mostly mechanical;
+the Streams backend is ~300–500 lines plus tests). Phases 4–5 are
+measurement and operations, not code. Total: a normal PR sequence on top of
+the current branch — not a rewrite.

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -134,6 +134,8 @@ impl GameClient {
             game_id: self.engine.game_id(),
             tick: game_state.current_tick(),
             sequence: game_state.event_sequence,
+            stream_seq: 0, // locally constructed, not from the transport
+
             user_id: None,
             event: GameEvent::Snapshot { game_state },
         };
@@ -190,6 +192,27 @@ impl GameClient {
     #[wasm_bindgen(js_name = getGameId)]
     pub fn get_game_id(&self) -> u32 {
         self.engine.game_id()
+    }
+
+    /// Get the engine's sync status (stream gaps, hash probes, needs_resync) as JSON
+    #[wasm_bindgen(js_name = getSyncStatusJson)]
+    pub fn get_sync_status_json(&self) -> Result<String, JsValue> {
+        self.engine
+            .sync_status_json()
+            .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
+
+    /// Get the committed-state sync hash as a decimal string
+    /// (u64 exceeds JS safe-integer range, so it crosses the boundary as text)
+    #[wasm_bindgen(js_name = getCommittedHash)]
+    pub fn get_committed_hash(&self) -> String {
+        self.engine.committed_sync_hash().to_string()
+    }
+
+    /// Clear the needs_resync flag once a resync request has been sent
+    #[wasm_bindgen(js_name = clearNeedsResync)]
+    pub fn clear_needs_resync(&mut self) {
+        self.engine.clear_needs_resync();
     }
 
     /// Get the snake ID for a given user ID

--- a/client/web/components/GameArena.tsx
+++ b/client/web/components/GameArena.tsx
@@ -39,6 +39,7 @@ export default function GameArena() {
     queueForMatch,
     queueForMatchMulti,
     isJoiningGame,
+    sendRequestResync,
   } = useGameWebSocket();
 
   const { user, loading: authLoading } = useAuth();
@@ -53,12 +54,17 @@ export default function GameArena() {
   const playerId = user?.id ?? 0;
   const queueMode: QueueMode = lobbyPreferences?.competitive ? 'Competitive' : 'Quickmatch';
 
+  const handleRequestResync = useCallback(() => {
+    sendRequestResync(gameId);
+  }, [sendRequestResync, gameId]);
+
   // Use game engine for client-side prediction (call unconditionally to keep hook order stable)
   const {
     gameEngine,
     gameState,
     committedState,
     isGameComplete,
+    connectionStale,
     // isRunning,
     sendCommand,
     processServerEvent,
@@ -67,6 +73,7 @@ export default function GameArena() {
     gameId,
     playerId,
     onCommandReady: sendGameCommand,
+    onRequestResync: handleRequestResync,
     latencyMs
   });
 
@@ -698,6 +705,16 @@ export default function GameArena() {
               </div>
             )}
             
+            {/* Connection watchdog overlay: prediction is frozen by the engine
+                while server messages are missing; explain the freeze */}
+            {connectionStale && !gameOver && (
+              <div className="absolute inset-0 flex items-center justify-center bg-white/85 z-30">
+                <span className="text-black font-black italic uppercase tracking-1 text-xl text-center px-4">
+                  CONNECTION LOST — RESYNCING
+                </span>
+              </div>
+            )}
+
             {/* Countdown Overlay */}
             {showCountdown && countdownState && (
               <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/30 z-10">

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -11,6 +11,7 @@ import {
   User,
 } from '../types';
 import { clockSync } from '../utils/clockSync';
+import { record as recordTrace } from '../utils/syncTrace';
 import { useLatency } from './LatencyContext';
 import { useAuth } from './AuthContext';
 import {
@@ -117,6 +118,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const gameChatIdRef = useRef<number | null>(null);
   const { settings: latencySettings } = useLatency();
   const { user, getToken } = useAuth();
+  const hasEverConnectedRef = useRef(false);
   const authHandshakeRef = useRef(false);
   const lastAuthTokenRef = useRef<string | null>(null);
   const previousUserRef = useRef<User | null>(null);
@@ -262,6 +264,10 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
 
       ws.current.onopen = () => {
         console.log('WebSocket connected to:', url);
+        if (hasEverConnectedRef.current) {
+          recordTrace({ Note: { ts_ms: Date.now(), note: 'ws reconnected' } });
+        }
+        hasEverConnectedRef.current = true;
         setIsConnected(true);
         if (reconnectTimeout.current) {
           clearTimeout(reconnectTimeout.current);
@@ -293,6 +299,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
 
       ws.current.onclose = () => {
         console.log('WebSocket disconnected');
+        recordTrace({ Note: { ts_ms: Date.now(), note: 'ws disconnected, reconnect scheduled' } });
         setIsConnected(false);
         // Reset clock sync
         clockSync.reset();
@@ -983,8 +990,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
           };
           return chatMessage;
         })
-        .filter((entry): entry is ChatMessage => entry !== null)
-        .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        .filter((entry: ChatMessage | null): entry is ChatMessage => entry !== null)
+        .sort((a: ChatMessage, b: ChatMessage) => a.timestamp.getTime() - b.timestamp.getTime());
 
       if (typeof lobbyId === 'number' && Number.isFinite(lobbyId)) {
         lobbyChatLobbyIdRef.current = lobbyId;
@@ -1151,8 +1158,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
           };
           return chatMessage;
         })
-        .filter((entry): entry is ChatMessage => entry !== null)
-        .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+        .filter((entry: ChatMessage | null): entry is ChatMessage => entry !== null)
+        .sort((a: ChatMessage, b: ChatMessage) => a.timestamp.getTime() - b.timestamp.getTime());
 
       if (typeof gameId === 'number' && Number.isFinite(gameId)) {
         gameChatIdRef.current = gameId;

--- a/client/web/hooks/useGameEngine.ts
+++ b/client/web/hooks/useGameEngine.ts
@@ -3,11 +3,13 @@ import { GameClient } from 'wasm-snaketron';
 import { GameState, GameCommand, Command } from '../types';
 import { getClockDrift } from '../utils/clockSync';
 import { parseU32GameId } from '../utils/gameId';
+import { startTrace, record as recordTrace, autoUploadOnce } from '../utils/syncTrace';
 
 interface UseGameEngineProps {
   gameId: string;
   playerId: number;
   onCommandReady?: (commandMessage: any) => void;
+  onRequestResync?: () => void;
   latencyMs?: number;
 }
 
@@ -16,16 +18,26 @@ interface UseGameEngineReturn {
   gameState: GameState | null;
   committedState: GameState | null;
   isGameComplete: boolean;
+  connectionStale: boolean;
   sendCommand: (command: Command) => void;
   processServerEvent: (event: any) => Promise<boolean>;
   stopEngine: () => void;
 }
 
+// Liveness watchdog: no server message for this long while the game is
+// running means the connection is effectively dead for gameplay purposes.
+const WATCHDOG_STALE_MS = 3000;
+// RequestResync pacing: needs_resync sends are debounced, watchdog sends
+// back off exponentially while the connection stays stale.
+const RESYNC_DEBOUNCE_MS = 2000;
+const WATCHDOG_BACKOFF_INITIAL_MS = 2000;
+const WATCHDOG_BACKOFF_MAX_MS = 10000;
 
 export const useGameEngine = ({
   gameId,
   playerId,
   onCommandReady,
+  onRequestResync,
   latencyMs = 0
 }: UseGameEngineProps): UseGameEngineReturn => {
   const engineRef = useRef<GameClient | null>(null);
@@ -33,8 +45,16 @@ export const useGameEngine = ({
   const [gameState, setGameState] = useState<GameState | null>(null);
   const [committedState, setCommittedState] = useState<GameState | null>(null);
   const [isGameComplete, setIsGameComplete] = useState(false);
+  const [connectionStale, setConnectionStale] = useState(false);
   const engineGameIdRef = useRef<string | null>(null);
   const latencyMsRef = useRef(latencyMs);
+  const onRequestResyncRef = useRef(onRequestResync);
+  const lastServerMsgAtRef = useRef<number | null>(null);
+  const staleRef = useRef(false);
+  const lastResyncSentAtRef = useRef(0);
+  const watchdogBackoffMsRef = useRef(WATCHDOG_BACKOFF_INITIAL_MS);
+  const watchdogNextSendAtRef = useRef(0);
+  const prevSyncStatusRef = useRef<any | null>(null);
 
   // console.log('useGameEngine called (initial state:', !!initialState);
 
@@ -42,6 +62,10 @@ export const useGameEngine = ({
   useEffect(() => {
     latencyMsRef.current = latencyMs;
   }, [latencyMs]);
+
+  useEffect(() => {
+    onRequestResyncRef.current = onRequestResync;
+  }, [onRequestResync]);
 
   // Tear down the current engine whenever the game ID changes so we can initialize from the next snapshot
   useEffect(() => {
@@ -67,6 +91,13 @@ export const useGameEngine = ({
     setGameState(null);
     setCommittedState(null);
     setIsGameComplete(false);
+    setConnectionStale(false);
+    staleRef.current = false;
+    lastServerMsgAtRef.current = null;
+    lastResyncSentAtRef.current = 0;
+    watchdogBackoffMsRef.current = WATCHDOG_BACKOFF_INITIAL_MS;
+    watchdogNextSendAtRef.current = 0;
+    prevSyncStatusRef.current = null;
   }, [gameId]);
 
   const runGameLoop = useCallback(() => {
@@ -165,6 +196,86 @@ export const useGameEngine = ({
         }
       }
 
+      // Sync health: watch the engine's stream/hash accounting for gaps and
+      // divergence, and drive the resync + liveness watchdog paths.
+      try {
+        const sync = JSON.parse(engineRef.current.getSyncStatusJson());
+        const prevSync = prevSyncStatusRef.current;
+        const nowMs = Date.now();
+
+        if (prevSync) {
+          if (sync.stream_gap_count > prevSync.stream_gap_count) {
+            recordTrace({
+              Note: {
+                ts_ms: nowMs,
+                note: `stream gap detected: gaps=${sync.stream_gap_count} missed=${sync.missed_messages} last_seq=${sync.last_stream_seq}`
+              }
+            });
+            autoUploadOnce('stream gap detected');
+          }
+          if (sync.total_mismatches > prevSync.total_mismatches) {
+            recordTrace({
+              Note: {
+                ts_ms: nowMs,
+                note: `hash mismatch at probe tick ${sync.last_probe_tick} (consecutive=${sync.consecutive_hash_mismatches}, total=${sync.total_mismatches})`
+              }
+            });
+          }
+          if (sync.consecutive_hash_mismatches >= 2 && prevSync.consecutive_hash_mismatches < 2) {
+            autoUploadOnce('2+ consecutive hash mismatches');
+          }
+        }
+        prevSyncStatusRef.current = sync;
+
+        if (sync.needs_resync && nowMs - lastResyncSentAtRef.current >= RESYNC_DEBOUNCE_MS) {
+          lastResyncSentAtRef.current = nowMs;
+          onRequestResyncRef.current?.();
+          engineRef.current.clearNeedsResync();
+          recordTrace({ Note: { ts_ms: nowMs, note: 'resync requested (needs_resync)' } });
+        }
+
+        // Liveness watchdog: the engine's bounded prediction freezes the
+        // simulation when server messages stop; surface that to the UI and
+        // nudge the server for a fresh snapshot with exponential backoff.
+        const committedStatus = committedState.status;
+        const isStarted =
+          typeof committedStatus === 'object' &&
+          committedStatus !== null &&
+          'Started' in committedStatus;
+        const lastMsgAt = lastServerMsgAtRef.current;
+
+        if (isStarted && lastMsgAt !== null && nowMs - lastMsgAt > WATCHDOG_STALE_MS) {
+          if (!staleRef.current) {
+            staleRef.current = true;
+            setConnectionStale(true);
+            watchdogBackoffMsRef.current = WATCHDOG_BACKOFF_INITIAL_MS;
+            watchdogNextSendAtRef.current = nowMs;
+            recordTrace({
+              Note: {
+                ts_ms: nowMs,
+                note: `watchdog fired: no server message for ${nowMs - lastMsgAt}ms`
+              }
+            });
+          }
+          if (nowMs >= watchdogNextSendAtRef.current) {
+            onRequestResyncRef.current?.();
+            recordTrace({
+              Note: {
+                ts_ms: nowMs,
+                note: `resync requested (watchdog, next backoff=${watchdogBackoffMsRef.current}ms)`
+              }
+            });
+            watchdogNextSendAtRef.current = nowMs + watchdogBackoffMsRef.current;
+            watchdogBackoffMsRef.current = Math.min(
+              watchdogBackoffMsRef.current * 2,
+              WATCHDOG_BACKOFF_MAX_MS
+            );
+          }
+        }
+      } catch (syncError) {
+        console.warn('Sync health check failed:', syncError);
+      }
+
       // Stop the loop if game is complete
       // if (typeof newState.status === 'object' && newState.status !== null && 'Complete' in newState.status) {
       //   console.log('Game completed, stopping game loop');
@@ -246,6 +357,14 @@ export const useGameEngine = ({
       const commandMessage = JSON.parse(commandMessageJson);
       console.log('Command message from engine:', commandMessage, 'at', Date.now());
 
+      recordTrace({
+        CmdOut: {
+          ts_ms: Date.now(),
+          predicted_tick: commandMessage?.command_id_client?.tick ?? 0,
+          cmd: commandMessage
+        }
+      });
+
       onCommandReady?.(commandMessage);
       console.log('Command sent to server at', Date.now());
     } catch (error) {
@@ -315,6 +434,7 @@ export const useGameEngine = ({
           cancelAnimationFrame(animationFrameRef.current);
           animationFrameRef.current = null;
         }
+        const isFirstInit = !engineRef.current;
         if (engineRef.current) {
           try {
             engineRef.current.free();
@@ -328,7 +448,38 @@ export const useGameEngine = ({
             JSON.stringify(event.Snapshot.game_state)
         );
         engineRef.current.setLocalPlayerId(playerId);
+
+        if (isFirstInit) {
+          // Use the game's real tick duration (custom games can differ from
+          // the default) so RCA clock-drift thresholds are computed correctly.
+          startTrace(
+            expectedGameId,
+            playerId,
+            event.Snapshot.game_state?.properties?.tick_duration_ms
+          );
+        } else {
+          // The rebuilt engine starts with fresh sync counters; the snapshot
+          // itself re-anchors the stream watermark.
+          recordTrace({ Note: { ts_ms: Date.now(), note: 'engine rebuilt from snapshot (resync)' } });
+        }
       }
+
+      // Liveness: any accepted server message for this game proves the pipe is alive
+      lastServerMsgAtRef.current = Date.now();
+      if (staleRef.current) {
+        staleRef.current = false;
+        setConnectionStale(false);
+        watchdogBackoffMsRef.current = WATCHDOG_BACKOFF_INITIAL_MS;
+        recordTrace({ Note: { ts_ms: Date.now(), note: 'watchdog cleared: server messages resumed' } });
+      }
+
+      recordTrace({
+        EventIn: {
+          ts_ms: Date.now(),
+          committed_tick: engineRef.current ? engineRef.current.getCommittedTick() : 0,
+          msg: fullEventMessage
+        }
+      });
 
       if (engineRef.current) {
         console.log('Processing server event:', fullEventMessage);
@@ -384,6 +535,7 @@ export const useGameEngine = ({
     gameState,
     committedState,
     isGameComplete,
+    connectionStale,
     sendCommand,
     processServerEvent,
     stopEngine,

--- a/client/web/hooks/useGameWebSocket.ts
+++ b/client/web/hooks/useGameWebSocket.ts
@@ -30,6 +30,7 @@ interface UseGameWebSocketReturn {
   startCustomGame: () => void;
   spectateGame: (gameId: string, gameCode?: string | null) => void;
   sendGameCommand: (command: GameCommand) => void;
+  sendRequestResync: (gameId: string) => void;
   connected: boolean;
 }
 
@@ -413,6 +414,20 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     });
   }, [isConnected, isSessionAuthenticated, sendMessage]);
 
+  // Ask the game executor for a fresh snapshot when the engine detects
+  // a stream gap / hash divergence, matching WSMessage::RequestResync
+  const sendRequestResync = useCallback((gameId: string) => {
+    const numericGameId = parseInt(gameId, 10);
+    if (!Number.isFinite(numericGameId)) {
+      console.error('Cannot request resync for invalid game ID:', gameId);
+      return;
+    }
+    console.log('Sending RequestResync for game', numericGameId);
+    sendMessage({
+      RequestResync: { game_id: numericGameId }
+    });
+  }, [sendMessage]);
+
   const createSoloGame = useCallback(() => {
     console.log('Queueing for a solo game');
     serverAssignedGameRef.current = null;
@@ -515,6 +530,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     startCustomGame,
     spectateGame,
     sendGameCommand,
+    sendRequestResync,
     connected: isConnected,
   };
 };

--- a/client/web/utils/clockSync.ts
+++ b/client/web/utils/clockSync.ts
@@ -3,6 +3,8 @@
  * between client and server to compensate for clock drift.
  */
 
+import { record as recordTrace } from './syncTrace';
+
 interface SyncMeasurement {
   offset: number;
   rtt: number;
@@ -75,6 +77,8 @@ class ClockSync {
       this.measurements.shift();
     }
 
+    recordTrace({ Clock: { ts_ms: t3, drift_ms: offset, rtt_ms: rtt } });
+
     console.log(`Clock sync - RTT: ${rtt}ms, Offset: ${offset.toFixed(1)}ms, Total measurements: ${this.measurements.length}`);
   }
 
@@ -128,10 +132,20 @@ class ClockSync {
   }
 
   /**
-   * Clear all measurements
+   * Reset for a new connection, carrying the last known drift forward.
+   *
+   * Wiping measurements entirely would make getClockDrift() return 0 until
+   * several new Pongs arrive — snapping the game-loop time base by the full
+   * true drift on every reconnect. That spike used to mis-stamp command
+   * ticks (the snake stops responding right after a reconnect). The real
+   * clock offset barely changes across a reconnect, so seed the new window
+   * with the previous estimate and let fresh measurements displace it.
    */
   reset() {
-    this.measurements = [];
+    const carriedDrift = this.getClockDrift();
+    this.measurements = this.measurements.length > 0
+      ? [{ offset: carriedDrift, rtt: 0, timestamp: Date.now() }]
+      : [];
     this.syncsSent = 0;
   }
 }

--- a/client/web/utils/syncTrace.ts
+++ b/client/web/utils/syncTrace.ts
@@ -1,0 +1,153 @@
+/**
+ * Client-side sync trace ("flight recorder") ring buffer.
+ *
+ * Records are shaped EXACTLY like the serde JSON of
+ * `common::trace::TraceRecord` (externally tagged), so a downloaded or
+ * uploaded client trace can be joined with a server trace by the offline
+ * RCA tooling without any conversion.
+ */
+
+import { api } from '../services/api';
+import { DEFAULT_TICK_INTERVAL_MS } from '../constants';
+
+export const TRACE_FORMAT_VERSION = 1;
+const MAX_RECORDS = 20000;
+
+export type TraceRecord =
+  | {
+      Meta: {
+        version: number;
+        side: 'Client' | 'Server';
+        game_id: number;
+        session: string;
+        ts_ms: number;
+        build: string;
+        tick_duration_ms: number;
+      };
+    }
+  | { EventIn: { ts_ms: number; committed_tick: number; msg: any } }
+  | { CmdOut: { ts_ms: number; predicted_tick: number; cmd: any } }
+  | { Fingerprint: { ts_ms: number; tick: number; hash: number } }
+  | { Clock: { ts_ms: number; drift_ms: number; rtt_ms: number } }
+  | { Note: { ts_ms: number; note: string } };
+
+let records: TraceRecord[] = [];
+let currentGameId: number | null = null;
+let currentUserId: number | null = null;
+let autoUploadTriggered = false;
+
+/**
+ * Reset the recorder for a new game and write the Meta record.
+ * Also re-arms the once-per-game auto-upload guard.
+ */
+export function startTrace(
+  gameId: number,
+  userId: number,
+  tickDurationMs: number = DEFAULT_TICK_INTERVAL_MS
+): void {
+  records = [];
+  currentGameId = gameId;
+  currentUserId = userId;
+  autoUploadTriggered = false;
+
+  records.push({
+    Meta: {
+      version: TRACE_FORMAT_VERSION,
+      side: 'Client',
+      game_id: gameId,
+      session: `user_${userId}`,
+      ts_ms: Date.now(),
+      build: `web-${process.env.NODE_ENV ?? 'unknown'}`,
+      tick_duration_ms: tickDurationMs,
+    },
+  });
+}
+
+/**
+ * Append a record. No-op until startTrace has been called. When the buffer
+ * is full the oldest non-Meta record is evicted so the Meta header (game id,
+ * session, tick duration) survives for the RCA tooling.
+ */
+export function record(rec: TraceRecord): void {
+  if (currentGameId === null) {
+    return;
+  }
+  records.push(rec);
+  if (records.length > MAX_RECORDS) {
+    records.splice(1, 1);
+  }
+}
+
+/** Download the current trace as game_<id>_client.jsonl. */
+export function downloadTrace(): void {
+  if (currentGameId === null || records.length === 0) {
+    console.warn('No sync trace to download');
+    return;
+  }
+
+  const jsonl = records.map((rec) => JSON.stringify(rec)).join('\n') + '\n';
+  const blob = new Blob([jsonl], { type: 'application/x-ndjson' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = `game_${currentGameId}_client.jsonl`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}
+
+/** Upload the current trace to the server-side debug collector. */
+export async function uploadTrace(): Promise<void> {
+  if (currentGameId === null || records.length === 0) {
+    console.warn('No sync trace to upload');
+    return;
+  }
+
+  // Snapshot before the async call so a concurrent startTrace can't mix games
+  const payload = {
+    game_id: currentGameId,
+    user_id: currentUserId,
+    records: [...records],
+  };
+
+  try {
+    await api.request('/api/debug/client-trace', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    });
+    console.log(`Uploaded sync trace for game ${payload.game_id} (${payload.records.length} records)`);
+  } catch (error) {
+    console.warn('Failed to upload sync trace:', error);
+    throw error;
+  }
+}
+
+/**
+ * Upload the trace at most once per game (re-armed by startTrace). Used to
+ * automatically capture the first desync of a game without spamming the
+ * collector on every subsequent anomaly.
+ */
+export function autoUploadOnce(reason: string): void {
+  if (currentGameId === null || autoUploadTriggered) {
+    return;
+  }
+  autoUploadTriggered = true;
+  record({ Note: { ts_ms: Date.now(), note: `auto-uploading trace: ${reason}` } });
+  uploadTrace().catch(() => {
+    // Already logged; keep the guard set so we don't retry-loop on failure
+  });
+}
+
+declare global {
+  interface Window {
+    snaketronDebug?: {
+      downloadTrace: () => void;
+      uploadTrace: () => Promise<void>;
+    };
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.snaketronDebug = { downloadTrace, uploadTrace };
+}

--- a/client/web/wasm-snaketron.d.ts
+++ b/client/web/wasm-snaketron.d.ts
@@ -57,6 +57,10 @@ declare module 'wasm-snaketron' {
     getPredictedTick(): number;
     getGameId(): number;
     getSnakeIdForUser(userId: number): number | undefined;
+    getSyncStatusJson(): string;
+    getCommittedHash(): string;
+    clearNeedsResync(): void;
+    free(): void;
   }
 
   export class Game {

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -18,3 +18,8 @@ pub const DEFAULT_QUICKMATCH_TEAM_TIME_LIMIT_MS: u32 = 90_000;
 
 /// Default interval for cluster singleton renewal in milliseconds
 pub const CLUSTER_RENEWAL_INTERVAL_MS: u64 = 150;
+
+/// How often (in committed ticks) the game executor publishes a TickHash
+/// heartbeat carrying the authoritative sync hash. Also used as a wall-clock
+/// cadence (interval * tick duration) when the committed tick is not advancing.
+pub const TICK_HASH_INTERVAL_TICKS: u32 = 10;

--- a/common/src/fingerprint.rs
+++ b/common/src/fingerprint.rs
@@ -1,0 +1,261 @@
+//! Deterministic fingerprinting of sync-critical game state.
+//!
+//! `GameState::sync_hash` produces a 64-bit digest of everything that must be
+//! identical between the server's authoritative state and a client's committed
+//! state at the same tick. The server broadcasts its hash periodically via
+//! `GameEvent::TickHash`; clients recompute the hash locally at that tick and
+//! compare, turning silent state divergence into a detectable, reportable event.
+//!
+//! Deliberately excluded from the hash:
+//! - `rng`: the client never spawns food, so its RNG state is not advanced.
+//! - `command_queue`: legitimately differs while a local command is in flight
+//!   (scheduled optimistically on the client, not yet confirmed by the server).
+//!   Divergence caused by lost/mis-scheduled commands still surfaces through
+//!   snake direction/body positions once the command executes.
+//! - `event_sequence`: client and server count locally-generated events
+//!   differently by design.
+//! - `usernames`, `spectators`, `game_code`, `host_user_id`, `start_ms`:
+//!   cosmetic or static; not gameplay state.
+
+use crate::game_state::{GameState, GameStatus};
+
+/// FNV-1a 64-bit, hand-rolled so both native and WASM builds hash identically
+/// with no dependencies. All multi-byte values are hashed little-endian.
+#[derive(Debug, Clone)]
+pub struct SyncHasher {
+    state: u64,
+}
+
+const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+const FNV_PRIME: u64 = 0x100000001b3;
+
+impl Default for SyncHasher {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl SyncHasher {
+    pub fn new() -> Self {
+        SyncHasher { state: FNV_OFFSET }
+    }
+
+    pub fn write_u8(&mut self, v: u8) {
+        self.state ^= v as u64;
+        self.state = self.state.wrapping_mul(FNV_PRIME);
+    }
+
+    pub fn write_bytes(&mut self, bytes: &[u8]) {
+        for b in bytes {
+            self.write_u8(*b);
+        }
+    }
+
+    pub fn write_u16(&mut self, v: u16) {
+        self.write_bytes(&v.to_le_bytes());
+    }
+
+    pub fn write_u32(&mut self, v: u32) {
+        self.write_bytes(&v.to_le_bytes());
+    }
+
+    pub fn write_u64(&mut self, v: u64) {
+        self.write_bytes(&v.to_le_bytes());
+    }
+
+    pub fn write_i16(&mut self, v: i16) {
+        self.write_bytes(&v.to_le_bytes());
+    }
+
+    pub fn finish(&self) -> u64 {
+        self.state
+    }
+}
+
+impl GameState {
+    /// Deterministic digest of the sync-critical state. Two states with equal
+    /// hashes at the same tick are gameplay-equivalent; a mismatch means the
+    /// client has diverged from the server and needs a resync.
+    pub fn sync_hash(&self) -> u64 {
+        let mut h = SyncHasher::new();
+
+        h.write_u32(self.tick);
+
+        // Status: discriminant plus gameplay-relevant payload. `server_id` is
+        // excluded so a mid-game failover does not read as divergence.
+        match &self.status {
+            GameStatus::Stopped => h.write_u8(0),
+            GameStatus::Started { .. } => h.write_u8(1),
+            GameStatus::Complete { winning_snake_id } => {
+                h.write_u8(2);
+                match winning_snake_id {
+                    Some(id) => {
+                        h.write_u8(1);
+                        h.write_u32(*id);
+                    }
+                    None => h.write_u8(0),
+                }
+            }
+        }
+
+        h.write_u16(self.arena.width);
+        h.write_u16(self.arena.height);
+        if let Some(zone) = &self.arena.team_zone_config {
+            h.write_u8(1);
+            h.write_u16(zone.end_zone_depth);
+            h.write_u16(zone.goal_width);
+        } else {
+            h.write_u8(0);
+        }
+
+        // Snakes: Vec index is the snake id, so order is canonical already.
+        h.write_u32(self.arena.snakes.len() as u32);
+        for snake in &self.arena.snakes {
+            h.write_u8(snake.is_alive as u8);
+            h.write_u8(direction_tag(&snake.direction));
+            h.write_u32(snake.food);
+            match snake.team_id {
+                Some(team) => {
+                    h.write_u8(1);
+                    h.write_u8(team.0);
+                }
+                None => h.write_u8(0),
+            }
+            h.write_u32(snake.body.len() as u32);
+            for pos in &snake.body {
+                h.write_i16(pos.x);
+                h.write_i16(pos.y);
+            }
+        }
+
+        // Food is a set for gameplay purposes; sort so that removal-order
+        // differences between server and client cannot cause false mismatches.
+        let mut food: Vec<(i16, i16)> = self.arena.food.iter().map(|p| (p.x, p.y)).collect();
+        food.sort_unstable();
+        h.write_u32(food.len() as u32);
+        for (x, y) in food {
+            h.write_i16(x);
+            h.write_i16(y);
+        }
+
+        // HashMaps are hashed in sorted key order for determinism.
+        let mut players: Vec<(u32, u32)> = self
+            .players
+            .iter()
+            .map(|(user_id, p)| (*user_id, p.snake_id))
+            .collect();
+        players.sort_unstable();
+        h.write_u32(players.len() as u32);
+        for (user_id, snake_id) in players {
+            h.write_u32(user_id);
+            h.write_u32(snake_id);
+        }
+
+        let mut scores: Vec<(u32, u32)> = self.scores.iter().map(|(k, v)| (*k, *v)).collect();
+        scores.sort_unstable();
+        h.write_u32(scores.len() as u32);
+        for (snake_id, score) in scores {
+            h.write_u32(snake_id);
+            h.write_u32(score);
+        }
+
+        match &self.team_scores {
+            Some(team_scores) => {
+                let mut ts: Vec<(u8, u32)> = team_scores.iter().map(|(k, v)| (k.0, *v)).collect();
+                ts.sort_unstable();
+                h.write_u8(1);
+                h.write_u32(ts.len() as u32);
+                for (team, score) in ts {
+                    h.write_u8(team);
+                    h.write_u32(score);
+                }
+            }
+            None => h.write_u8(0),
+        }
+
+        let mut xp: Vec<(u32, u32)> = self.player_xp.iter().map(|(k, v)| (*k, *v)).collect();
+        xp.sort_unstable();
+        h.write_u32(xp.len() as u32);
+        for (user_id, amount) in xp {
+            h.write_u32(user_id);
+            h.write_u32(amount);
+        }
+
+        h.write_u64(self.properties.available_food_target as u64);
+        h.write_u32(self.properties.tick_duration_ms);
+        match self.properties.time_limit_ms {
+            Some(limit) => {
+                h.write_u8(1);
+                h.write_u32(limit);
+            }
+            None => h.write_u8(0),
+        }
+
+        h.finish()
+    }
+}
+
+fn direction_tag(direction: &crate::Direction) -> u8 {
+    match direction {
+        crate::Direction::Up => 0,
+        crate::Direction::Down => 1,
+        crate::Direction::Left => 2,
+        crate::Direction::Right => 3,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{GameState, GameType, Position, QueueMode};
+
+    fn test_state() -> GameState {
+        GameState::new(
+            20,
+            20,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(42),
+            1_000,
+        )
+    }
+
+    #[test]
+    fn hash_is_stable_across_recomputation() {
+        let state = test_state();
+        assert_eq!(state.sync_hash(), state.sync_hash());
+    }
+
+    #[test]
+    fn hash_ignores_food_order() {
+        let mut a = test_state();
+        let mut b = test_state();
+        a.arena.food = vec![Position { x: 1, y: 2 }, Position { x: 3, y: 4 }];
+        b.arena.food = vec![Position { x: 3, y: 4 }, Position { x: 1, y: 2 }];
+        assert_eq!(a.sync_hash(), b.sync_hash());
+    }
+
+    #[test]
+    fn hash_detects_food_divergence() {
+        let mut a = test_state();
+        let mut b = test_state();
+        a.arena.food = vec![Position { x: 1, y: 2 }];
+        b.arena.food = vec![Position { x: 1, y: 3 }];
+        assert_ne!(a.sync_hash(), b.sync_hash());
+    }
+
+    #[test]
+    fn hash_ignores_rng_and_command_queue() {
+        let mut a = test_state();
+        let b = test_state();
+        a.rng = None;
+        assert_eq!(a.sync_hash(), b.sync_hash());
+    }
+
+    #[test]
+    fn hash_detects_tick_difference() {
+        let mut a = test_state();
+        let b = test_state();
+        a.tick += 1;
+        assert_ne!(a.sync_hash(), b.sync_hash());
+    }
+}

--- a/common/src/game_engine.rs
+++ b/common/src/game_engine.rs
@@ -3,6 +3,44 @@ use crate::{
     GameEventMessage, GameState, GameType, QueueMode,
 };
 use anyhow::Result;
+use serde::Serialize;
+
+/// How far past its last authoritative anchor the predicted state may free-run,
+/// on top of the committed-state lag. Once the committed state stops advancing
+/// (server silent, stream dead), prediction freezes after this window instead
+/// of simulating a ghost game indefinitely.
+pub const MAX_PREDICTION_AHEAD_MS: u32 = 1000;
+
+/// Client-side synchronization health, updated on every processed server
+/// message. Exposed to the UI so it can detect divergence (hash mismatches),
+/// message loss (stream gaps), and trigger a resync instead of drifting.
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct SyncStatus {
+    /// Last transport sequence seen (0 = none yet).
+    pub last_stream_seq: u64,
+    /// Number of distinct gap incidents observed.
+    pub stream_gap_count: u32,
+    /// Total messages known to have been missed.
+    pub missed_messages: u64,
+    /// Stale/duplicate messages skipped instead of double-applied.
+    pub stale_messages_skipped: u64,
+    /// Tick of the last server fingerprint probe processed.
+    pub last_probe_tick: Option<u32>,
+    /// Whether the last probe matched our committed state.
+    pub last_probe_matched: Option<bool>,
+    pub consecutive_hash_mismatches: u32,
+    pub total_probes: u64,
+    pub total_mismatches: u64,
+    /// First tick at which a hash mismatch was observed (for RCA).
+    pub first_mismatch_tick: Option<u32>,
+    /// Set when a gap or repeated mismatch means the client should request a
+    /// fresh snapshot. Cleared automatically when a snapshot is applied.
+    pub needs_resync: bool,
+    /// Highest tick seen in any server message (liveness reference).
+    pub last_server_tick: u32,
+    /// Server wall-clock from the last TickHash heartbeat (clock reference).
+    pub last_server_ts_ms: Option<i64>,
+}
 
 pub struct GameEngine {
     game_id: u32,
@@ -13,6 +51,7 @@ pub struct GameEngine {
     local_player_id: Option<u32>,
     command_counter: u32,
     last_command_tick: Option<u32>,
+    sync_status: SyncStatus,
 }
 
 impl GameEngine {
@@ -40,6 +79,7 @@ impl GameEngine {
             local_player_id: None,
             command_counter: 0,
             last_command_tick: None,
+            sync_status: SyncStatus::default(),
         }
     }
 
@@ -91,6 +131,7 @@ impl GameEngine {
             local_player_id: None,
             command_counter: 0,
             last_command_tick: None,
+            sync_status: SyncStatus::default(),
         }
     }
 
@@ -107,6 +148,7 @@ impl GameEngine {
             local_player_id: None,
             command_counter: 0,
             last_command_tick: None,
+            sync_status: SyncStatus::default(),
         }
     }
 
@@ -128,15 +170,24 @@ impl GameEngine {
             return Err(anyhow::anyhow!("Local player ID not set"));
         };
 
-        let mut predicted_tick = self
+        let current_predicted_tick = self
             .predicted_state
             .as_ref()
             .map(|s| s.current_tick())
             .unwrap_or(0);
+        let mut predicted_tick = current_predicted_tick;
 
-        // Ensure the tick is higher than the last command sent
+        // Ensure the tick is higher than the last command sent, but never let
+        // the ratchet run away from the present: if a clock spike once pushed
+        // last_command_tick far into the future, an unbounded ratchet would
+        // schedule every subsequent command at that far-future tick — the
+        // snake would simply stop responding. Rapid inputs may legitimately
+        // queue a few ticks ahead; beyond that margin the ratchet resets.
+        const MAX_COMMAND_AHEAD_TICKS: u32 = 8;
         if let Some(last_tick) = self.last_command_tick {
-            if predicted_tick <= last_tick {
+            if predicted_tick <= last_tick
+                && last_tick < current_predicted_tick + MAX_COMMAND_AHEAD_TICKS
+            {
                 predicted_tick = last_tick + 1;
             }
         }
@@ -163,14 +214,81 @@ impl GameEngine {
 
     /// Process a server event and reconcile with local predictions
     pub fn process_server_event(&mut self, event_message: &GameEventMessage) -> Result<()> {
+        let is_snapshot = matches!(&event_message.event, GameEvent::Snapshot { .. });
+
+        // Transport-integrity accounting. A gap means messages were lost
+        // somewhere between the game executor and us; our committed state can
+        // no longer be trusted and a snapshot resync is required.
+        if event_message.stream_seq > 0 {
+            let last = self.sync_status.last_stream_seq;
+            if is_snapshot {
+                // A snapshot re-anchors the stream: everything before it is
+                // superseded, so the watermark resets unconditionally.
+                self.sync_status.last_stream_seq = event_message.stream_seq;
+            } else if last == 0 {
+                self.sync_status.last_stream_seq = event_message.stream_seq;
+            } else if event_message.stream_seq <= last {
+                // Duplicate or stale delivery: applying it again would corrupt
+                // state (e.g. FoodEaten grows the snake twice). Skip it.
+                self.sync_status.stale_messages_skipped += 1;
+                return Ok(());
+            } else {
+                if event_message.stream_seq > last + 1 {
+                    self.sync_status.stream_gap_count += 1;
+                    self.sync_status.missed_messages += event_message.stream_seq - last - 1;
+                    self.sync_status.needs_resync = true;
+                }
+                self.sync_status.last_stream_seq = event_message.stream_seq;
+            }
+        }
+
+        if event_message.tick > self.sync_status.last_server_tick {
+            self.sync_status.last_server_tick = event_message.tick;
+        }
+
         // Step the committed state forward to the event tick before applying the event
         // This ensures events are applied at the correct tick (similar to ReplayViewer)
         while self.committed_state.current_tick() < event_message.tick {
             self.committed_state.tick_forward(true)?;
         }
 
+        // Fingerprint probes compare instead of mutate.
+        if let GameEvent::TickHash {
+            hash: server_hash,
+            server_ts_ms,
+        } = &event_message.event
+        {
+            let local_hash = self.committed_state.sync_hash();
+            let matched = local_hash == *server_hash;
+            self.sync_status.last_probe_tick = Some(event_message.tick);
+            self.sync_status.last_probe_matched = Some(matched);
+            self.sync_status.total_probes += 1;
+            self.sync_status.last_server_ts_ms = Some(*server_ts_ms);
+            if matched {
+                self.sync_status.consecutive_hash_mismatches = 0;
+            } else {
+                self.sync_status.total_mismatches += 1;
+                self.sync_status.consecutive_hash_mismatches += 1;
+                if self.sync_status.first_mismatch_tick.is_none() {
+                    self.sync_status.first_mismatch_tick = Some(event_message.tick);
+                }
+                // A single mismatch can be a transient in-flight command; two
+                // in a row means we have genuinely diverged.
+                if self.sync_status.consecutive_hash_mismatches >= 2 {
+                    self.sync_status.needs_resync = true;
+                }
+            }
+            return Ok(());
+        }
+
         self.committed_state
             .apply_event(event_message.event.clone(), None);
+
+        if is_snapshot {
+            // Fresh authoritative state: divergence bookkeeping starts over.
+            self.sync_status.needs_resync = false;
+            self.sync_status.consecutive_hash_mismatches = 0;
+        }
 
         // Also schedule in predicted state if it exists
         if let GameEvent::CommandScheduled { command_message: _ } = &event_message.event {
@@ -182,6 +300,18 @@ impl GameEngine {
         Ok(())
     }
 
+    /// Maximum tick the predicted state may reach given the committed state's
+    /// current tick: the committed lag window plus a bounded free-run margin.
+    /// When server messages stop arriving, the committed state freezes and
+    /// this cap freezes prediction shortly after, instead of letting the
+    /// client simulate a game the backend is no longer running.
+    fn max_predicted_tick(&self) -> u32 {
+        let tick_duration_ms = self.committed_state.properties.tick_duration_ms.max(1);
+        let ahead_ticks =
+            (self.committed_state_lag_ms + MAX_PREDICTION_AHEAD_MS) / tick_duration_ms;
+        self.committed_state.current_tick() + ahead_ticks.max(1)
+    }
+
     /// Rebuild predicted state from committed state and advance to current time
     pub fn rebuild_predicted_state(&mut self, current_ts: i64) -> Result<()> {
         // Handle pre-start case: if current time is before start time, don't advance
@@ -190,9 +320,11 @@ impl GameEngine {
             return Ok(());
         }
 
-        // Calculate target tick
+        // Calculate target tick, bounded so prediction cannot run away from
+        // the last authoritative state (see `max_predicted_tick`).
         let tick_duration_ms = self.committed_state.properties.tick_duration_ms as i64;
-        let predicted_target_tick = (elapsed_ms / tick_duration_ms) as u32;
+        let predicted_target_tick =
+            ((elapsed_ms / tick_duration_ms) as u32).min(self.max_predicted_tick());
 
         // Special case: if committed state is complete, always rebuild predicted from it
         // This ensures the predicted state shows the authoritative final outcome
@@ -240,22 +372,31 @@ impl GameEngine {
             return Ok(Vec::new());
         }
 
-        let predicted_target_tick = (elapsed_ms / tick_duration_ms as i64) as u32;
+        let wallclock_target_tick = (elapsed_ms / tick_duration_ms as i64) as u32;
         let lag_ticks = self.committed_state_lag_ms / tick_duration_ms;
-        let lagged_target_tick = predicted_target_tick.saturating_sub(lag_ticks);
+        let lagged_target_tick = wallclock_target_tick.saturating_sub(lag_ticks);
         let mut out: Vec<(u32, u64, GameEvent)> = Vec::new();
 
         while !self.committed_state.is_complete()
             && self.committed_state.current_tick() < lagged_target_tick
         {
-            let current_tick = self.committed_state.current_tick();
-            for (sequence, event) in self.committed_state.tick_forward(false)? {
-                // eprintln!("game_engine: Emitting event at tick {} seq {}: {:?}", current_tick, sequence, event);
-                out.push((current_tick, sequence, event));
+            let events = self.committed_state.tick_forward(false)?;
+            // Label events with the POST-step tick: an event produced during
+            // the step N -> N+1 describes the state at N+1. Receivers
+            // fast-forward their committed state to the event's tick before
+            // applying, so a pre-step label would make them apply movement
+            // effects (FoodEaten, SnakeDied, ...) one movement-step early —
+            // e.g. growing the snake a tick before the server does, forking
+            // the body geometry permanently.
+            let post_tick = self.committed_state.current_tick();
+            for (sequence, event) in events {
+                out.push((post_tick, sequence, event));
             }
         }
 
-        // Run predicted state to current time (not lagged)
+        // Run predicted state to current time (not lagged), bounded by the
+        // prediction cap relative to the just-advanced committed state.
+        let predicted_target_tick = wallclock_target_tick.min(self.max_predicted_tick());
         if let Some(predicted_state) = &mut self.predicted_state {
             while !predicted_state.is_complete()
                 && predicted_state.current_tick() < predicted_target_tick
@@ -329,5 +470,26 @@ impl GameEngine {
             .as_ref()
             .map(|state| state.current_tick())
             .unwrap_or_else(|| self.committed_state.current_tick())
+    }
+
+    // --- Sync health / debugging ---
+
+    pub fn sync_status(&self) -> &SyncStatus {
+        &self.sync_status
+    }
+
+    pub fn sync_status_json(&self) -> Result<String> {
+        Ok(serde_json::to_string(&self.sync_status)?)
+    }
+
+    /// Fingerprint of the committed state at its current tick.
+    pub fn committed_sync_hash(&self) -> u64 {
+        self.committed_state.sync_hash()
+    }
+
+    /// Call after a resync request has been issued so it isn't re-triggered
+    /// every frame while the snapshot is in flight.
+    pub fn clear_needs_resync(&mut self) {
+        self.sync_status.needs_resync = false;
     }
 }

--- a/common/src/game_state.rs
+++ b/common/src/game_state.rs
@@ -24,6 +24,12 @@ pub struct GameEventMessage {
     pub game_id: u32,
     pub tick: u32,
     pub sequence: u64,
+    /// Transport-level sequence, assigned by the publishing game executor and
+    /// strictly monotonic per game across ALL published messages (events,
+    /// snapshots, tick hashes). Receivers detect lost messages by checking
+    /// contiguity. 0 means "unassigned" (legacy or locally constructed).
+    #[serde(default)]
+    pub stream_seq: u64,
     pub user_id: Option<u32>,
     pub event: GameEvent,
 }
@@ -73,6 +79,16 @@ pub enum GameEvent {
     XPAwarded {
         player_xp: HashMap<u32, u32>,
     }, // user_id -> xp_gained
+
+    /// Periodic server heartbeat carrying the authoritative state fingerprint
+    /// at the message's tick (see `GameState::sync_hash`). Clients compare it
+    /// against their own committed state to detect divergence, use its arrival
+    /// as a liveness signal, and use `server_ts_ms` as a clock reference.
+    /// Never mutates state.
+    TickHash {
+        hash: u64,
+        server_ts_ms: i64,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
@@ -1070,7 +1086,13 @@ impl GameState {
             }
         }
 
-        // Rollback and kill snakes that crashed
+        // Rollback and kill snakes that crashed.
+        // Sorted order is required for determinism: HashSet iteration order
+        // differs between processes (native server vs WASM client), and
+        // respawn events consume RNG / emit events whose order must be
+        // identical on both sides.
+        let mut died_snake_ids: Vec<u32> = died_snake_ids.into_iter().collect();
+        died_snake_ids.sort_unstable();
         for snake_id in died_snake_ids {
             self.arena.snakes[snake_id as usize] = old_snakes[snake_id as usize].clone();
             self.apply_event(GameEvent::SnakeDied { snake_id }, Some(&mut out));
@@ -1514,6 +1536,9 @@ impl GameState {
             GameEvent::XPAwarded { player_xp } => {
                 self.player_xp = player_xp;
             }
+
+            // Pure observability signal; state is never mutated by it.
+            GameEvent::TickHash { .. } => {}
         }
     }
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,14 +1,18 @@
 mod ai;
 mod arena;
 mod constants;
+mod fingerprint;
 mod game_engine;
 mod game_state;
+pub mod replay;
 mod snake;
+pub mod trace;
 
 pub mod util;
 
 pub use ai::*;
 pub use constants::*;
+pub use fingerprint::SyncHasher;
 pub use game_engine::*;
 pub use game_state::*;
 pub use snake::*;

--- a/common/src/replay.rs
+++ b/common/src/replay.rs
@@ -1,0 +1,1215 @@
+//! Offline root-cause analysis over sync traces (`common::trace`).
+//!
+//! Three tools, all pure and portable (file I/O is native-only):
+//! - [`ServerReplay`]: re-drives a `GameEngine` from a server trace's anchor
+//!   state through the recorded command/event timeline and verifies that the
+//!   engine re-emits exactly the recorded event stream — proving (or refuting)
+//!   that the server simulation is deterministic.
+//! - [`ClientReplay`]: re-drives a `GameEngine` the way the web client does
+//!   (process_server_event per received message, recorded local commands
+//!   scheduled as-is) and verifies the client's recorded committed-state
+//!   fingerprints are reproduced.
+//! - [`diff_traces`]: joins a server trace and a client trace of the same game
+//!   into a [`DivergenceReport`]: lost stream sequences, first fingerprint
+//!   mismatch, command wire latency and rescheduling, clock drift, and a
+//!   root-cause [`DivergenceReport::verdict`].
+
+use crate::trace::{TraceRecord, TraceSide};
+use crate::{
+    CommandId, DEFAULT_TICK_INTERVAL_MS, GameCommandMessage, GameEngine, GameEvent,
+    GameEventMessage, GameState,
+};
+use anyhow::{Context, Result, bail};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::fmt::Write as _;
+
+/// First point where a replay stopped matching its recording.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct Divergence {
+    pub tick: u32,
+    pub kind: String,
+    /// What the recorded trace says happened.
+    pub expected: String,
+    /// What the replayed engine produced.
+    pub actual: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ReplayOutcome {
+    pub deterministic: bool,
+    pub ticks_replayed: u32,
+    pub events_compared: usize,
+    pub first_divergence: Option<Divergence>,
+}
+
+impl ReplayOutcome {
+    pub fn render(&self) -> String {
+        let mut s = String::new();
+        let _ = writeln!(s, "== server replay ==");
+        let _ = writeln!(s, "deterministic:   {}", self.deterministic);
+        let _ = writeln!(s, "ticks replayed:  {}", self.ticks_replayed);
+        let _ = writeln!(s, "events compared: {}", self.events_compared);
+        render_divergence(&mut s, &self.first_divergence);
+        s
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClientReplayOutcome {
+    pub reproduces: bool,
+    pub ticks_replayed: u32,
+    pub fingerprints_compared: usize,
+    pub first_divergence: Option<Divergence>,
+}
+
+impl ClientReplayOutcome {
+    pub fn render(&self) -> String {
+        let mut s = String::new();
+        let _ = writeln!(s, "== client replay ==");
+        let _ = writeln!(s, "reproduces:            {}", self.reproduces);
+        let _ = writeln!(s, "ticks replayed:        {}", self.ticks_replayed);
+        let _ = writeln!(s, "fingerprints compared: {}", self.fingerprints_compared);
+        render_divergence(&mut s, &self.first_divergence);
+        s
+    }
+}
+
+fn render_divergence(s: &mut String, divergence: &Option<Divergence>) {
+    match divergence {
+        None => {
+            let _ = writeln!(s, "first divergence: none");
+        }
+        Some(d) => {
+            let _ = writeln!(s, "first divergence: tick {} [{}]", d.tick, d.kind);
+            let _ = writeln!(s, "  recorded: {}", d.expected);
+            let _ = writeln!(s, "  replayed: {}", d.actual);
+        }
+    }
+}
+
+/// Side declared by the trace's Meta record, if any. Used by the CLI to pick
+/// the right replay for a trace file.
+pub fn trace_side(records: &[TraceRecord]) -> Option<TraceSide> {
+    records.iter().find_map(|r| match r {
+        TraceRecord::Meta { side, .. } => Some(*side),
+        _ => None,
+    })
+}
+
+fn event_value(event: &GameEvent) -> serde_json::Value {
+    serde_json::to_value(event).unwrap_or(serde_json::Value::Null)
+}
+
+fn fmt_event(tick: u32, sequence: u64, event: &GameEvent) -> String {
+    format!("tick={} seq={} {}", tick, sequence, event_value(event))
+}
+
+fn fmt_cmd(cmd: &GameCommandMessage) -> String {
+    serde_json::to_value(cmd)
+        .map(|v| v.to_string())
+        .unwrap_or_else(|_| format!("{:?}", cmd))
+}
+
+fn fmt_hash(hash: u64) -> String {
+    format!("{:#018x}", hash)
+}
+
+// ---------------------------------------------------------------------------
+// Server replay
+// ---------------------------------------------------------------------------
+
+enum ServerItem {
+    Cmd {
+        ts_ms: i64,
+        cmd: GameCommandMessage,
+    },
+    Event {
+        ts_ms: i64,
+        msg: Box<GameEventMessage>,
+    },
+    Probe {
+        ts_ms: i64,
+        tick: u32,
+        hash: u64,
+    },
+}
+
+/// Deterministic replay of a server-side trace.
+pub struct ServerReplay {
+    game_id: u32,
+    anchor: Box<GameState>,
+    timeline: Vec<ServerItem>,
+}
+
+impl ServerReplay {
+    pub fn from_records(records: Vec<TraceRecord>) -> Result<ServerReplay> {
+        let side = trace_side(&records).context("trace has no Meta record")?;
+        if side != TraceSide::Server {
+            bail!("trace Meta.side is {:?}, expected Server", side);
+        }
+        let game_id = records
+            .iter()
+            .find_map(|r| match r {
+                TraceRecord::Meta { game_id, .. } => Some(*game_id),
+                _ => None,
+            })
+            .context("trace has no Meta record")?;
+
+        let mut anchor: Option<Box<GameState>> = None;
+        let mut timeline = Vec::new();
+        for record in records {
+            // Only records at or after the anchor participate in the replay.
+            match record {
+                TraceRecord::State { state, .. } => {
+                    if anchor.is_none() {
+                        anchor = Some(state);
+                    }
+                }
+                TraceRecord::CmdIn { ts_ms, cmd } if anchor.is_some() => {
+                    timeline.push(ServerItem::Cmd { ts_ms, cmd });
+                }
+                TraceRecord::EventOut { ts_ms, msg } if anchor.is_some() => {
+                    timeline.push(ServerItem::Event { ts_ms, msg });
+                }
+                TraceRecord::Fingerprint { ts_ms, tick, hash } if anchor.is_some() => {
+                    timeline.push(ServerItem::Probe { ts_ms, tick, hash });
+                }
+                _ => {}
+            }
+        }
+        let anchor = anchor.context("server trace has no State record to anchor the replay")?;
+
+        Ok(ServerReplay {
+            game_id,
+            anchor,
+            timeline,
+        })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<ServerReplay> {
+        Self::from_records(crate::trace::read_trace(path)?)
+    }
+
+    /// Rebuild the engine from the anchor state and walk a virtual clock
+    /// through the recorded timeline, comparing everything the engine emits
+    /// against everything the trace says was published.
+    pub fn replay(&self) -> Result<ReplayOutcome> {
+        let mut engine = GameEngine::new_from_state(self.game_id, (*self.anchor).clone());
+        let anchor_tick = self.anchor.tick;
+
+        // Engine-emitted gameplay events not yet matched to a recorded
+        // EventOut. Snapshots are excluded: they are re-anchoring payloads,
+        // not gameplay events, and are byte-for-byte huge.
+        let mut emitted: VecDeque<(u32, u64, GameEvent)> = VecDeque::new();
+        // Commands scheduled by our process_command calls, awaiting their
+        // recorded CommandScheduled EventOut counterpart.
+        let mut scheduled: VecDeque<GameCommandMessage> = VecDeque::new();
+        let mut events_compared = 0usize;
+        let mut first_divergence: Option<Divergence> = None;
+
+        fn advance(
+            engine: &mut GameEngine,
+            ts_ms: i64,
+            emitted: &mut VecDeque<(u32, u64, GameEvent)>,
+        ) -> Result<()> {
+            for (tick, sequence, event) in engine.run_until(ts_ms)? {
+                if !matches!(event, GameEvent::Snapshot { .. }) {
+                    emitted.push_back((tick, sequence, event));
+                }
+            }
+            Ok(())
+        }
+
+        for item in &self.timeline {
+            if first_divergence.is_some() {
+                break;
+            }
+            match item {
+                ServerItem::Cmd { ts_ms, cmd } => {
+                    advance(&mut engine, *ts_ms, &mut emitted)?;
+                    scheduled.push_back(engine.process_command(cmd.clone())?);
+                }
+                ServerItem::Probe { ts_ms, tick, hash } => {
+                    advance(&mut engine, *ts_ms, &mut emitted)?;
+                    // Fingerprints are sampled between executor loop turns, so
+                    // the replayed tick can legitimately be ahead by the time
+                    // we process the record; only compare exact-tick samples.
+                    if engine.current_tick() == *tick && engine.committed_sync_hash() != *hash {
+                        first_divergence = Some(Divergence {
+                            tick: *tick,
+                            kind: "fingerprint_mismatch".into(),
+                            expected: fmt_hash(*hash),
+                            actual: fmt_hash(engine.committed_sync_hash()),
+                        });
+                    }
+                }
+                ServerItem::Event { ts_ms, msg } => {
+                    advance(&mut engine, *ts_ms, &mut emitted)?;
+                    match &msg.event {
+                        GameEvent::Snapshot { .. } => {}
+                        GameEvent::TickHash { hash, .. } => {
+                            events_compared += 1;
+                            if engine.current_tick() != msg.tick {
+                                first_divergence = Some(Divergence {
+                                    tick: msg.tick,
+                                    kind: "tick_hash_tick_mismatch".into(),
+                                    expected: format!("committed tick {}", msg.tick),
+                                    actual: format!("committed tick {}", engine.current_tick()),
+                                });
+                            } else if engine.committed_sync_hash() != *hash {
+                                first_divergence = Some(Divergence {
+                                    tick: msg.tick,
+                                    kind: "tick_hash_mismatch".into(),
+                                    expected: fmt_hash(*hash),
+                                    actual: fmt_hash(engine.committed_sync_hash()),
+                                });
+                            }
+                        }
+                        GameEvent::CommandScheduled { command_message } => {
+                            events_compared += 1;
+                            match scheduled.pop_front() {
+                                None => {
+                                    first_divergence = Some(Divergence {
+                                        tick: msg.tick,
+                                        kind: "unexpected_command_scheduled".into(),
+                                        expected: fmt_cmd(command_message),
+                                        actual: "<replay scheduled no command>".into(),
+                                    });
+                                }
+                                Some(ours) => {
+                                    if serde_json::to_value(&ours).ok()
+                                        != serde_json::to_value(command_message).ok()
+                                    {
+                                        first_divergence = Some(Divergence {
+                                            tick: msg.tick,
+                                            kind: "command_schedule_mismatch".into(),
+                                            expected: fmt_cmd(command_message),
+                                            actual: fmt_cmd(&ours),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                        _ => {
+                            events_compared += 1;
+                            match emitted.pop_front() {
+                                None => {
+                                    first_divergence = Some(Divergence {
+                                        tick: msg.tick,
+                                        kind: "missing_event".into(),
+                                        expected: fmt_event(msg.tick, msg.sequence, &msg.event),
+                                        actual: "<engine emitted no event>".into(),
+                                    });
+                                }
+                                Some((tick, sequence, event)) => {
+                                    if tick != msg.tick
+                                        || sequence != msg.sequence
+                                        || event_value(&event) != event_value(&msg.event)
+                                    {
+                                        first_divergence = Some(Divergence {
+                                            tick: msg.tick,
+                                            kind: "event_mismatch".into(),
+                                            expected: fmt_event(msg.tick, msg.sequence, &msg.event),
+                                            actual: fmt_event(tick, sequence, &event),
+                                        });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if first_divergence.is_none() {
+            if let Some((tick, sequence, event)) = emitted.pop_front() {
+                first_divergence = Some(Divergence {
+                    tick,
+                    kind: "extra_event".into(),
+                    expected: "<no further recorded events>".into(),
+                    actual: fmt_event(tick, sequence, &event),
+                });
+            }
+        }
+
+        Ok(ReplayOutcome {
+            deterministic: first_divergence.is_none(),
+            ticks_replayed: engine.current_tick().saturating_sub(anchor_tick),
+            events_compared,
+            first_divergence,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Client replay
+// ---------------------------------------------------------------------------
+
+enum ClientItem {
+    Event { msg: Box<GameEventMessage> },
+    Cmd { cmd: GameCommandMessage },
+    Probe { tick: u32, hash: u64 },
+}
+
+/// Replay of a client-side trace: reproduces the committed state exactly as
+/// the live client built it and checks the recorded fingerprints.
+pub struct ClientReplay {
+    game_id: u32,
+    anchor: Box<GameState>,
+    timeline: Vec<ClientItem>,
+}
+
+impl ClientReplay {
+    pub fn from_records(records: Vec<TraceRecord>) -> Result<ClientReplay> {
+        let side = trace_side(&records).context("trace has no Meta record")?;
+        if side != TraceSide::Client {
+            bail!("trace Meta.side is {:?}, expected Client", side);
+        }
+        let game_id = records
+            .iter()
+            .find_map(|r| match r {
+                TraceRecord::Meta { game_id, .. } => Some(*game_id),
+                _ => None,
+            })
+            .context("trace has no Meta record")?;
+
+        // Anchor: the first recorded State, or the state inside the first
+        // received Snapshot. Records before the anchor predate any
+        // authoritative state and are skipped, exactly as the live client's
+        // pre-snapshot state was thrown away.
+        let mut anchor: Option<Box<GameState>> = None;
+        let mut timeline = Vec::new();
+        for record in records {
+            match record {
+                TraceRecord::State { state, .. } => {
+                    if anchor.is_none() {
+                        anchor = Some(state);
+                    }
+                }
+                TraceRecord::EventIn { msg, .. } => {
+                    if anchor.is_some() {
+                        timeline.push(ClientItem::Event { msg });
+                    } else if let GameEvent::Snapshot { game_state } = &msg.event {
+                        anchor = Some(Box::new(game_state.clone()));
+                        // Keep the snapshot in the timeline: re-applying it is
+                        // idempotent and sets the stream watermark like the
+                        // live client's processing did.
+                        timeline.push(ClientItem::Event { msg });
+                    }
+                }
+                TraceRecord::CmdOut { cmd, .. } if anchor.is_some() => {
+                    timeline.push(ClientItem::Cmd { cmd });
+                }
+                TraceRecord::Fingerprint { tick, hash, .. } if anchor.is_some() => {
+                    timeline.push(ClientItem::Probe { tick, hash });
+                }
+                _ => {}
+            }
+        }
+        let anchor =
+            anchor.context("client trace has no State record and no Snapshot EventIn to anchor")?;
+
+        Ok(ClientReplay {
+            game_id,
+            anchor,
+            timeline,
+        })
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn from_file(path: impl AsRef<std::path::Path>) -> Result<ClientReplay> {
+        Self::from_records(crate::trace::read_trace(path)?)
+    }
+
+    pub fn replay(&self) -> Result<ClientReplayOutcome> {
+        let mut engine = GameEngine::new_from_state(self.game_id, (*self.anchor).clone());
+        let anchor_tick = self.anchor.tick;
+        let mut fingerprints_compared = 0usize;
+        let mut first_divergence: Option<Divergence> = None;
+
+        for item in &self.timeline {
+            if first_divergence.is_some() {
+                break;
+            }
+            match item {
+                ClientItem::Event { msg } => {
+                    engine.process_server_event(msg)?;
+                }
+                ClientItem::Cmd { cmd } => {
+                    schedule_recorded_client_command(&mut engine, self.game_id, cmd)?;
+                }
+                ClientItem::Probe { tick, hash } => {
+                    fingerprints_compared += 1;
+                    if engine.current_tick() != *tick {
+                        first_divergence = Some(Divergence {
+                            tick: *tick,
+                            kind: "fingerprint_tick_mismatch".into(),
+                            expected: format!("committed tick {}", tick),
+                            actual: format!("committed tick {}", engine.current_tick()),
+                        });
+                    } else if engine.committed_sync_hash() != *hash {
+                        first_divergence = Some(Divergence {
+                            tick: *tick,
+                            kind: "fingerprint_mismatch".into(),
+                            expected: fmt_hash(*hash),
+                            actual: fmt_hash(engine.committed_sync_hash()),
+                        });
+                    }
+                }
+            }
+        }
+
+        Ok(ClientReplayOutcome {
+            reproduces: first_divergence.is_none(),
+            ticks_replayed: engine.current_tick().saturating_sub(anchor_tick),
+            fingerprints_compared,
+            first_divergence,
+        })
+    }
+}
+
+/// Schedule a recorded client command exactly as `process_local_command` did
+/// at capture time: the recorded message already carries the tick the client
+/// chose, so it is applied as-is (never re-derived) through a synthetic
+/// CommandScheduled message. `tick: 0` / `stream_seq: 0` guarantee this can
+/// neither fast-forward the committed state nor disturb gap accounting.
+fn schedule_recorded_client_command(
+    engine: &mut GameEngine,
+    game_id: u32,
+    cmd: &GameCommandMessage,
+) -> Result<()> {
+    let msg = GameEventMessage {
+        game_id,
+        tick: 0,
+        sequence: 0,
+        stream_seq: 0,
+        user_id: Some(cmd.command_id_client.user_id),
+        event: GameEvent::CommandScheduled {
+            command_message: cmd.clone(),
+        },
+    };
+    engine.process_server_event(&msg)
+}
+
+// ---------------------------------------------------------------------------
+// Trace diffing
+// ---------------------------------------------------------------------------
+
+/// Inclusive range of missing transport sequences.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+pub struct SeqRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct FingerprintMismatch {
+    pub tick: u32,
+    pub server_hash: u64,
+    pub client_hash: u64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CommandLatencyEntry {
+    pub user_id: u32,
+    /// Tick the client scheduled the command at (CmdOut.predicted_tick).
+    pub client_tick: u32,
+    /// CmdIn receive time minus CmdOut send time; None if the command never
+    /// reached the server (itself a transport-loss signal).
+    pub wire_latency_ms: Option<i64>,
+    /// Tick the server actually scheduled the command at.
+    pub server_tick: Option<u32>,
+    /// server_tick - client_tick; non-zero means the command was rescheduled.
+    pub tick_delta: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ClockDriftSummary {
+    pub samples: usize,
+    pub min_ms: f64,
+    pub max_ms: f64,
+    pub mean_ms: f64,
+    pub max_abs_ms: f64,
+    pub mean_rtt_ms: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct TaggedNote {
+    pub side: TraceSide,
+    pub ts_ms: i64,
+    pub note: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct DivergenceReport {
+    /// EventOut stream_seqs the server published (up to the last seq the
+    /// client saw) that never appear in the client's EventIn records.
+    pub missing_stream_seqs: Vec<SeqRange>,
+    /// Server tick of the earliest missing message, for ordering against the
+    /// first fingerprint mismatch.
+    pub first_missing_seq_tick: Option<u32>,
+    /// Earliest tick where both sides recorded a Fingerprint and disagree.
+    pub first_fingerprint_mismatch: Option<FingerprintMismatch>,
+    pub command_latency: Vec<CommandLatencyEntry>,
+    pub clock_drift_summary: Option<ClockDriftSummary>,
+    pub notes: Vec<TaggedNote>,
+    pub tick_duration_ms: u32,
+}
+
+impl DivergenceReport {
+    /// Root-cause heuristic, most-specific first.
+    pub fn verdict(&self) -> String {
+        let first_mismatch_tick = self.first_fingerprint_mismatch.as_ref().map(|m| m.tick);
+        if !self.missing_stream_seqs.is_empty() {
+            // Loss that precedes (or exists without) any hash divergence is
+            // the root cause; divergence is just its downstream symptom.
+            let loss_precedes_mismatch = match (self.first_missing_seq_tick, first_mismatch_tick) {
+                (_, None) => true,
+                (Some(loss_tick), Some(mismatch_tick)) => loss_tick <= mismatch_tick,
+                (None, Some(_)) => false,
+            };
+            if loss_precedes_mismatch {
+                return "TRANSPORT_LOSS".into();
+            }
+        }
+        if first_mismatch_tick.is_some() {
+            return "ENGINE_NONDETERMINISM".into();
+        }
+        let rescheduled = self
+            .command_latency
+            .iter()
+            .any(|c| c.tick_delta.is_some_and(|d| d != 0));
+        let drift_exceeds_half_tick = self
+            .clock_drift_summary
+            .as_ref()
+            .is_some_and(|s| s.max_abs_ms > self.tick_duration_ms as f64 / 2.0);
+        if drift_exceeds_half_tick && rescheduled {
+            return "CLOCK_DRIFT".into();
+        }
+        "IN_SYNC".into()
+    }
+
+    pub fn render(&self) -> String {
+        let mut s = String::new();
+        let _ = writeln!(s, "== trace divergence report ==");
+        let _ = writeln!(s, "verdict: {}", self.verdict());
+        let _ = writeln!(s, "tick duration: {} ms", self.tick_duration_ms);
+
+        if self.missing_stream_seqs.is_empty() {
+            let _ = writeln!(s, "missing stream seqs: none");
+        } else {
+            let total: u64 = self
+                .missing_stream_seqs
+                .iter()
+                .map(|r| r.end - r.start + 1)
+                .sum();
+            let _ = writeln!(
+                s,
+                "missing stream seqs: {} message(s) in {} range(s){}",
+                total,
+                self.missing_stream_seqs.len(),
+                self.first_missing_seq_tick
+                    .map(|t| format!(", first at server tick {}", t))
+                    .unwrap_or_default()
+            );
+            for r in &self.missing_stream_seqs {
+                let _ = writeln!(s, "  seq {}..={}", r.start, r.end);
+            }
+        }
+
+        match &self.first_fingerprint_mismatch {
+            None => {
+                let _ = writeln!(s, "first fingerprint mismatch: none");
+            }
+            Some(m) => {
+                let _ = writeln!(
+                    s,
+                    "first fingerprint mismatch: tick {} server={} client={}",
+                    m.tick,
+                    fmt_hash(m.server_hash),
+                    fmt_hash(m.client_hash)
+                );
+            }
+        }
+
+        let _ = writeln!(s, "commands: {}", self.command_latency.len());
+        for c in &self.command_latency {
+            let _ = writeln!(
+                s,
+                "  user {} client_tick={} wire={} server_tick={} delta={}",
+                c.user_id,
+                c.client_tick,
+                c.wire_latency_ms
+                    .map(|v| format!("{}ms", v))
+                    .unwrap_or_else(|| "LOST".into()),
+                c.server_tick
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into()),
+                c.tick_delta
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into()),
+            );
+        }
+
+        match &self.clock_drift_summary {
+            None => {
+                let _ = writeln!(s, "clock drift: no samples");
+            }
+            Some(d) => {
+                let _ = writeln!(
+                    s,
+                    "clock drift: samples={} min={:.1}ms max={:.1}ms mean={:.1}ms mean_rtt={:.1}ms",
+                    d.samples, d.min_ms, d.max_ms, d.mean_ms, d.mean_rtt_ms
+                );
+            }
+        }
+
+        if self.notes.is_empty() {
+            let _ = writeln!(s, "notes: none");
+        } else {
+            let _ = writeln!(s, "notes:");
+            for n in &self.notes {
+                let _ = writeln!(s, "  [{:?} @ {}] {}", n.side, n.ts_ms, n.note);
+            }
+        }
+        s
+    }
+}
+
+fn seqs_to_ranges(seqs: &[u64]) -> Vec<SeqRange> {
+    let mut ranges: Vec<SeqRange> = Vec::new();
+    for &seq in seqs {
+        match ranges.last_mut() {
+            Some(last) if last.end + 1 == seq => last.end = seq,
+            _ => ranges.push(SeqRange {
+                start: seq,
+                end: seq,
+            }),
+        }
+    }
+    ranges
+}
+
+/// Join a server trace and a client trace of the same game.
+pub fn diff_traces(server: &[TraceRecord], client: &[TraceRecord]) -> DivergenceReport {
+    let tick_duration_ms = [server, client]
+        .iter()
+        .find_map(|records| {
+            records.iter().find_map(|r| match r {
+                TraceRecord::Meta {
+                    tick_duration_ms, ..
+                } => Some(*tick_duration_ms),
+                _ => None,
+            })
+        })
+        .unwrap_or(DEFAULT_TICK_INTERVAL_MS);
+
+    // --- server side ---
+    let mut server_seq_ticks: BTreeMap<u64, u32> = BTreeMap::new();
+    let mut server_fingerprints: BTreeMap<u32, u64> = BTreeMap::new();
+    let mut cmd_in_ts: HashMap<CommandId, i64> = HashMap::new();
+    let mut server_assigned: HashMap<CommandId, u32> = HashMap::new();
+    let mut notes: Vec<TaggedNote> = Vec::new();
+
+    for record in server {
+        match record {
+            TraceRecord::EventOut { msg, .. } => {
+                if msg.stream_seq > 0 {
+                    server_seq_ticks.insert(msg.stream_seq, msg.tick);
+                }
+                if let GameEvent::CommandScheduled { command_message } = &msg.event {
+                    if let Some(server_id) = &command_message.command_id_server {
+                        server_assigned
+                            .insert(command_message.command_id_client.clone(), server_id.tick);
+                    }
+                }
+            }
+            TraceRecord::CmdIn { ts_ms, cmd } => {
+                cmd_in_ts.insert(cmd.command_id_client.clone(), *ts_ms);
+                if let Some(server_id) = &cmd.command_id_server {
+                    server_assigned.insert(cmd.command_id_client.clone(), server_id.tick);
+                }
+            }
+            TraceRecord::Fingerprint { tick, hash, .. } => {
+                server_fingerprints.entry(*tick).or_insert(*hash);
+            }
+            TraceRecord::Note { ts_ms, note } => notes.push(TaggedNote {
+                side: TraceSide::Server,
+                ts_ms: *ts_ms,
+                note: note.clone(),
+            }),
+            _ => {}
+        }
+    }
+
+    // --- client side ---
+    let mut client_seqs: HashSet<u64> = HashSet::new();
+    let mut client_first_seq: Option<u64> = None;
+    let mut client_fingerprints: BTreeMap<u32, u64> = BTreeMap::new();
+    let mut cmd_outs: Vec<(i64, u32, GameCommandMessage)> = Vec::new();
+    let mut drift_samples: Vec<(f64, f64)> = Vec::new();
+
+    for record in client {
+        match record {
+            TraceRecord::EventIn { msg, .. } => {
+                if msg.stream_seq > 0 {
+                    client_first_seq.get_or_insert(msg.stream_seq);
+                    client_seqs.insert(msg.stream_seq);
+                }
+            }
+            TraceRecord::CmdOut {
+                ts_ms,
+                predicted_tick,
+                cmd,
+            } => cmd_outs.push((*ts_ms, *predicted_tick, cmd.clone())),
+            TraceRecord::Fingerprint { tick, hash, .. } => {
+                client_fingerprints.entry(*tick).or_insert(*hash);
+            }
+            TraceRecord::Clock {
+                drift_ms, rtt_ms, ..
+            } => drift_samples.push((*drift_ms, *rtt_ms)),
+            TraceRecord::Note { ts_ms, note } => notes.push(TaggedNote {
+                side: TraceSide::Client,
+                ts_ms: *ts_ms,
+                note: note.clone(),
+            }),
+            _ => {}
+        }
+    }
+    notes.sort_by_key(|n| n.ts_ms);
+
+    // Missing seqs: only within the window the client was actually attached.
+    // Seqs below the first received message were absorbed into the join
+    // snapshot (not lost); seqs above the highest received may simply be
+    // still in flight when the trace ended.
+    let client_min_seq = client_first_seq.unwrap_or(0);
+    let client_max_seq = client_seqs.iter().max().copied().unwrap_or(0);
+    let missing: Vec<u64> = server_seq_ticks
+        .iter()
+        .filter(|(seq, _)| {
+            **seq > client_min_seq && **seq <= client_max_seq && !client_seqs.contains(seq)
+        })
+        .map(|(seq, _)| *seq)
+        .collect();
+    let first_missing_seq_tick = missing
+        .first()
+        .and_then(|seq| server_seq_ticks.get(seq).copied());
+    let missing_stream_seqs = seqs_to_ranges(&missing);
+
+    let first_fingerprint_mismatch = server_fingerprints.iter().find_map(|(tick, server_hash)| {
+        client_fingerprints
+            .get(tick)
+            .filter(|client_hash| *client_hash != server_hash)
+            .map(|client_hash| FingerprintMismatch {
+                tick: *tick,
+                server_hash: *server_hash,
+                client_hash: *client_hash,
+            })
+    });
+
+    let command_latency: Vec<CommandLatencyEntry> = cmd_outs
+        .iter()
+        .map(|(ts_ms, predicted_tick, cmd)| {
+            let client_id = &cmd.command_id_client;
+            let server_tick = server_assigned.get(client_id).copied();
+            CommandLatencyEntry {
+                user_id: client_id.user_id,
+                client_tick: *predicted_tick,
+                wire_latency_ms: cmd_in_ts.get(client_id).map(|received| received - ts_ms),
+                server_tick,
+                tick_delta: server_tick.map(|t| t as i64 - *predicted_tick as i64),
+            }
+        })
+        .collect();
+
+    let clock_drift_summary = if drift_samples.is_empty() {
+        None
+    } else {
+        let n = drift_samples.len() as f64;
+        Some(ClockDriftSummary {
+            samples: drift_samples.len(),
+            min_ms: drift_samples
+                .iter()
+                .map(|(d, _)| *d)
+                .fold(f64::MAX, f64::min),
+            max_ms: drift_samples
+                .iter()
+                .map(|(d, _)| *d)
+                .fold(f64::MIN, f64::max),
+            mean_ms: drift_samples.iter().map(|(d, _)| *d).sum::<f64>() / n,
+            max_abs_ms: drift_samples
+                .iter()
+                .map(|(d, _)| d.abs())
+                .fold(0.0, f64::max),
+            mean_rtt_ms: drift_samples.iter().map(|(_, r)| *r).sum::<f64>() / n,
+        })
+    };
+
+    DivergenceReport {
+        missing_stream_seqs,
+        first_missing_seq_tick,
+        first_fingerprint_mismatch,
+        command_latency,
+        clock_drift_summary,
+        notes,
+        tick_duration_ms,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::trace::TRACE_FORMAT_VERSION;
+    use crate::{Direction, GameCommand, GameStatus, GameType, QueueMode};
+
+    const GAME_ID: u32 = 7;
+    const START_MS: i64 = 1_000;
+    const TICK_MS: i64 = 100;
+
+    /// Drive a real seeded engine through a synthetic game the way the game
+    /// executor does (run_until on a 50ms virtual clock, commands injected
+    /// mid-stream, TickHash heartbeats and fingerprints every 500ms) while
+    /// recording a server trace with the real TraceRecord shapes.
+    fn build_synthetic_server_trace() -> Vec<TraceRecord> {
+        let mut state = GameState::new(
+            40,
+            40,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(42),
+            START_MS,
+        );
+        state.add_player(1, Some("alice".into())).unwrap();
+        state.add_player(2, Some("bob".into())).unwrap();
+        state.status = GameStatus::Started { server_id: 99 };
+        state.spawn_initial_food();
+
+        let mut engine = GameEngine::new_from_state(GAME_ID, state.clone());
+        let mut records = vec![
+            TraceRecord::Meta {
+                version: TRACE_FORMAT_VERSION,
+                side: TraceSide::Server,
+                game_id: GAME_ID,
+                session: "synthetic".into(),
+                ts_ms: START_MS,
+                build: "test".into(),
+                tick_duration_ms: TICK_MS as u32,
+            },
+            TraceRecord::State {
+                ts_ms: START_MS,
+                tick: 0,
+                state: Box::new(state),
+            },
+        ];
+
+        let mut stream_seq = 0u64;
+        // (virtual receive time, user_id, snake_id, direction)
+        let commands = [
+            (START_MS + 300, 1u32, 0u32, Direction::Up),
+            (START_MS + 2_200, 2u32, 1u32, Direction::Up),
+        ];
+
+        let mut ts = START_MS;
+        while ts <= START_MS + 3_500 {
+            for (tick, sequence, event) in engine.run_until(ts).unwrap() {
+                stream_seq += 1;
+                records.push(TraceRecord::EventOut {
+                    ts_ms: ts,
+                    msg: Box::new(GameEventMessage {
+                        game_id: GAME_ID,
+                        tick,
+                        sequence,
+                        stream_seq,
+                        user_id: None,
+                        event,
+                    }),
+                });
+            }
+
+            for (cmd_ts, user_id, snake_id, direction) in commands {
+                if cmd_ts == ts {
+                    let cmd = GameCommandMessage {
+                        command_id_client: CommandId {
+                            tick: engine.current_tick() + 2,
+                            user_id,
+                            sequence_number: 0,
+                        },
+                        command_id_server: None,
+                        command: GameCommand::Turn {
+                            snake_id,
+                            direction,
+                        },
+                    };
+                    records.push(TraceRecord::CmdIn {
+                        ts_ms: ts,
+                        cmd: cmd.clone(),
+                    });
+                    let scheduled = engine.process_command(cmd).unwrap();
+                    stream_seq += 1;
+                    records.push(TraceRecord::EventOut {
+                        ts_ms: ts,
+                        msg: Box::new(GameEventMessage {
+                            game_id: GAME_ID,
+                            tick: engine.current_tick(),
+                            sequence: engine.get_committed_state().event_sequence + 1,
+                            stream_seq,
+                            user_id: None,
+                            event: GameEvent::CommandScheduled {
+                                command_message: scheduled,
+                            },
+                        }),
+                    });
+                }
+            }
+
+            if (ts - START_MS) % 500 == 0 && ts > START_MS {
+                let hash = engine.committed_sync_hash();
+                let tick = engine.current_tick();
+                stream_seq += 1;
+                records.push(TraceRecord::EventOut {
+                    ts_ms: ts,
+                    msg: Box::new(GameEventMessage {
+                        game_id: GAME_ID,
+                        tick,
+                        sequence: engine.get_committed_state().event_sequence,
+                        stream_seq,
+                        user_id: None,
+                        event: GameEvent::TickHash {
+                            hash,
+                            server_ts_ms: ts,
+                        },
+                    }),
+                });
+                records.push(TraceRecord::Fingerprint {
+                    ts_ms: ts,
+                    tick,
+                    hash,
+                });
+            }
+
+            ts += 50;
+        }
+
+        records
+    }
+
+    /// Derive the client-side trace a lossless client would have recorded for
+    /// the given server trace: every EventOut received as an EventIn, every
+    /// CmdIn preceded by its CmdOut 40ms earlier, fingerprints sampled at
+    /// every TickHash by actually re-driving a client engine.
+    fn build_matching_client_trace(server_records: &[TraceRecord]) -> Vec<TraceRecord> {
+        let mut records = vec![TraceRecord::Meta {
+            version: TRACE_FORMAT_VERSION,
+            side: TraceSide::Client,
+            game_id: GAME_ID,
+            session: "synthetic-client".into(),
+            ts_ms: START_MS,
+            build: "test".into(),
+            tick_duration_ms: TICK_MS as u32,
+        }];
+
+        let mut engine: Option<GameEngine> = None;
+        for record in server_records {
+            match record {
+                TraceRecord::CmdIn { ts_ms, cmd } => {
+                    let cmd_out_ts = ts_ms - 40;
+                    records.push(TraceRecord::CmdOut {
+                        ts_ms: cmd_out_ts,
+                        predicted_tick: cmd.command_id_client.tick,
+                        cmd: cmd.clone(),
+                    });
+                    if let Some(engine) = engine.as_mut() {
+                        schedule_recorded_client_command(engine, GAME_ID, cmd).unwrap();
+                    }
+                }
+                TraceRecord::EventOut { ts_ms, msg } => {
+                    if engine.is_none() {
+                        if let GameEvent::Snapshot { game_state } = &msg.event {
+                            engine = Some(GameEngine::new_from_state(GAME_ID, game_state.clone()));
+                        } else {
+                            continue; // client discards pre-snapshot messages
+                        }
+                    }
+                    let engine = engine.as_mut().unwrap();
+                    records.push(TraceRecord::EventIn {
+                        ts_ms: ts_ms + 30,
+                        committed_tick: engine.current_tick(),
+                        msg: msg.clone(),
+                    });
+                    engine.process_server_event(msg).unwrap();
+                    if matches!(msg.event, GameEvent::TickHash { .. }) {
+                        records.push(TraceRecord::Fingerprint {
+                            ts_ms: ts_ms + 30,
+                            tick: engine.current_tick(),
+                            hash: engine.committed_sync_hash(),
+                        });
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        records
+    }
+
+    fn gameplay_event_count(records: &[TraceRecord]) -> usize {
+        records
+            .iter()
+            .filter(|r| {
+                matches!(
+                    r,
+                    TraceRecord::EventOut { msg, .. }
+                        if !matches!(msg.event, GameEvent::Snapshot { .. } | GameEvent::TickHash { .. })
+                )
+            })
+            .count()
+    }
+
+    #[test]
+    fn server_replay_is_deterministic() {
+        let records = build_synthetic_server_trace();
+        assert!(
+            gameplay_event_count(&records) > 4,
+            "synthetic trace should contain real gameplay events"
+        );
+
+        let outcome = ServerReplay::from_records(records)
+            .unwrap()
+            .replay()
+            .unwrap();
+        assert!(
+            outcome.deterministic,
+            "expected deterministic replay, got {:?}",
+            outcome.first_divergence
+        );
+        assert!(outcome.ticks_replayed >= 25);
+        assert!(outcome.events_compared > 4);
+    }
+
+    #[test]
+    fn tampered_event_diverges_at_the_right_tick() {
+        let mut records = build_synthetic_server_trace();
+
+        // Corrupt the first recorded SnakeTurned event: flip its direction.
+        let mut tampered_tick = None;
+        for record in records.iter_mut() {
+            if let TraceRecord::EventOut { msg, .. } = record {
+                if let GameEvent::SnakeTurned { direction, .. } = &mut msg.event {
+                    *direction = Direction::Down;
+                    tampered_tick = Some(msg.tick);
+                    break;
+                }
+            }
+        }
+        let tampered_tick = tampered_tick.expect("synthetic trace has a SnakeTurned event");
+
+        let outcome = ServerReplay::from_records(records)
+            .unwrap()
+            .replay()
+            .unwrap();
+        assert!(!outcome.deterministic);
+        let divergence = outcome.first_divergence.expect("divergence expected");
+        assert_eq!(divergence.tick, tampered_tick);
+        assert_eq!(divergence.kind, "event_mismatch");
+    }
+
+    #[test]
+    fn client_replay_reproduces_recorded_fingerprints() {
+        let server_records = build_synthetic_server_trace();
+        let client_records = build_matching_client_trace(&server_records);
+
+        let outcome = ClientReplay::from_records(client_records)
+            .unwrap()
+            .replay()
+            .unwrap();
+        assert!(
+            outcome.reproduces,
+            "expected reproduction, got {:?}",
+            outcome.first_divergence
+        );
+        assert!(outcome.fingerprints_compared >= 5);
+    }
+
+    #[test]
+    fn dropped_message_reports_exact_missing_seq_and_transport_loss() {
+        let server_records = build_synthetic_server_trace();
+        let mut client_records = build_matching_client_trace(&server_records);
+
+        // Drop one mid-stream gameplay EventIn from the client trace.
+        let victim_idx = {
+            let event_in_indices: Vec<usize> = client_records
+                .iter()
+                .enumerate()
+                .filter(|(_, r)| {
+                    matches!(
+                        r,
+                        TraceRecord::EventIn { msg, .. }
+                            if !matches!(msg.event, GameEvent::Snapshot { .. })
+                    )
+                })
+                .map(|(i, _)| i)
+                .collect();
+            event_in_indices[event_in_indices.len() / 2]
+        };
+        let dropped_seq = match &client_records[victim_idx] {
+            TraceRecord::EventIn { msg, .. } => msg.stream_seq,
+            _ => unreachable!(),
+        };
+        assert!(dropped_seq > 0);
+        client_records.remove(victim_idx);
+
+        let report = diff_traces(&server_records, &client_records);
+        assert_eq!(
+            report.missing_stream_seqs,
+            vec![SeqRange {
+                start: dropped_seq,
+                end: dropped_seq
+            }]
+        );
+        assert_eq!(report.verdict(), "TRANSPORT_LOSS");
+
+        // Both commands matched with the synthetic 40ms wire latency.
+        assert_eq!(report.command_latency.len(), 2);
+        for entry in &report.command_latency {
+            assert_eq!(entry.wire_latency_ms, Some(40));
+            assert!(entry.server_tick.is_some());
+        }
+    }
+
+    #[test]
+    fn lossless_traces_are_in_sync() {
+        let server_records = build_synthetic_server_trace();
+        let client_records = build_matching_client_trace(&server_records);
+        let report = diff_traces(&server_records, &client_records);
+        assert!(report.missing_stream_seqs.is_empty());
+        assert!(report.first_fingerprint_mismatch.is_none());
+        assert_eq!(report.verdict(), "IN_SYNC");
+    }
+
+    /// Not a test of behavior: writes the synthetic demo traces to disk for
+    /// exercising the `trace_rca` CLI end-to-end. Opt-in via env var so
+    /// normal test runs stay side-effect free.
+    #[test]
+    fn write_demo_traces_for_cli() {
+        let Ok(dir) = std::env::var("SNAKETRON_DEMO_TRACE_DIR") else {
+            return;
+        };
+        let server_records = build_synthetic_server_trace();
+        let client_records = build_matching_client_trace(&server_records);
+        let dir = std::path::PathBuf::from(dir);
+        for (name, records) in [
+            ("server_trace.jsonl", &server_records),
+            ("client_trace.jsonl", &client_records),
+        ] {
+            let path = dir.join(name);
+            let _ = std::fs::remove_file(&path);
+            let mut writer = crate::trace::TraceWriter::create(&path).unwrap();
+            for r in records {
+                writer.record(r).unwrap();
+            }
+            writer.flush().unwrap();
+        }
+    }
+}

--- a/common/src/trace.rs
+++ b/common/src/trace.rs
@@ -1,0 +1,248 @@
+//! Sync trace ("flight recorder") format shared by the server, the web client,
+//! and the offline root-cause-analysis tooling.
+//!
+//! A trace is a JSONL stream of `TraceRecord`s describing everything a game
+//! engine instance observed: the initial state, every command and event that
+//! crossed its boundary (with timestamps), periodic state fingerprints, clock
+//! sync samples, and anomaly notes. A server trace and a client trace for the
+//! same game can be joined offline to find the first divergent tick, missing
+//! events, and command-scheduling latency — and to re-drive the engine
+//! deterministically as a local reproduction of a production bug.
+//!
+//! Records are plain serde data so the same shapes work in native and WASM
+//! builds; the TypeScript client writes literally the same JSON. File I/O
+//! lives behind `#[cfg(not(target_arch = "wasm32"))]`.
+
+use crate::{GameCommandMessage, GameEventMessage, GameState};
+use serde::{Deserialize, Serialize};
+
+pub const TRACE_FORMAT_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TraceSide {
+    Server,
+    Client,
+}
+
+// NOTE: externally tagged (serde default) on purpose — internally-tagged enums
+// (`#[serde(tag = ...)]`) buffer content through serde's private Content type,
+// which cannot deserialize integer-keyed maps like GameState's HashMap<u32, _>.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum TraceRecord {
+    /// First record of every trace.
+    Meta {
+        version: u32,
+        side: TraceSide,
+        game_id: u32,
+        /// Distinguishes multiple traces of the same game (e.g. per user).
+        session: String,
+        ts_ms: i64,
+        build: String,
+        tick_duration_ms: u32,
+    },
+    /// Full engine state, including RNG on the server side. The first `State`
+    /// record is the replay starting point; later ones (e.g. applied
+    /// snapshots) re-anchor it.
+    State {
+        ts_ms: i64,
+        tick: u32,
+        state: Box<GameState>,
+    },
+    /// Server perspective: a message published toward clients.
+    EventOut {
+        ts_ms: i64,
+        msg: Box<GameEventMessage>,
+    },
+    /// Client perspective: a message received from the server.
+    /// `committed_tick` is the local committed tick at the moment of receipt,
+    /// which exposes how far ahead/behind the client was.
+    EventIn {
+        ts_ms: i64,
+        committed_tick: u32,
+        msg: Box<GameEventMessage>,
+    },
+    /// Server perspective: a player command received for scheduling.
+    CmdIn { ts_ms: i64, cmd: GameCommandMessage },
+    /// Client perspective: a locally predicted command sent to the server.
+    /// `predicted_tick` is the tick the client scheduled it at.
+    CmdOut {
+        ts_ms: i64,
+        predicted_tick: u32,
+        cmd: GameCommandMessage,
+    },
+    /// Periodic state fingerprint of this side's committed state.
+    Fingerprint { ts_ms: i64, tick: u32, hash: u64 },
+    /// Client clock-sync sample.
+    Clock {
+        ts_ms: i64,
+        drift_ms: f64,
+        rtt_ms: f64,
+    },
+    /// Anomalies observed by the runtime: detected sequence gaps, hash
+    /// mismatches, channel overflows, lag warnings, reconnects...
+    Note { ts_ms: i64, note: String },
+}
+
+impl TraceRecord {
+    pub fn ts_ms(&self) -> i64 {
+        match self {
+            TraceRecord::Meta { ts_ms, .. }
+            | TraceRecord::State { ts_ms, .. }
+            | TraceRecord::EventOut { ts_ms, .. }
+            | TraceRecord::EventIn { ts_ms, .. }
+            | TraceRecord::CmdIn { ts_ms, .. }
+            | TraceRecord::CmdOut { ts_ms, .. }
+            | TraceRecord::Fingerprint { ts_ms, .. }
+            | TraceRecord::Clock { ts_ms, .. }
+            | TraceRecord::Note { ts_ms, .. } => *ts_ms,
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub use io::{TraceWriter, read_trace};
+
+#[cfg(not(target_arch = "wasm32"))]
+mod io {
+    use super::TraceRecord;
+    use anyhow::{Context, Result};
+    use std::fs::{File, OpenOptions};
+    use std::io::{BufRead, BufReader, BufWriter, Write};
+    use std::path::{Path, PathBuf};
+
+    /// Append-only JSONL trace writer. Flushes on every batch boundary so a
+    /// crashed or killed game still leaves a readable trace — the moments a
+    /// game dies unexpectedly are exactly the ones worth debugging.
+    pub struct TraceWriter {
+        path: PathBuf,
+        writer: BufWriter<File>,
+    }
+
+    impl TraceWriter {
+        pub fn create(path: impl AsRef<Path>) -> Result<Self> {
+            let path = path.as_ref().to_path_buf();
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create trace dir {:?}", parent))?;
+            }
+            let file = OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&path)
+                .with_context(|| format!("Failed to open trace file {:?}", path))?;
+            Ok(TraceWriter {
+                path,
+                writer: BufWriter::new(file),
+            })
+        }
+
+        pub fn path(&self) -> &Path {
+            &self.path
+        }
+
+        pub fn record(&mut self, record: &TraceRecord) -> Result<()> {
+            let line = serde_json::to_string(record).context("Failed to serialize trace record")?;
+            writeln!(self.writer, "{}", line).context("Failed to write trace record")?;
+            Ok(())
+        }
+
+        pub fn flush(&mut self) -> Result<()> {
+            self.writer.flush().context("Failed to flush trace file")
+        }
+    }
+
+    /// Read a JSONL trace, tolerating a truncated final line (crash mid-write).
+    pub fn read_trace(path: impl AsRef<Path>) -> Result<Vec<TraceRecord>> {
+        let path = path.as_ref();
+        let file =
+            File::open(path).with_context(|| format!("Failed to open trace file {:?}", path))?;
+        let lines: Vec<String> = BufReader::new(file)
+            .lines()
+            .collect::<std::io::Result<_>>()
+            .with_context(|| format!("Failed to read trace file {:?}", path))?;
+
+        let mut records = Vec::new();
+        for (idx, line) in lines.iter().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<TraceRecord>(line) {
+                Ok(record) => records.push(record),
+                // A torn final line is expected after a crash; anything
+                // else mid-file is corruption worth failing loudly on.
+                Err(_) if idx + 1 == lines.len() => break,
+                Err(e) => {
+                    return Err(anyhow::anyhow!(
+                        "Corrupt trace record at {:?}:{}: {}",
+                        path,
+                        idx + 1,
+                        e
+                    ));
+                }
+            }
+        }
+        Ok(records)
+    }
+}
+
+#[cfg(test)]
+#[cfg(not(target_arch = "wasm32"))]
+mod tests {
+    use super::*;
+    use crate::{GameType, QueueMode};
+
+    #[test]
+    fn trace_roundtrip() {
+        let dir = std::env::temp_dir().join("snaketron_trace_test");
+        let path = dir.join("roundtrip.jsonl");
+        let _ = std::fs::remove_file(&path);
+
+        let state = GameState::new(
+            10,
+            10,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(7),
+            0,
+        );
+
+        let records = vec![
+            TraceRecord::Meta {
+                version: TRACE_FORMAT_VERSION,
+                side: TraceSide::Server,
+                game_id: 1,
+                session: "test".into(),
+                ts_ms: 100,
+                build: "test-build".into(),
+                tick_duration_ms: 100,
+            },
+            TraceRecord::State {
+                ts_ms: 100,
+                tick: 0,
+                state: Box::new(state),
+            },
+            TraceRecord::Fingerprint {
+                ts_ms: 200,
+                tick: 1,
+                hash: 0xdeadbeef,
+            },
+            TraceRecord::Note {
+                ts_ms: 300,
+                note: "gap detected: expected stream_seq 5, got 9".into(),
+            },
+        ];
+
+        let mut writer = TraceWriter::create(&path).unwrap();
+        for r in &records {
+            writer.record(r).unwrap();
+        }
+        writer.flush().unwrap();
+
+        let read = read_trace(&path).unwrap();
+        assert_eq!(read.len(), records.len());
+        assert!(matches!(read[0], TraceRecord::Meta { game_id: 1, .. }));
+        assert!(matches!(read[2], TraceRecord::Fingerprint { hash, .. } if hash == 0xdeadbeef));
+
+        let _ = std::fs::remove_file(&path);
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -50,7 +50,7 @@ tower = { version = "0.4", features = ["full"] }
 tower-http = { version = "0.5", features = ["cors", "trace"] }
 # Password hashing
 bcrypt = "0.15"
-redis = { version = "0.32.7", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "0.32.7", features = ["tokio-comp", "connection-manager", "streams"] }
 skillratings = "0.27"
 indexmap = "2"
 

--- a/server/src/bin/trace_rca.rs
+++ b/server/src/bin/trace_rca.rs
@@ -1,0 +1,204 @@
+//! Root-cause analysis for captured sync traces (see DEBUGGING.md).
+//!
+//! Usage:
+//!   trace_rca <trace.jsonl>                       replay one trace
+//!   trace_rca <server.jsonl> <client.jsonl>       replay both + cross-diff
+//!   flags: --json (machine-readable), --emit-test <out.rs> (write a repro test)
+
+use anyhow::{Context, Result, bail};
+use common::replay::{ClientReplay, ServerReplay, diff_traces, trace_side};
+use common::trace::{TraceSide, read_trace};
+use std::path::{Path, PathBuf};
+
+struct Args {
+    traces: Vec<PathBuf>,
+    json: bool,
+    emit_test: Option<PathBuf>,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut traces = Vec::new();
+    let mut json = false;
+    let mut emit_test = None;
+
+    let mut iter = std::env::args().skip(1);
+    while let Some(arg) = iter.next() {
+        match arg.as_str() {
+            "--json" => json = true,
+            "--emit-test" => {
+                let path = iter.next().context("--emit-test requires an output path")?;
+                emit_test = Some(PathBuf::from(path));
+            }
+            "--help" | "-h" => {
+                print_usage();
+                std::process::exit(0);
+            }
+            other if other.starts_with("--") => bail!("Unknown flag: {}", other),
+            path => traces.push(PathBuf::from(path)),
+        }
+    }
+
+    if traces.is_empty() || traces.len() > 2 {
+        print_usage();
+        bail!("Expected one or two trace paths, got {}", traces.len());
+    }
+
+    Ok(Args {
+        traces,
+        json,
+        emit_test,
+    })
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: trace_rca <server_trace.jsonl> [<client_trace.jsonl>] [--json] [--emit-test <out.rs>]\n\
+         Replays captured sync traces deterministically through the real game engine,\n\
+         reports the first divergence, and cross-diffs server vs client perspectives.\n\
+         See DEBUGGING.md for the full workflow."
+    );
+}
+
+fn main() -> Result<()> {
+    let args = parse_args()?;
+
+    let mut loaded = Vec::new();
+    for path in &args.traces {
+        let records =
+            read_trace(path).with_context(|| format!("Failed to read trace {}", path.display()))?;
+        let side = trace_side(&records)
+            .with_context(|| format!("{} has no Meta record", path.display()))?;
+        loaded.push((path.clone(), side, records));
+    }
+
+    // Order as (server, client) when both are present.
+    loaded.sort_by_key(|(_, side, _)| match side {
+        TraceSide::Server => 0,
+        TraceSide::Client => 1,
+    });
+    if loaded.len() == 2 && loaded[0].1 == loaded[1].1 {
+        bail!(
+            "Both traces are {:?}-side; need one server and one client trace to diff",
+            loaded[0].1
+        );
+    }
+
+    let mut json_out = serde_json::Map::new();
+
+    for (path, side, records) in &loaded {
+        match side {
+            TraceSide::Server => {
+                let outcome = ServerReplay::from_records(records.clone())?
+                    .replay()
+                    .with_context(|| format!("Server replay of {} failed", path.display()))?;
+                if args.json {
+                    json_out.insert("server_replay".into(), serde_json::to_value(&outcome)?);
+                } else {
+                    println!("=== Server replay: {} ===", path.display());
+                    println!("{}", outcome.render());
+                    println!();
+                }
+            }
+            TraceSide::Client => {
+                let outcome = ClientReplay::from_records(records.clone())?
+                    .replay()
+                    .with_context(|| format!("Client replay of {} failed", path.display()))?;
+                if args.json {
+                    json_out.insert("client_replay".into(), serde_json::to_value(&outcome)?);
+                } else {
+                    println!("=== Client replay: {} ===", path.display());
+                    println!("{}", outcome.render());
+                    println!();
+                }
+            }
+        }
+    }
+
+    if loaded.len() == 2 {
+        let report = diff_traces(&loaded[0].2, &loaded[1].2);
+        if args.json {
+            json_out.insert("diff".into(), serde_json::to_value(&report)?);
+            json_out.insert(
+                "verdict".into(),
+                serde_json::Value::String(report.verdict()),
+            );
+        } else {
+            println!("=== Cross-diff ===");
+            println!("{}", report.render());
+        }
+    }
+
+    if args.json {
+        println!("{}", serde_json::to_string_pretty(&json_out)?);
+    }
+
+    if let Some(out) = &args.emit_test {
+        emit_repro_test(out, &loaded)?;
+        eprintln!(
+            "Wrote repro test to {} — move the trace file(s) into the repo (e.g. server/tests/fixtures/) \
+             and adjust the embedded paths before committing.",
+            out.display()
+        );
+    }
+
+    Ok(())
+}
+
+/// Write a #[test] that replays the trace(s) and asserts on today's outcome:
+/// a deterministic trace asserts it stays deterministic; a divergent trace
+/// asserts the divergence (so the test starts red and goes green with the fix,
+/// at which point the assertion should be flipped to lock in determinism).
+fn emit_repro_test(
+    out: &Path,
+    loaded: &[(PathBuf, TraceSide, Vec<common::trace::TraceRecord>)],
+) -> Result<()> {
+    let mut body = String::from(
+        "// Auto-generated by trace_rca --emit-test. Reproduces a captured sync trace\n\
+         // as a local test. See DEBUGGING.md (\"Freeze it as a test\").\n\n",
+    );
+
+    for (path, side, records) in loaded {
+        let abs = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+        match side {
+            TraceSide::Server => {
+                let outcome = ServerReplay::from_records(records.clone())?.replay()?;
+                let assertion = if outcome.deterministic {
+                    "assert!(outcome.deterministic, \"engine replay diverged from recorded trace: {:?}\", outcome.first_divergence);".to_string()
+                } else {
+                    let div = outcome
+                        .first_divergence
+                        .as_ref()
+                        .map(|d| format!("tick {} ({})", d.tick, d.kind))
+                        .unwrap_or_else(|| "unknown".into());
+                    format!(
+                        "// Captured divergence: {div}. Flip this assertion once the bug is fixed.\n    \
+                         assert!(!outcome.deterministic, \"divergence no longer reproduces — fix confirmed; flip this assertion to lock it in\");"
+                    )
+                };
+                body.push_str(&format!(
+                    "#[test]\nfn replay_server_trace_reproduces() {{\n    \
+                     let replay = common::replay::ServerReplay::from_file({:?}).unwrap();\n    \
+                     let outcome = replay.replay().unwrap();\n    {}\n}}\n\n",
+                    abs, assertion
+                ));
+            }
+            TraceSide::Client => {
+                let outcome = ClientReplay::from_records(records.clone())?.replay()?;
+                let assertion = if outcome.reproduces {
+                    "assert!(outcome.reproduces, \"client replay diverged from recorded trace: {:?}\", outcome.first_divergence);".to_string()
+                } else {
+                    "assert!(!outcome.reproduces, \"divergence no longer reproduces — fix confirmed; flip this assertion to lock it in\");".to_string()
+                };
+                body.push_str(&format!(
+                    "#[test]\nfn replay_client_trace_reproduces() {{\n    \
+                     let replay = common::replay::ClientReplay::from_file({:?}).unwrap();\n    \
+                     let outcome = replay.replay().unwrap();\n    {}\n}}\n\n",
+                    abs, assertion
+                ));
+            }
+        }
+    }
+
+    std::fs::write(out, body).with_context(|| format!("Failed to write {}", out.display()))?;
+    Ok(())
+}

--- a/server/src/cluster_singleton.rs
+++ b/server/src/cluster_singleton.rs
@@ -1,12 +1,9 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{Result, anyhow};
 use common::CLUSTER_RENEWAL_INTERVAL_MS;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use redis::aio::ConnectionManager;
-use redis::{
-    AsyncCommands, ExistenceCheck, RedisResult, Script, ScriptInvocation, SetExpiry, SetOptions,
-    TypedCommands,
-};
+use redis::{AsyncCommands, Script};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
@@ -85,6 +82,10 @@ impl ClusterSingleton {
         let mut service_handle: Option<tokio::task::JoinHandle<Result<()>>> = None;
         let mut service_token: Option<CancellationToken> = None;
         let mut rng = StdRng::from_entropy();
+        // When the last successful lease renewal (or acquisition) happened.
+        // Transient Redis errors are tolerated while the lease is provably
+        // still ours (see `renew_error_should_step_down`).
+        let mut last_renewal_success = tokio::time::Instant::now();
 
         // Create the initial claim sleep
         let claim_duration_ms = rng.gen_range(500..=1500);
@@ -108,6 +109,7 @@ impl ClusterSingleton {
                             Ok(true) => {
                                 info!("Became leader for server_id={}", self.server_id);
                                 self.is_leader.store(true, Ordering::Release);
+                                last_renewal_success = tokio::time::Instant::now();
 
                                 // Start the user service
                                 if service_handle.is_none() {
@@ -136,32 +138,55 @@ impl ClusterSingleton {
                 }
                 _ = renew_interval.tick() => {
                     if self.is_leader() {
-                        // debug!("Renewing lease for server_id={}", self.server_id);
                         match self.renew_lease().await {
                             Ok(true) => {
-                                // debug!("Successfully renewed lease");
+                                last_renewal_success = tokio::time::Instant::now();
                             }
                             Ok(false) => {
+                                // Definitive: the key is gone or owned by
+                                // someone else. Step down immediately.
                                 warn!("Lost leadership - failed to renew lease");
                                 self.is_leader.store(false, Ordering::Release);
-
-                                // Stop the user service
                                 self.stop_service(&mut service_token, &mut service_handle).await;
                             }
                             Err(e) => {
-                                error!("Error renewing lease: {}", e);
-                                self.is_leader.store(false, Ordering::Release);
-
-                                // Stop the user service on error
-                                self.stop_service(&mut service_token, &mut service_handle).await;
+                                // Transient (couldn't reach Redis): the lease
+                                // key may well still be ours and unexpired.
+                                // Cancelling every running game on the first
+                                // blip is what used to make a brief Redis
+                                // hiccup wipe out all in-flight games. Keep
+                                // leadership within the safety window; beyond
+                                // it the key may have expired and another
+                                // server may own it, so step down.
+                                let elapsed = last_renewal_success.elapsed();
+                                if renew_error_should_step_down(elapsed, self.lease_duration_ms) {
+                                    error!(
+                                        "Error renewing lease for {:?} (last success {:?} ago); stepping down: {}",
+                                        self.lease_key, elapsed, e
+                                    );
+                                    self.is_leader.store(false, Ordering::Release);
+                                    self.stop_service(&mut service_token, &mut service_handle).await;
+                                } else {
+                                    warn!(
+                                        "Error renewing lease for {:?} (last success {:?} ago, within grace window); retrying: {}",
+                                        self.lease_key, elapsed, e
+                                    );
+                                }
                             }
                         }
                     }
                 }
                 _ = health_check_interval.tick() => {
                     let ping_timeout = Duration::from_secs(1);
-                    let ping_result = timeout(ping_timeout, self.redis.ping::<String>()).await
-                        .map_err(|_| anyhow!("Redis PING timed out after {:?}", ping_timeout))?;
+                    // A timed-out PING must take the same step-down path as a
+                    // failed PING. Propagating it with `?` would exit run()
+                    // WITHOUT stopping the running service — leaving a zombie
+                    // leader still executing games while another server
+                    // acquires the lease and starts duplicates (split brain).
+                    let ping_result = match timeout(ping_timeout, self.redis.ping::<String>()).await {
+                        Ok(result) => result.map_err(anyhow::Error::from),
+                        Err(_) => Err(anyhow!("Redis PING timed out after {:?}", ping_timeout)),
+                    };
 
                     match ping_result {
                         Ok(rsp) => if rsp != "PONG" {
@@ -183,19 +208,38 @@ impl ClusterSingleton {
         Ok(())
     }
 
-    async fn try_acquire_lease(&mut self) -> RedisResult<bool> {
-        let acquired: bool = self
+    async fn try_acquire_lease(&mut self) -> Result<bool> {
+        // Acquire when free, OR reclaim a lease that still holds OUR id.
+        // Plain SET NX cannot reclaim: after a transient Redis outage our
+        // still-unexpired key would block us from re-acquiring our own lease
+        // until it expires, extending the outage for no reason.
+        let lua_script = r#"
+            local v = redis.call("get", KEYS[1])
+            if v == false then
+                redis.call("set", KEYS[1], ARGV[1], "PX", ARGV[2])
+                return 1
+            elseif v == ARGV[1] then
+                redis.call("pexpire", KEYS[1], ARGV[2])
+                return 1
+            else
+                return 0
+            end
+        "#;
+
+        let script = Script::new(lua_script);
+        let _: String = self.redis.load_script(&script).await?;
+
+        let result = self
             .redis
-            .set_options(
-                &self.lease_key,
-                self.server_id.to_string(),
-                SetOptions::default()
-                    .conditional_set(ExistenceCheck::NX)
-                    .with_expiration(SetExpiry::PX(self.lease_duration_ms)),
+            .invoke_script::<i32>(
+                script
+                    .key(self.lease_key.clone())
+                    .arg(self.server_id.to_string())
+                    .arg(self.lease_duration_ms),
             )
             .await?;
 
-        Ok(acquired)
+        Ok(result == 1)
     }
 
     async fn renew_lease(&mut self) -> Result<bool> {
@@ -255,5 +299,56 @@ impl ClusterSingleton {
                 }
             }
         }
+    }
+}
+
+/// Whether a transient (Err, not Ok(false)) lease-renewal failure should end
+/// leadership. The lease key's TTL is reset on every successful renewal, so
+/// another server cannot acquire it until `lease_duration` has passed since
+/// our last success. Tolerating errors for 60% of that window keeps a >=40%
+/// safety margin between "we stop acting as leader" and "someone else can
+/// possibly become leader" — no split-brain, but a brief Redis blip no longer
+/// cancels every running game.
+fn renew_error_should_step_down(elapsed_since_success: Duration, lease_duration_ms: u64) -> bool {
+    elapsed_since_success.as_millis() as u64 * 10 >= lease_duration_ms * 6
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_renewal_errors_tolerated_within_grace() {
+        // 3s lease -> grace window is 1.8s.
+        assert!(!renew_error_should_step_down(
+            Duration::from_millis(0),
+            3000
+        ));
+        assert!(!renew_error_should_step_down(
+            Duration::from_millis(1500),
+            3000
+        ));
+        assert!(!renew_error_should_step_down(
+            Duration::from_millis(1799),
+            3000
+        ));
+    }
+
+    #[test]
+    fn sustained_renewal_errors_step_down_before_lease_expiry() {
+        assert!(renew_error_should_step_down(
+            Duration::from_millis(1800),
+            3000
+        ));
+        assert!(renew_error_should_step_down(
+            Duration::from_millis(3000),
+            3000
+        ));
+        // Step-down always happens strictly before the lease can expire.
+        let lease_ms = 1000u64;
+        let step_down_at = (0..=lease_ms)
+            .find(|ms| renew_error_should_step_down(Duration::from_millis(*ms), lease_ms))
+            .unwrap();
+        assert!(step_down_at < lease_ms);
     }
 }

--- a/server/src/game_bus.rs
+++ b/server/src/game_bus.rs
@@ -1,0 +1,664 @@
+//! The game-critical message bus: partition-scoped events, commands, and
+//! snapshot requests between game executors, replicas, and WebSocket servers.
+//!
+//! Two interchangeable transports, selected by `SNAKETRON_BUS`:
+//!
+//! - `streams` (default): Redis/Valkey Streams — an ordered, trimmed,
+//!   replayable log per partition. Readers resume from their last-delivered
+//!   entry, so subscriber blips lose nothing and slow consumers get real
+//!   backpressure instead of drops. The `stream_seq`/resync machinery
+//!   remains as defense-in-depth and should sit idle on this transport.
+//! - `pubsub` (fallback): Redis Pub/Sub — push-based, at-most-once. Loss is
+//!   detected downstream via `stream_seq` gaps and healed with snapshot
+//!   resyncs (see DEBUGGING.md).
+//!
+//! Loss-tolerant fan-out (chat, lobby updates, user counts) is NOT routed
+//! through this bus — it stays on plain Pub/Sub under either setting
+//! (see `PubSubManager::subscribe_to_channel`).
+//!
+//! ## Streams latency rules (learned the hard way — see STREAMS_MIGRATION.md)
+//!
+//! The 2025 Streams implementation was abandoned for Pub/Sub because blocking
+//! `XREAD`s were multiplexed onto shared connections, adding 100–900 ms per
+//! event. The rules encoded here:
+//! 1. Every blocking reader owns a DEDICATED connection; publishers use the
+//!    shared non-blocking `ConnectionManager` and never queue behind a
+//!    parked read.
+//! 2. `XREAD BLOCK` is a push-like wait (Redis wakes the reader on write) —
+//!    the BLOCK value is a liveness checkpoint, not a poll interval.
+//! 3. One `XREAD` watches all three partition streams at once.
+//! 4. Streams are trimmed with `MAXLEN ~` at publish time; no consumer
+//!    groups, no XACK — consumers are fan-out readers tracking their own
+//!    position.
+
+use crate::game_executor::StreamEvent;
+use crate::pubsub_manager::{PartitionSubscription, PubSubManager, SnapshotRequest};
+use crate::redis_keys::RedisKeys;
+use anyhow::{Context, Result};
+use common::{GameEvent, GameEventMessage, GameState};
+use redis::AsyncCommands;
+use redis::aio::ConnectionManager;
+use redis::streams::{StreamMaxlen, StreamReadOptions, StreamReadReply};
+use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, error, info, warn};
+
+/// Which transport backs the game bus. Parsed from `SNAKETRON_BUS`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusKind {
+    PubSub,
+    Streams,
+}
+
+impl BusKind {
+    pub fn from_env() -> Self {
+        Self::parse(std::env::var("SNAKETRON_BUS").ok().as_deref())
+    }
+
+    fn parse(value: Option<&str>) -> Self {
+        match value.map(|v| v.trim().to_ascii_lowercase()) {
+            Some(v) if v == "pubsub" => BusKind::PubSub,
+            Some(v) if v == "streams" || v.is_empty() => BusKind::Streams,
+            Some(other) => {
+                // Deliberately loud: a typo here silently changes which
+                // transport carries every game message.
+                tracing::error!(
+                    "Unknown SNAKETRON_BUS value {:?} (expected \"pubsub\" or \"streams\"); falling back to the streams default",
+                    other
+                );
+                BusKind::Streams
+            }
+            None => BusKind::Streams,
+        }
+    }
+}
+
+/// The configurable game-critical transport. All methods take `&self`;
+/// internal connections are cheaply cloneable handles.
+pub enum GameBus {
+    PubSub(PubSubManager),
+    Streams(StreamsTransport),
+}
+
+impl GameBus {
+    pub fn new(
+        kind: BusKind,
+        pubsub: PubSubManager,
+        redis: ConnectionManager,
+        redis_client: redis::Client,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        match kind {
+            BusKind::PubSub => GameBus::PubSub(pubsub),
+            BusKind::Streams => {
+                info!("Game bus: Redis Streams transport enabled");
+                GameBus::Streams(StreamsTransport {
+                    redis,
+                    redis_client,
+                    cancellation_token,
+                })
+            }
+        }
+    }
+
+    pub fn kind(&self) -> BusKind {
+        match self {
+            GameBus::PubSub(_) => BusKind::PubSub,
+            GameBus::Streams(_) => BusKind::Streams,
+        }
+    }
+
+    pub async fn publish_event(&self, partition_id: u32, event: &GameEventMessage) -> Result<()> {
+        match self {
+            GameBus::PubSub(manager) => {
+                let mut manager = manager.clone();
+                manager.publish_event(partition_id, event).await
+            }
+            GameBus::Streams(streams) => streams.publish_event(partition_id, event).await,
+        }
+    }
+
+    /// Publish a snapshot AND persist it under the game's snapshot key.
+    /// Returns the constructed message so callers can trace exactly what was
+    /// published.
+    pub async fn publish_snapshot(
+        &self,
+        partition_id: u32,
+        game_id: u32,
+        snapshot: &GameState,
+        stream_seq: u64,
+    ) -> Result<GameEventMessage> {
+        match self {
+            GameBus::PubSub(manager) => {
+                manager
+                    .publish_snapshot(partition_id, game_id, snapshot, stream_seq)
+                    .await
+            }
+            GameBus::Streams(streams) => {
+                streams
+                    .publish_snapshot(partition_id, game_id, snapshot, stream_seq)
+                    .await
+            }
+        }
+    }
+
+    pub async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
+        match self {
+            GameBus::PubSub(manager) => manager.publish_command(partition_id, command).await,
+            GameBus::Streams(streams) => streams.publish_command(partition_id, command).await,
+        }
+    }
+
+    pub async fn request_partition_snapshots(&self, partition_id: u32) -> Result<()> {
+        match self {
+            GameBus::PubSub(manager) => {
+                let mut manager = manager.clone();
+                manager.request_partition_snapshots(partition_id).await
+            }
+            GameBus::Streams(streams) => streams.request_partition_snapshots(partition_id).await,
+        }
+    }
+
+    pub async fn subscribe_to_partition(&self, partition_id: u32) -> Result<PartitionSubscription> {
+        match self {
+            GameBus::PubSub(manager) => {
+                let mut manager = manager.clone();
+                manager.subscribe_to_partition(partition_id).await
+            }
+            GameBus::Streams(streams) => streams.subscribe_to_partition(partition_id).await,
+        }
+    }
+
+    pub async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
+        match self {
+            GameBus::PubSub(manager) => manager.store_snapshot(game_id, snapshot).await,
+            GameBus::Streams(streams) => streams.store_snapshot(game_id, snapshot).await,
+        }
+    }
+
+    pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
+        match self {
+            GameBus::PubSub(manager) => {
+                let mut manager = manager.clone();
+                manager.get_stored_snapshot(game_id).await
+            }
+            GameBus::Streams(streams) => streams.get_stored_snapshot(game_id).await,
+        }
+    }
+}
+
+/// Approximate trim bounds (`MAXLEN ~`). At game rates (a handful of events
+/// per 100 ms tick, 1/10 of games per partition) the events bound keeps
+/// several minutes of backlog — ample for any reconnect window — while
+/// keeping memory strictly bounded (the old implementation never trimmed).
+const EVENTS_MAXLEN: usize = 8192;
+// Commands get the same window as events, not a smaller one: they are the one
+// message class with NO end-to-end sequence numbers, so loss past the trim
+// horizon is detectable only by the reader's horizon check — give it the
+// longest practical window.
+const COMMANDS_MAXLEN: usize = 8192;
+const SNAPREQ_MAXLEN: usize = 64;
+
+/// How long one XREAD parks before returning empty. Purely a liveness /
+/// cancellation checkpoint — delivery latency does not depend on it.
+const XREAD_BLOCK_MS: usize = 5_000;
+/// Max entries drained per XREAD round trip.
+const XREAD_COUNT: usize = 512;
+/// Capacity of the mpsc channels handed to subscribers (matches the pubsub
+/// transport). When full, the reader awaits — backpressure, not drops.
+const SUBSCRIBER_CHANNEL_CAPACITY: usize = 2000;
+/// Backoff before rebuilding a failed reader connection.
+const READER_RECONNECT_BACKOFF_MS: u64 = 100;
+
+pub struct StreamsTransport {
+    /// Shared non-blocking connection for XADD/KV. Never used for blocking
+    /// reads (rule #1).
+    redis: ConnectionManager,
+    /// Used to open a dedicated connection per reader task.
+    redis_client: redis::Client,
+    cancellation_token: CancellationToken,
+}
+
+impl StreamsTransport {
+    async fn xadd(&self, key: &str, maxlen: usize, payload: Vec<u8>) -> Result<()> {
+        let mut redis = self.redis.clone();
+        let _: String = redis
+            .xadd_maxlen(key, StreamMaxlen::Approx(maxlen), "*", &[("data", payload)])
+            .await
+            .with_context(|| format!("Failed to XADD to {}", key))?;
+        Ok(())
+    }
+
+    async fn publish_event(&self, partition_id: u32, event: &GameEventMessage) -> Result<()> {
+        let payload = serde_json::to_vec(event).context("Failed to serialize event")?;
+        self.xadd(
+            &RedisKeys::stream_events(partition_id),
+            EVENTS_MAXLEN,
+            payload,
+        )
+        .await?;
+        debug!(
+            "XADD event to partition {} for game {} (stream_seq {})",
+            partition_id, event.game_id, event.stream_seq
+        );
+        Ok(())
+    }
+
+    async fn publish_snapshot(
+        &self,
+        partition_id: u32,
+        game_id: u32,
+        snapshot: &GameState,
+        stream_seq: u64,
+    ) -> Result<GameEventMessage> {
+        let event = GameEventMessage {
+            game_id,
+            tick: snapshot.tick,
+            sequence: snapshot.event_sequence,
+            stream_seq,
+            user_id: None,
+            event: GameEvent::Snapshot {
+                game_state: snapshot.clone(),
+            },
+        };
+
+        let payload = serde_json::to_vec(&event).context("Failed to serialize snapshot event")?;
+        self.xadd(
+            &RedisKeys::stream_events(partition_id),
+            EVENTS_MAXLEN,
+            payload,
+        )
+        .await?;
+        self.store_snapshot(game_id, snapshot).await?;
+
+        info!(
+            "XADD snapshot for game {} at tick {} to partition {} (stream_seq {})",
+            game_id, snapshot.tick, partition_id, stream_seq
+        );
+        Ok(event)
+    }
+
+    async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
+        let payload = serde_json::to_vec(command).context("Failed to serialize command")?;
+        self.xadd(
+            &RedisKeys::stream_commands(partition_id),
+            COMMANDS_MAXLEN,
+            payload,
+        )
+        .await
+    }
+
+    async fn request_partition_snapshots(&self, partition_id: u32) -> Result<()> {
+        let request = SnapshotRequest {
+            partition_id,
+            requester_id: None,
+        };
+        let payload =
+            serde_json::to_vec(&request).context("Failed to serialize snapshot request")?;
+        self.xadd(
+            &RedisKeys::stream_snapshot_requests(partition_id),
+            SNAPREQ_MAXLEN,
+            payload,
+        )
+        .await
+    }
+
+    async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
+        let key = RedisKeys::game_snapshot(game_id);
+        let data =
+            serde_json::to_vec(snapshot).context("Failed to serialize snapshot for storage")?;
+        let mut redis = self.redis.clone();
+        let _: () = redis
+            .set_ex(&key, data, 300)
+            .await
+            .context("Failed to store snapshot")?;
+        Ok(())
+    }
+
+    async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
+        let mut redis = self.redis.clone();
+        let data: Option<Vec<u8>> = redis
+            .get(RedisKeys::game_snapshot(game_id))
+            .await
+            .context("Failed to get snapshot from Redis")?;
+        match data {
+            Some(bytes) => Ok(Some(
+                serde_json::from_slice(&bytes).context("Failed to deserialize snapshot")?,
+            )),
+            None => Ok(None),
+        }
+    }
+
+    async fn subscribe_to_partition(&self, partition_id: u32) -> Result<PartitionSubscription> {
+        let (event_tx, event_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+        let (command_tx, command_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+        let (request_tx, request_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
+
+        // Anchor all three streams SYNCHRONOUSLY, before this method returns,
+        // on the warm shared connection. Anchoring inside the reader task
+        // would leave a window (spawn -> new connection -> XINFO) during
+        // which a published entry raises the tail past itself and is then
+        // never delivered — e.g. a snapshot response beating a fresh
+        // replica's reader startup. Anchored here, every XADD that happens
+        // after subscribe() returns is strictly newer than the anchor.
+        let mut redis = self.redis.clone();
+        let last_ids = [
+            resolve_stream_anchor(&mut redis, &RedisKeys::stream_events(partition_id)).await?,
+            resolve_stream_anchor(&mut redis, &RedisKeys::stream_commands(partition_id)).await?,
+            resolve_stream_anchor(
+                &mut redis,
+                &RedisKeys::stream_snapshot_requests(partition_id),
+            )
+            .await?,
+        ];
+
+        let client = self.redis_client.clone();
+        let token = self.cancellation_token.clone();
+        tokio::spawn(async move {
+            partition_reader(
+                client,
+                partition_id,
+                last_ids,
+                event_tx,
+                command_tx,
+                request_tx,
+                token,
+            )
+            .await;
+        });
+
+        Ok(PartitionSubscription {
+            partition_id,
+            event_receiver: event_rx,
+            command_receiver: command_rx,
+            snapshot_request_receiver: request_rx,
+        })
+    }
+}
+
+/// Resolve a stream's current tail ID as the subscription anchor.
+///
+/// Only a confirmed "no such key" maps to `0-0` (an empty stream has no
+/// history, so "from creation" equals "from now"). Every OTHER error —
+/// -LOADING after a Redis restart, connection resets, cluster redirects —
+/// propagates instead of defaulting: defaulting to 0-0 on a live stream
+/// would replay the entire retained backlog as fresh messages (re-running
+/// stale commands and resurrecting completed games).
+async fn resolve_stream_anchor(redis: &mut ConnectionManager, key: &str) -> Result<String> {
+    match redis
+        .xinfo_stream::<_, redis::streams::StreamInfoStreamReply>(key)
+        .await
+    {
+        Ok(info) => Ok(info.last_generated_id),
+        Err(e) if stream_does_not_exist(&e) => Ok("0-0".to_string()),
+        Err(e) => Err(e).with_context(|| format!("Failed to anchor stream {}", key)),
+    }
+}
+
+fn stream_does_not_exist(e: &redis::RedisError) -> bool {
+    e.kind() == redis::ErrorKind::ResponseError
+        && e.detail().is_some_and(|d| d.contains("no such key"))
+}
+
+/// The per-subscription reader task: one dedicated connection, one blocking
+/// XREAD covering all three partition streams, entries forwarded with
+/// backpressure. Survives connection failures by reconnecting and resuming
+/// from the last-delivered IDs (zero loss within the trim window; falling
+/// behind the trim horizon is detected and logged loudly).
+///
+/// `last_ids` are concrete tail anchors resolved by `subscribe_to_partition`
+/// BEFORE the subscription was handed out. NEVER pass "$" to XREAD here:
+/// "$" re-evaluates to "now" on every call, so an entry written to stream B
+/// while we were processing stream A's reply would be skipped forever.
+async fn partition_reader(
+    client: redis::Client,
+    partition_id: u32,
+    mut last_ids: [String; 3],
+    event_tx: mpsc::Sender<GameEventMessage>,
+    command_tx: mpsc::Sender<StreamEvent>,
+    request_tx: mpsc::Sender<SnapshotRequest>,
+    cancellation_token: CancellationToken,
+) {
+    let events_key = RedisKeys::stream_events(partition_id);
+    let commands_key = RedisKeys::stream_commands(partition_id);
+    let requests_key = RedisKeys::stream_snapshot_requests(partition_id);
+
+    let mut first_connect = true;
+    'reconnect: loop {
+        if cancellation_token.is_cancelled() {
+            break;
+        }
+
+        // Dedicated connection: blocking XREADs park it, and nothing else
+        // shares it (rule #1 — this is what made the old implementation slow).
+        let mut conn = match client.get_multiplexed_async_connection().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                warn!(
+                    "Stream reader for partition {} failed to connect: {}; retrying",
+                    partition_id, e
+                );
+                tokio::time::sleep(std::time::Duration::from_millis(
+                    READER_RECONNECT_BACKOFF_MS,
+                ))
+                .await;
+                continue;
+            }
+        };
+        debug!("Stream reader for partition {} connected", partition_id);
+
+        // After an outage, verify we haven't fallen behind the trim horizon.
+        // XREAD from a pre-horizon ID silently resumes at the oldest retained
+        // entry — fine for the events stream (stream_seq gap detection heals
+        // it downstream) but the commands stream has no sequence numbers, so
+        // this loud log is the ONLY record that commands were lost.
+        if !first_connect {
+            for (slot, key) in [&events_key, &commands_key, &requests_key]
+                .iter()
+                .enumerate()
+            {
+                match conn
+                    .xrange_count::<_, _, _, _, redis::streams::StreamRangeReply>(key, "-", "+", 1)
+                    .await
+                {
+                    Ok(reply) => {
+                        if let Some(oldest) = reply
+                            .ids
+                            .first()
+                            .filter(|oldest| stream_id_less_than(&last_ids[slot], &oldest.id))
+                        {
+                            error!(
+                                "Stream reader for partition {} fell behind the trim horizon on {} (resume {} < oldest {}): messages were lost during the outage; resuming from oldest",
+                                partition_id, key, last_ids[slot], oldest.id
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        warn!(
+                            "Stream reader for partition {} could not check trim horizon on {}: {}",
+                            partition_id, key, e
+                        );
+                    }
+                }
+            }
+        }
+        first_connect = false;
+
+        loop {
+            let options = StreamReadOptions::default()
+                .count(XREAD_COUNT)
+                .block(XREAD_BLOCK_MS);
+            let keys = [&events_key, &commands_key, &requests_key];
+            let ids: [&String; 3] = [&last_ids[0], &last_ids[1], &last_ids[2]];
+
+            let reply: StreamReadReply = tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => {
+                    info!("Stream reader for partition {} shutting down", partition_id);
+                    break 'reconnect;
+                }
+                result = conn.xread_options::<_, _, StreamReadReply>(&keys, &ids, &options) => {
+                    match result {
+                        Ok(reply) => reply,
+                        Err(e) => {
+                            warn!(
+                                "Stream reader for partition {} XREAD failed: {}; reconnecting from last IDs",
+                                partition_id, e
+                            );
+                            tokio::time::sleep(std::time::Duration::from_millis(
+                                READER_RECONNECT_BACKOFF_MS,
+                            ))
+                            .await;
+                            continue 'reconnect;
+                        }
+                    }
+                }
+            };
+
+            for stream in reply.keys {
+                for entry in stream.ids {
+                    let Some(payload) = entry.map.get("data") else {
+                        warn!(
+                            "Stream entry {} on {} has no data field; skipping",
+                            entry.id, stream.key
+                        );
+                        continue;
+                    };
+                    let bytes: Vec<u8> = match redis::from_redis_value(payload) {
+                        Ok(bytes) => bytes,
+                        Err(e) => {
+                            warn!(
+                                "Stream entry {} on {} has non-bytes payload: {}; skipping",
+                                entry.id, stream.key, e
+                            );
+                            continue;
+                        }
+                    };
+
+                    // Forward with backpressure: if the subscriber is slow we
+                    // wait (the log holds the backlog) instead of dropping.
+                    // A closed receiver means the subscriber is gone, and
+                    // cancellation must win even while parked on a full
+                    // channel — otherwise shutdown hangs behind a stalled
+                    // subscriber.
+                    let outcome = if stream.key == events_key {
+                        match serde_json::from_slice::<GameEventMessage>(&bytes) {
+                            Ok(msg) => forward(&event_tx, msg, &cancellation_token).await,
+                            Err(e) => {
+                                warn!("Malformed event on {}: {}; skipping", stream.key, e);
+                                Forward::Delivered
+                            }
+                        }
+                    } else if stream.key == commands_key {
+                        match serde_json::from_slice::<StreamEvent>(&bytes) {
+                            Ok(msg) => forward(&command_tx, msg, &cancellation_token).await,
+                            Err(e) => {
+                                warn!("Malformed command on {}: {}; skipping", stream.key, e);
+                                Forward::Delivered
+                            }
+                        }
+                    } else {
+                        match serde_json::from_slice::<SnapshotRequest>(&bytes) {
+                            Ok(msg) => forward(&request_tx, msg, &cancellation_token).await,
+                            Err(e) => {
+                                warn!(
+                                    "Malformed snapshot request on {}: {}; skipping",
+                                    stream.key, e
+                                );
+                                Forward::Delivered
+                            }
+                        }
+                    };
+
+                    match outcome {
+                        Forward::Delivered => {}
+                        Forward::SubscriberGone => {
+                            info!(
+                                "Stream reader for partition {} subscriber dropped; exiting",
+                                partition_id
+                            );
+                            break 'reconnect;
+                        }
+                        Forward::Cancelled => {
+                            info!(
+                                "Stream reader for partition {} cancelled during delivery; exiting",
+                                partition_id
+                            );
+                            break 'reconnect;
+                        }
+                    }
+
+                    let slot = if stream.key == events_key {
+                        0
+                    } else if stream.key == commands_key {
+                        1
+                    } else {
+                        2
+                    };
+                    last_ids[slot] = entry.id.clone();
+                }
+            }
+        }
+    }
+}
+
+enum Forward {
+    Delivered,
+    SubscriberGone,
+    Cancelled,
+}
+
+/// Backpressure-aware forward that still honors shutdown.
+async fn forward<T>(
+    tx: &mpsc::Sender<T>,
+    msg: T,
+    cancellation_token: &CancellationToken,
+) -> Forward {
+    tokio::select! {
+        biased;
+        _ = cancellation_token.cancelled() => Forward::Cancelled,
+        result = tx.send(msg) => match result {
+            Ok(()) => Forward::Delivered,
+            Err(_) => Forward::SubscriberGone,
+        },
+    }
+}
+
+/// Compare two stream entry IDs ("<ms>-<seq>") numerically.
+fn stream_id_less_than(a: &str, b: &str) -> bool {
+    fn parse(id: &str) -> (u64, u64) {
+        let mut parts = id.splitn(2, '-');
+        let ms = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        let seq = parts.next().and_then(|p| p.parse().ok()).unwrap_or(0);
+        (ms, seq)
+    }
+    parse(a) < parse(b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BusKind, stream_id_less_than};
+
+    #[test]
+    fn bus_kind_parse() {
+        assert_eq!(BusKind::parse(Some("streams")), BusKind::Streams);
+        assert_eq!(BusKind::parse(Some(" Streams ")), BusKind::Streams);
+        assert_eq!(BusKind::parse(Some("pubsub")), BusKind::PubSub);
+        assert_eq!(BusKind::parse(Some(" PubSub ")), BusKind::PubSub);
+        // Streams is the default: unset, empty, and unrecognized values.
+        assert_eq!(BusKind::parse(Some("")), BusKind::Streams);
+        assert_eq!(BusKind::parse(Some("nonsense")), BusKind::Streams);
+        assert_eq!(BusKind::parse(None), BusKind::Streams);
+    }
+
+    #[test]
+    fn stream_id_ordering() {
+        assert!(stream_id_less_than("5-1", "5-2"));
+        assert!(stream_id_less_than("5-9", "6-0"));
+        assert!(stream_id_less_than("0-0", "1-0"));
+        // Numeric, not lexicographic: 9-x < 10-x.
+        assert!(stream_id_less_than("9-0", "10-0"));
+        assert!(!stream_id_less_than("10-0", "9-0"));
+        assert!(!stream_id_less_than("5-2", "5-2"));
+    }
+}

--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -1,11 +1,14 @@
 use crate::db::Database;
 use crate::pubsub_manager::{PartitionSubscription, PubSubManager, SnapshotRequest};
 use crate::redis_keys::RedisKeys;
+use crate::replication::GameStateReader;
+use crate::sync_trace::GameTraceRecorder;
 use crate::xp_persistence;
 use anyhow::{Context, Result};
+use common::trace::{TRACE_FORMAT_VERSION, TraceRecord, TraceSide};
 use common::{
     EXECUTOR_POLL_INTERVAL_MS, GameCommandMessage, GameEngine, GameEvent, GameEventMessage,
-    GameState, GameStatus,
+    GameState, GameStatus, TICK_HASH_INTERVAL_TICKS,
 };
 use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
@@ -81,6 +84,42 @@ pub enum StreamEvent {
     },
 }
 
+/// Decides when to emit a TickHash heartbeat: every `interval_ticks` committed
+/// ticks, or the equivalent span of wall time when the committed tick is not
+/// advancing (pre-start, completion pending) so it doubles as a liveness
+/// signal.
+pub(crate) struct TickHashCadence {
+    interval_ticks: u32,
+    interval_ms: i64,
+    last_tick: u32,
+    last_ms: i64,
+}
+
+impl TickHashCadence {
+    pub(crate) fn new(
+        interval_ticks: u32,
+        tick_duration_ms: u32,
+        start_tick: u32,
+        start_ms: i64,
+    ) -> Self {
+        Self {
+            interval_ticks,
+            interval_ms: interval_ticks as i64 * tick_duration_ms.max(1) as i64,
+            last_tick: start_tick,
+            last_ms: start_ms,
+        }
+    }
+
+    pub(crate) fn due(&self, tick: u32, now_ms: i64) -> bool {
+        tick >= self.last_tick + self.interval_ticks || now_ms >= self.last_ms + self.interval_ms
+    }
+
+    pub(crate) fn mark(&mut self, tick: u32, now_ms: i64) {
+        self.last_tick = tick;
+        self.last_ms = now_ms;
+    }
+}
+
 /// Create a game engine and run the game loop for a specific game.
 async fn run_game(
     server_id: u64,
@@ -95,28 +134,60 @@ async fn run_game(
     info!("run_game called for game {}", game_id);
     let partition_id = game_id % PARTITION_COUNT;
 
-    // Create the game engine from the provided game state
-    let _start_ms = chrono::Utc::now().timestamp_millis();
+    // Transport-level sequence for every message this executor publishes for
+    // the game. Strictly monotonic starting at 1; receivers detect lost
+    // messages via contiguity.
+    let mut stream_seq: u64 = 0;
 
     // If the game is in Stopped status, start it before creating the engine
     let mut initial_state = game_state;
-    if matches!(initial_state.status, GameStatus::Stopped) {
+    let publish_started = matches!(initial_state.status, GameStatus::Stopped);
+    if publish_started {
         info!("Game {} is in Stopped status, starting it", game_id);
         initial_state.status = GameStatus::Started { server_id };
+    }
 
+    // Flight recorder: Meta + full initial state (including rng) form the
+    // deterministic replay anchor. Recorder failures never break the loop.
+    let mut recorder = GameTraceRecorder::for_server_game(game_id);
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    recorder.record(&TraceRecord::Meta {
+        version: TRACE_FORMAT_VERSION,
+        side: TraceSide::Server,
+        game_id,
+        session: server_id.to_string(),
+        ts_ms: now_ms,
+        build: env!("CARGO_PKG_VERSION").to_string(),
+        tick_duration_ms: initial_state.properties.tick_duration_ms,
+    });
+    recorder.record(&TraceRecord::State {
+        ts_ms: now_ms,
+        tick: initial_state.tick,
+        state: Box::new(initial_state.clone()),
+    });
+
+    if publish_started {
         // Emit status update event
+        stream_seq += 1;
         let status_event = GameEventMessage {
             game_id,
             tick: initial_state.tick,
             sequence: initial_state.event_sequence + 1,
+            stream_seq,
             user_id: None,
             event: GameEvent::StatusUpdated {
                 status: GameStatus::Started { server_id },
             },
         };
 
-        if let Err(e) = pubsub.publish_event(partition_id, &status_event).await {
+        let publish_result = pubsub.publish_event(partition_id, &status_event).await;
+        recorder.record(&TraceRecord::EventOut {
+            ts_ms: now_ms,
+            msg: Box::new(status_event),
+        });
+        if let Err(e) = publish_result {
             error!("Failed to publish game started status: {}", e);
+            recorder.note(format!("failed to publish game started status: {}", e));
         }
     }
 
@@ -128,12 +199,34 @@ async fn run_game(
     );
 
     // Publish initial snapshot
-    if let Err(e) = pubsub
-        .publish_snapshot(partition_id, game_id, &engine.get_committed_state())
+    stream_seq += 1;
+    match pubsub
+        .publish_snapshot(
+            partition_id,
+            game_id,
+            engine.get_committed_state(),
+            stream_seq,
+        )
         .await
     {
-        error!("Failed to publish initial snapshot: {}", e);
+        Ok(snapshot_event) => {
+            recorder.record(&TraceRecord::EventOut {
+                ts_ms: chrono::Utc::now().timestamp_millis(),
+                msg: Box::new(snapshot_event),
+            });
+        }
+        Err(e) => {
+            error!("Failed to publish initial snapshot: {}", e);
+            recorder.note(format!("failed to publish initial snapshot: {}", e));
+        }
     }
+
+    let mut hash_cadence = TickHashCadence::new(
+        TICK_HASH_INTERVAL_TICKS,
+        engine.get_committed_state().properties.tick_duration_ms,
+        engine.current_tick(),
+        chrono::Utc::now().timestamp_millis(),
+    );
 
     let mut interval = tokio::time::interval(Duration::from_millis(EXECUTOR_POLL_INTERVAL_MS));
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -144,6 +237,7 @@ async fn run_game(
 
             _ = cancellation_token.cancelled() => {
                 info!("Game loop for game {} shutting down", game_id);
+                recorder.note("game loop cancelled");
                 break;
             }
 
@@ -152,9 +246,22 @@ async fn run_game(
                 debug!("Received snapshot request for partition {}", request.partition_id);
                 // Only publish snapshot if this game belongs to the requested partition
                 if game_id % PARTITION_COUNT == request.partition_id {
-                    let snapshot = engine.get_committed_state();
-                    if let Err(e) = pubsub.publish_snapshot(partition_id, game_id, &snapshot).await {
-                        error!("Failed to publish requested snapshot: {}", e);
+                    recorder.note(format!(
+                        "snapshot requested for partition {} by {:?}",
+                        request.partition_id, request.requester_id
+                    ));
+                    stream_seq += 1;
+                    match pubsub.publish_snapshot(partition_id, game_id, engine.get_committed_state(), stream_seq).await {
+                        Ok(snapshot_event) => {
+                            recorder.record(&TraceRecord::EventOut {
+                                ts_ms: chrono::Utc::now().timestamp_millis(),
+                                msg: Box::new(snapshot_event),
+                            });
+                        }
+                        Err(e) => {
+                            error!("Failed to publish requested snapshot: {}", e);
+                            recorder.note(format!("failed to publish requested snapshot: {}", e));
+                        }
                     }
                 }
             }
@@ -164,27 +271,42 @@ async fn run_game(
                 debug!("Processing command for game {}. Command: {:?}",
                     game_id, command);
 
+                let now_ms = chrono::Utc::now().timestamp_millis();
+                recorder.record(&TraceRecord::CmdIn {
+                    ts_ms: now_ms,
+                    cmd: command.clone(),
+                });
+
                 // Process the command through the game engine
                 match engine.process_command(command) {
                     Ok(scheduled_command) => {
                         // Emit CommandScheduled event
                         let event = GameEvent::CommandScheduled { command_message: scheduled_command };
                         let current_state = engine.get_committed_state();
+                        stream_seq += 1;
                         let event_msg = GameEventMessage {
                             game_id,
                             tick: engine.current_tick(),
                             sequence: current_state.event_sequence + 1,
+                            stream_seq,
                             user_id: None,
                             event,
                         };
 
                         // Publish event via PubSub
-                        if let Err(e) = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await {
+                        let publish_result = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
+                        recorder.record(&TraceRecord::EventOut {
+                            ts_ms: now_ms,
+                            msg: Box::new(event_msg),
+                        });
+                        if let Err(e) = publish_result {
                             warn!("Failed to publish command scheduled event: {}", e);
+                            recorder.note(format!("failed to publish command scheduled event: {}", e));
                         }
                     }
                     Err(e) => {
                         warn!("Failed to process command for game {}: {:?}", game_id, e);
+                        recorder.note(format!("failed to process command: {:?}", e));
                     }
                 }
             }
@@ -236,17 +358,71 @@ async fn run_game(
                         };
 
                         for (tick, sequence, event) in &events {
+                            stream_seq += 1;
                             let event_msg = GameEventMessage {
                                 game_id,
                                 tick: *tick,
                                 sequence: *sequence,
+                                stream_seq,
                                 user_id: None,
                                 event: event.clone(),
                             };
 
                             // Publish event via PubSub
-                            if let Err(e) = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await {
+                            let publish_result = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
+                            recorder.record(&TraceRecord::EventOut {
+                                ts_ms: now_ms,
+                                msg: Box::new(event_msg),
+                            });
+                            if let Err(e) = publish_result {
                                 warn!("Failed to publish game event: {}", e);
+                                recorder.note(format!("failed to publish game event: {}", e));
+                            }
+                        }
+
+                        let committed_tick = engine.current_tick();
+
+                        // Publish the TickHash heartbeat: on the tick cadence,
+                        // on the equivalent wall-clock cadence when ticks are
+                        // not advancing, and immediately on completion (final
+                        // authoritative hash).
+                        if game_completed || hash_cadence.due(committed_tick, now_ms) {
+                            stream_seq += 1;
+                            let hash = engine.committed_sync_hash();
+                            let hash_msg = GameEventMessage {
+                                game_id,
+                                tick: committed_tick,
+                                sequence: engine.get_committed_state().event_sequence,
+                                stream_seq,
+                                user_id: None,
+                                event: GameEvent::TickHash { hash, server_ts_ms: now_ms },
+                            };
+                            let publish_result = pubsub.publish_event(partition_id, &hash_msg).await;
+                            recorder.record(&TraceRecord::EventOut {
+                                ts_ms: now_ms,
+                                msg: Box::new(hash_msg),
+                            });
+                            if let Err(e) = publish_result {
+                                warn!("Failed to publish tick hash: {}", e);
+                                recorder.note(format!("failed to publish tick hash: {}", e));
+                            }
+                            recorder.record(&TraceRecord::Fingerprint {
+                                ts_ms: now_ms,
+                                tick: committed_tick,
+                                hash,
+                            });
+                            recorder.flush();
+                            hash_cadence.mark(committed_tick, now_ms);
+
+                            // Refresh the stored (not published) snapshot at
+                            // the same cadence so a takeover executor can
+                            // resume this game from <=1s-stale state.
+                            if let Err(e) = pubsub
+                                .store_snapshot(game_id, engine.get_committed_state())
+                                .await
+                            {
+                                warn!("Failed to refresh stored snapshot for game {}: {}", game_id, e);
+                                recorder.note(format!("failed to refresh stored snapshot: {}", e));
                             }
                         }
 
@@ -255,8 +431,18 @@ async fn run_game(
                             info!("Game {} has completed, exiting game loop", game_id);
 
                             // Publish final snapshot
-                            if let Err(e) = pubsub.publish_snapshot(partition_id, game_id, &game_state).await {
-                                warn!("Failed to publish final snapshot: {}", e);
+                            stream_seq += 1;
+                            match pubsub.publish_snapshot(partition_id, game_id, game_state, stream_seq).await {
+                                Ok(snapshot_event) => {
+                                    recorder.record(&TraceRecord::EventOut {
+                                        ts_ms: now_ms,
+                                        msg: Box::new(snapshot_event),
+                                    });
+                                }
+                                Err(e) => {
+                                    warn!("Failed to publish final snapshot: {}", e);
+                                    recorder.note(format!("failed to publish final snapshot: {}", e));
+                                }
                             }
 
                             // Completion events and the final Redis snapshot are already visible
@@ -318,22 +504,106 @@ async fn run_game(
                         }
                     }
                     Err(e) => {
-                        eprintln!("Error running game tick: {:?}", e);
+                        error!("Error running game tick: {:?}", e);
+                        recorder.note(format!("error running game tick: {:?}", e));
                     }
                 }
             }
         }
     }
+
+    // Final state + flush regardless of how the loop ended (completion,
+    // cancellation, error) so the trace always has a terminal anchor.
+    let final_state = engine.get_committed_state();
+    recorder.record(&TraceRecord::State {
+        ts_ms: chrono::Utc::now().timestamp_millis(),
+        tick: final_state.tick,
+        state: Box::new(final_state.clone()),
+    });
+    recorder.flush();
+}
+
+/// Load every stored game snapshot from Redis (game:snapshot:* keys, written
+/// by publish_snapshot and refreshed at TickHash cadence by live game loops).
+/// Unreadable entries are skipped with a warning — resume is best-effort.
+pub async fn load_stored_snapshots(redis: &mut ConnectionManager) -> Vec<(u32, GameState)> {
+    use redis::AsyncCommands;
+
+    let prefix = crate::redis_keys::RedisKeys::game_snapshot(0);
+    let prefix = prefix.trim_end_matches('0');
+    let pattern = format!("{}*", prefix);
+
+    let keys: Vec<String> = {
+        let mut keys = Vec::new();
+        match redis.scan_match::<_, String>(&pattern).await {
+            Ok(mut iter) => {
+                while let Some(key) = iter.next_item().await {
+                    keys.push(key);
+                }
+            }
+            Err(e) => {
+                warn!("Failed to scan stored game snapshots: {}", e);
+                return Vec::new();
+            }
+        }
+        keys
+    };
+
+    let mut games = Vec::new();
+    for key in keys {
+        let Some(game_id) = key
+            .strip_prefix(prefix)
+            .and_then(|id| id.parse::<u32>().ok())
+        else {
+            continue;
+        };
+        match redis.get::<_, Option<Vec<u8>>>(&key).await {
+            Ok(Some(bytes)) => match serde_json::from_slice::<GameState>(&bytes) {
+                Ok(state) => games.push((game_id, state)),
+                Err(e) => warn!("Skipping unreadable stored snapshot {}: {}", key, e),
+            },
+            Ok(None) => {} // expired between scan and get
+            Err(e) => warn!("Failed to read stored snapshot {}: {}", key, e),
+        }
+    }
+    games
+}
+
+/// Choose which games a freshly started partition executor must resume.
+/// Replica states (event-current) take precedence over stored snapshots
+/// (periodically refreshed, slightly staler). Completed games are never
+/// resumed; Stopped ones are (their GameCreated message may have been lost
+/// while no executor was listening — run_game starts them).
+pub fn select_resumable_games(
+    partition_id: u32,
+    replica_games: Vec<(u32, GameState)>,
+    snapshot_games: Vec<(u32, GameState)>,
+) -> Vec<(u32, GameState)> {
+    let mut by_id: HashMap<u32, GameState> = HashMap::new();
+    for (game_id, state) in snapshot_games {
+        by_id.insert(game_id, state);
+    }
+    for (game_id, state) in replica_games {
+        by_id.insert(game_id, state);
+    }
+
+    let mut resumable: Vec<(u32, GameState)> = by_id
+        .into_iter()
+        .filter(|(game_id, _)| game_id % PARTITION_COUNT == partition_id)
+        .filter(|(_, state)| !matches!(state.status, GameStatus::Complete { .. }))
+        .collect();
+    resumable.sort_by_key(|(game_id, _)| *game_id);
+    resumable
 }
 
 /// Run the game executor service for a specific partition
 pub async fn run_game_executor(
     server_id: u64,
     partition_id: u32,
-    redis: ConnectionManager,
+    mut redis: ConnectionManager,
     mut pubsub_manager: PubSubManager,
     db: Arc<dyn Database>,
-    _replication_manager: Arc<crate::replication::ReplicationManager>,
+    replication_manager: Arc<crate::replication::ReplicationManager>,
     cancellation_token: CancellationToken,
 ) -> Result<()> {
     info!(
@@ -420,6 +690,40 @@ pub async fn run_game_executor(
 
         true
     };
+
+    // Resume in-flight games. This executor only starts once this server
+    // holds the partition lease, so any game found here belongs to an
+    // executor that died or lost its lease — without this, those games were
+    // cancelled forever and later player commands silently discarded. The
+    // replica state (event-current) wins over stored Redis snapshots
+    // (refreshed at TickHash cadence, so <=~1s stale); snapshots cover games
+    // this server's replica never saw, including games whose GameCreated
+    // pub/sub message was lost while no executor was listening. run_game
+    // re-anchors clients by publishing a fresh snapshot first, which resets
+    // stream_seq watermarks all the way down.
+    {
+        let replica_games = replication_manager.get_partition_games(partition_id).await;
+        let snapshot_games = load_stored_snapshots(&mut redis).await;
+        let resumable = select_resumable_games(partition_id, replica_games, snapshot_games);
+        if !resumable.is_empty() {
+            info!(
+                "Partition {} resuming {} in-flight game(s) after executor (re)start: {:?}",
+                partition_id,
+                resumable.len(),
+                resumable.iter().map(|(id, _)| *id).collect::<Vec<_>>()
+            );
+        }
+        for (game_id, game_state) in resumable {
+            try_start_game(
+                game_id,
+                game_state,
+                pubsub_manager.clone(),
+                db.clone(),
+                cancellation_token.clone(),
+                &mut game_channels,
+            );
+        }
+    }
 
     loop {
         tokio::select! {
@@ -515,4 +819,118 @@ pub async fn run_game_executor(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PARTITION_COUNT, TickHashCadence, select_resumable_games};
+    use common::{GameState, GameStatus, GameType, QueueMode};
+
+    fn state(status: GameStatus, tick: u32) -> GameState {
+        let mut s = GameState::new(
+            10,
+            10,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(1),
+            0,
+        );
+        s.status = status;
+        s.tick = tick;
+        s
+    }
+
+    #[test]
+    fn resume_selects_started_and_stopped_games_for_own_partition() {
+        let partition = 3;
+        let own_started = partition; // game_id % PARTITION_COUNT == partition
+        let own_stopped = partition + PARTITION_COUNT;
+        let own_complete = partition + 2 * PARTITION_COUNT;
+        let other_partition = partition + 1;
+
+        let snapshot_games = vec![
+            (own_started, state(GameStatus::Started { server_id: 1 }, 50)),
+            (own_stopped, state(GameStatus::Stopped, 0)),
+            (
+                own_complete,
+                state(
+                    GameStatus::Complete {
+                        winning_snake_id: None,
+                    },
+                    99,
+                ),
+            ),
+            (
+                other_partition,
+                state(GameStatus::Started { server_id: 1 }, 10),
+            ),
+        ];
+
+        let resumable = select_resumable_games(partition, Vec::new(), snapshot_games);
+        let ids: Vec<u32> = resumable.iter().map(|(id, _)| *id).collect();
+        assert_eq!(ids, vec![own_started, own_stopped]);
+    }
+
+    #[test]
+    fn resume_prefers_replica_state_over_stored_snapshot() {
+        let partition = 0;
+        let game_id = PARTITION_COUNT; // partition 0
+        let replica = vec![(game_id, state(GameStatus::Started { server_id: 1 }, 120))];
+        let snapshot = vec![(game_id, state(GameStatus::Started { server_id: 1 }, 90))];
+
+        let resumable = select_resumable_games(partition, replica, snapshot);
+        assert_eq!(resumable.len(), 1);
+        assert_eq!(
+            resumable[0].1.tick, 120,
+            "replica (event-current) state must win"
+        );
+    }
+
+    #[test]
+    fn resume_skips_games_completed_per_replica_even_if_snapshot_is_stale() {
+        let partition = 0;
+        let game_id = PARTITION_COUNT;
+        let replica = vec![(
+            game_id,
+            state(
+                GameStatus::Complete {
+                    winning_snake_id: Some(0),
+                },
+                200,
+            ),
+        )];
+        let snapshot = vec![(game_id, state(GameStatus::Started { server_id: 1 }, 150))];
+
+        let resumable = select_resumable_games(partition, replica, snapshot);
+        assert!(
+            resumable.is_empty(),
+            "a completed game must never be resurrected"
+        );
+    }
+
+    #[test]
+    fn tick_hash_due_on_tick_cadence() {
+        let cadence = TickHashCadence::new(10, 100, 0, 0);
+        assert!(!cadence.due(5, 100));
+        assert!(cadence.due(10, 100));
+        assert!(cadence.due(15, 100));
+    }
+
+    #[test]
+    fn tick_hash_due_on_wall_clock_when_ticks_stall() {
+        // 10 ticks * 100ms = 1000ms heartbeat interval.
+        let cadence = TickHashCadence::new(10, 100, 0, 0);
+        assert!(!cadence.due(0, 999));
+        assert!(cadence.due(0, 1000));
+    }
+
+    #[test]
+    fn tick_hash_mark_resets_both_cadences() {
+        let mut cadence = TickHashCadence::new(10, 100, 0, 0);
+        assert!(cadence.due(10, 500));
+        cadence.mark(10, 500);
+        assert!(!cadence.due(19, 1499));
+        assert!(cadence.due(20, 600));
+        assert!(cadence.due(19, 1500));
+    }
 }

--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
-use crate::pubsub_manager::{PartitionSubscription, PubSubManager, SnapshotRequest};
+use crate::game_bus::GameBus;
+use crate::pubsub_manager::{PartitionSubscription, SnapshotRequest};
 use crate::redis_keys::RedisKeys;
 use crate::replication::GameStateReader;
 use crate::sync_trace::GameTraceRecorder;
@@ -125,7 +126,7 @@ async fn run_game(
     server_id: u64,
     game_id: u32,
     game_state: GameState,
-    mut pubsub: PubSubManager,
+    bus: Arc<GameBus>,
     mut command_receiver: mpsc::Receiver<GameCommandMessage>,
     mut snapshot_request_receiver: mpsc::Receiver<SnapshotRequest>,
     db: Arc<dyn Database>,
@@ -180,7 +181,7 @@ async fn run_game(
             },
         };
 
-        let publish_result = pubsub.publish_event(partition_id, &status_event).await;
+        let publish_result = bus.publish_event(partition_id, &status_event).await;
         recorder.record(&TraceRecord::EventOut {
             ts_ms: now_ms,
             msg: Box::new(status_event),
@@ -200,7 +201,7 @@ async fn run_game(
 
     // Publish initial snapshot
     stream_seq += 1;
-    match pubsub
+    match bus
         .publish_snapshot(
             partition_id,
             game_id,
@@ -251,7 +252,7 @@ async fn run_game(
                         request.partition_id, request.requester_id
                     ));
                     stream_seq += 1;
-                    match pubsub.publish_snapshot(partition_id, game_id, engine.get_committed_state(), stream_seq).await {
+                    match bus.publish_snapshot(partition_id, game_id, engine.get_committed_state(), stream_seq).await {
                         Ok(snapshot_event) => {
                             recorder.record(&TraceRecord::EventOut {
                                 ts_ms: chrono::Utc::now().timestamp_millis(),
@@ -294,7 +295,7 @@ async fn run_game(
                         };
 
                         // Publish event via PubSub
-                        let publish_result = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
+                        let publish_result = bus.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
                         recorder.record(&TraceRecord::EventOut {
                             ts_ms: now_ms,
                             msg: Box::new(event_msg),
@@ -324,7 +325,7 @@ async fn run_game(
                             // Establish the terminal grace-period cache before any Complete event
                             // can evict replicas. This keeps refreshes loadable while durable
                             // persistence retries outside the client-visible completion path.
-                            if let Err(e) = pubsub.store_snapshot(game_id, &game_state).await {
+                            if let Err(e) = bus.store_snapshot(game_id, &game_state).await {
                                 error!(
                                     "Failed to store terminal reload snapshot for game {}: {:?}",
                                     game_id, e
@@ -369,7 +370,7 @@ async fn run_game(
                             };
 
                             // Publish event via PubSub
-                            let publish_result = pubsub.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
+                            let publish_result = bus.publish_event(game_id % PARTITION_COUNT, &event_msg).await;
                             recorder.record(&TraceRecord::EventOut {
                                 ts_ms: now_ms,
                                 msg: Box::new(event_msg),
@@ -397,7 +398,7 @@ async fn run_game(
                                 user_id: None,
                                 event: GameEvent::TickHash { hash, server_ts_ms: now_ms },
                             };
-                            let publish_result = pubsub.publish_event(partition_id, &hash_msg).await;
+                            let publish_result = bus.publish_event(partition_id, &hash_msg).await;
                             recorder.record(&TraceRecord::EventOut {
                                 ts_ms: now_ms,
                                 msg: Box::new(hash_msg),
@@ -417,7 +418,7 @@ async fn run_game(
                             // Refresh the stored (not published) snapshot at
                             // the same cadence so a takeover executor can
                             // resume this game from <=1s-stale state.
-                            if let Err(e) = pubsub
+                            if let Err(e) = bus
                                 .store_snapshot(game_id, engine.get_committed_state())
                                 .await
                             {
@@ -432,7 +433,7 @@ async fn run_game(
 
                             // Publish final snapshot
                             stream_seq += 1;
-                            match pubsub.publish_snapshot(partition_id, game_id, game_state, stream_seq).await {
+                            match bus.publish_snapshot(partition_id, game_id, game_state, stream_seq).await {
                                 Ok(snapshot_event) => {
                                     recorder.record(&TraceRecord::EventOut {
                                         ts_ms: now_ms,
@@ -473,7 +474,7 @@ async fn run_game(
                             // Replicas use this command as the durable-commit marker. Never evict
                             // the authoritative completed state when persistence did not succeed.
                             if completion_is_durable {
-                                if let Err(e) = pubsub.publish_command(
+                                if let Err(e) = bus.publish_command(
                                     partition_id,
                                     &StreamEvent::StatusUpdated {
                                         game_id,
@@ -601,7 +602,7 @@ pub async fn run_game_executor(
     server_id: u64,
     partition_id: u32,
     mut redis: ConnectionManager,
-    mut pubsub_manager: PubSubManager,
+    bus: Arc<GameBus>,
     db: Arc<dyn Database>,
     replication_manager: Arc<crate::replication::ReplicationManager>,
     cancellation_token: CancellationToken,
@@ -617,7 +618,7 @@ pub async fn run_game_executor(
     //     .context("Failed to create PubSub manager")?;
 
     // Subscribe to partition commands and snapshot requests
-    let partition_sub = pubsub_manager
+    let partition_sub = bus
         .subscribe_to_partition(partition_id)
         .await
         .context("Failed to subscribe to partition")?;
@@ -640,7 +641,7 @@ pub async fn run_game_executor(
 
     let try_start_game = |game_id: u32,
                           game_state: GameState,
-                          pubsub: PubSubManager,
+                          bus: Arc<GameBus>,
                           db: Arc<dyn Database>,
                           cancellation_token: CancellationToken,
                           game_channels: &mut HashMap<
@@ -678,7 +679,7 @@ pub async fn run_game_executor(
                 server_id,
                 game_id,
                 game_state,
-                pubsub,
+                bus,
                 cmd_rx,
                 snap_rx,
                 db,
@@ -717,7 +718,7 @@ pub async fn run_game_executor(
             try_start_game(
                 game_id,
                 game_state,
-                pubsub_manager.clone(),
+                bus.clone(),
                 db.clone(),
                 cancellation_token.clone(),
                 &mut game_channels,
@@ -760,13 +761,13 @@ pub async fn run_game_executor(
                 match command_data {
                     StreamEvent::GameCreated { game_id, game_state } => {
                         info!("Received GameCreated event for game {}", game_id);
-                        let pubsub_clone = pubsub_manager.clone();
+                        let bus_clone = bus.clone();
                         let db_clone = db.clone();
                         let cancellation_token_clone = cancellation_token.clone();
                         let accepted = try_start_game(
                             game_id,
                             game_state,
-                            pubsub_clone,
+                            bus_clone,
                             db_clone,
                             cancellation_token_clone,
                             &mut game_channels

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -9,6 +9,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, trace, warn};
 
 use crate::api::jwt::JwtManager;
+use crate::game_bus::{BusKind, GameBus};
 use crate::game_executor::PARTITION_COUNT;
 use crate::game_executor::StreamEvent;
 use crate::http_server::run_http_server;
@@ -152,6 +153,20 @@ impl GameServer {
             cancellation_token.clone(),
         ));
 
+        // Create the game-critical message bus (transport per SNAKETRON_BUS).
+        // Loss-tolerant fan-out (chat/lobby/counters) stays on the
+        // PubSubManager regardless of this setting.
+        let bus_kind = BusKind::from_env();
+        info!("Game bus transport: {:?}", bus_kind);
+        let game_bus = Arc::new(GameBus::new(
+            bus_kind,
+            (*pubsub_manager).clone(),
+            redis.clone(),
+            Client::open(redis_url.clone())
+                .context("Failed to create Redis client for game bus")?,
+            cancellation_token.clone(),
+        ));
+
         // Create the LobbyManager
         let lobby_manager = Arc::new(LobbyManager::new(
             redis.clone(),
@@ -180,7 +195,7 @@ impl GameServer {
         // Start the matchmaking service
         info!("Starting matchmaking service");
         let match_token = cancellation_token.clone();
-        let match_pubsub_manager = (*pubsub_manager).clone();
+        let match_game_bus = game_bus.clone();
         let match_matchmaking_manager = matchmaking_manager.clone();
         let match_lobby_manager = lobby_manager.clone();
         let match_db = db.clone();
@@ -190,7 +205,7 @@ impl GameServer {
             drop(match_matchmaking_manager); // Drop the lock
             if let Err(e) = run_matchmaking_loop(
                 mm,
-                match_pubsub_manager,
+                match_game_bus,
                 match_token,
                 match_lobby_manager,
                 match_db,
@@ -209,6 +224,7 @@ impl GameServer {
                 replication_partitions,
                 cancellation_token.clone(),
                 &redis_url,
+                bus_kind,
             )
             .await
             .context("Failed to create replication manager")?,
@@ -243,7 +259,7 @@ impl GameServer {
             let exec_redis_clone = redis.clone();
             let exec_db = db.clone();
             let exec_replication_manager = replication_manager.clone();
-            let exec_pubsub_manager = pubsub_manager.clone();
+            let exec_game_bus = game_bus.clone();
 
             handles.push(tokio::spawn(async move {
                 info!(
@@ -270,7 +286,7 @@ impl GameServer {
                     let server_id_clone = server_id;
                     let partition_id_clone = partition_id;
                     let exec_redis_clone = exec_redis_clone.clone();
-                    let exec_pubsub_manager_clone = (*exec_pubsub_manager).clone();
+                    let exec_game_bus_clone = exec_game_bus.clone();
                     let exec_db = exec_db.clone();
                     let exec_replication_manager = exec_replication_manager.clone();
 
@@ -284,7 +300,7 @@ impl GameServer {
                             server_id_clone,
                             partition_id_clone,
                             exec_redis_clone,
-                            exec_pubsub_manager_clone,
+                            exec_game_bus_clone,
                             exec_db,
                             exec_replication_manager,
                             token,
@@ -322,6 +338,7 @@ impl GameServer {
         let http_redis = redis.clone();
         let http_redis_url = redis_url.clone();
         let http_pubsub_manager = pubsub_manager.clone();
+        let http_game_bus = game_bus.clone();
         let http_matchmaking_manager = matchmaking_manager.clone();
         let http_replication_manager = replication_manager.clone();
         let http_cancellation_token = cancellation_token.clone();
@@ -338,6 +355,7 @@ impl GameServer {
                 http_redis,
                 http_redis_url,
                 http_pubsub_manager,
+                http_game_bus,
                 http_matchmaking_manager,
                 http_replication_manager,
                 http_cancellation_token,

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -251,11 +251,16 @@ impl GameServer {
                     partition_id
                 );
 
+                // 3s lease (renewed every 150ms): with the renewal-error
+                // grace window at 60% of the lease, a Redis blip of up to
+                // ~1.8s no longer cancels the partition's games, while
+                // failover after a real death still completes within ~3s —
+                // inside the client liveness watchdog's reconnect overlay.
                 let singleton = ClusterSingleton::new(
                     exec_redis_clone.clone(),
                     server_id,
                     RedisKeys::partition_executor_lease(partition_id),
-                    Duration::from_secs(1),
+                    Duration::from_secs(3),
                     exec_token.clone(),
                 );
 

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -19,6 +19,7 @@ use crate::api::middleware::auth_middleware;
 use crate::api::rate_limit::{rate_limit_layer, rate_limit_middleware};
 use crate::api::regions;
 use crate::db::Database;
+use crate::game_bus::GameBus;
 use crate::lobby_manager::LobbyManager;
 use crate::region_cache::RegionCache;
 use crate::replication::ReplicationManager;
@@ -43,8 +44,10 @@ pub struct HttpServerState {
     pub redis: ConnectionManager,
     /// Redis URL for creating new connections
     pub redis_url: String,
-    /// PubSub manager for Redis pub/sub operations
+    /// PubSub manager for loss-tolerant fan-out (chat, lobby, counters)
     pub pubsub_manager: Arc<crate::pubsub_manager::PubSubManager>,
+    /// Game-critical message bus (transport per SNAKETRON_BUS)
+    pub game_bus: Arc<GameBus>,
     /// Matchmaking manager for queue operations
     pub matchmaking_manager:
         Arc<tokio::sync::Mutex<crate::matchmaking_manager::MatchmakingManager>>,
@@ -75,6 +78,7 @@ pub async fn run_http_server(
     redis: ConnectionManager,
     redis_url: String,
     pubsub_manager: Arc<crate::pubsub_manager::PubSubManager>,
+    game_bus: Arc<GameBus>,
     matchmaking_manager: Arc<tokio::sync::Mutex<crate::matchmaking_manager::MatchmakingManager>>,
     replication_manager: Arc<ReplicationManager>,
     cancellation_token: tokio_util::sync::CancellationToken,
@@ -94,6 +98,7 @@ pub async fn run_http_server(
         redis: redis.clone(),
         redis_url,
         pubsub_manager,
+        game_bus,
         matchmaking_manager,
         replication_manager,
         cancellation_token: cancellation_token.clone(),
@@ -300,6 +305,7 @@ async fn websocket_handler(
             state.redis,
             state.redis_url,
             state.pubsub_manager,
+            state.game_bus,
             state.matchmaking_manager,
             state.replication_manager,
             state.cancellation_token,

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -147,6 +147,14 @@ pub async fn run_http_server(
         .route("/api/regions/user-counts", get(regions::get_user_counts))
         .with_state(state.clone());
 
+    // Debug/observability routes: clients upload their sync trace (flight
+    // recorder ring buffer) here when they detect a desync. Body capped at
+    // 10 MB; records are validated as TraceRecords before being persisted
+    // next to the server-side traces.
+    let debug_routes = Router::new()
+        .route("/api/debug/client-trace", post(upload_client_trace))
+        .layer(axum::extract::DefaultBodyLimit::max(10 * 1024 * 1024));
+
     // Build leaderboard routes with LeaderboardState
     let leaderboard_state = LeaderboardState { db: db.clone() };
     let leaderboard_routes = Router::new()
@@ -182,6 +190,7 @@ pub async fn run_http_server(
         .merge(region_routes)
         .merge(leaderboard_routes)
         .merge(protected_leaderboard_routes)
+        .merge(debug_routes)
         .with_state(auth_state);
 
     // Build main router combining API and WebSocket endpoints
@@ -207,6 +216,67 @@ pub async fn run_http_server(
         })
         .await
         .map_err(|e| anyhow::anyhow!("HTTP server error: {}", e))
+}
+
+#[derive(serde::Deserialize)]
+struct ClientTraceUpload {
+    game_id: u32,
+    user_id: u32,
+    records: Vec<serde_json::Value>,
+}
+
+/// Persist a client-side sync trace next to the server traces so a desync
+/// can be analyzed from both perspectives (see DEBUGGING.md).
+async fn upload_client_trace(
+    axum::Json(upload): axum::Json<ClientTraceUpload>,
+) -> impl IntoResponse {
+    // Validate every record parses as a TraceRecord; a malformed trace is
+    // rejected rather than persisted half-usable.
+    let mut records = Vec::with_capacity(upload.records.len());
+    for (idx, value) in upload.records.into_iter().enumerate() {
+        match serde_json::from_value::<common::trace::TraceRecord>(value) {
+            Ok(record) => records.push(record),
+            Err(e) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    format!("record {} is not a valid TraceRecord: {}", idx, e),
+                )
+                    .into_response();
+            }
+        }
+    }
+
+    let config = crate::sync_trace::TraceConfig::from_env();
+    let game_id = upload.game_id;
+    let user_id = upload.user_id;
+    // File I/O is small (<=10MB) but still blocking; keep it off the reactor.
+    let result = tokio::task::spawn_blocking(move || {
+        crate::sync_trace::write_client_trace(&config, game_id, user_id, &records)
+    })
+    .await;
+
+    match result {
+        Ok(Ok(path)) => {
+            info!(
+                "Stored client sync trace for game {} user {} at {:?}",
+                game_id, user_id, path
+            );
+            StatusCode::NO_CONTENT.into_response()
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(
+                "Failed to store client trace for game {} user {}: {}",
+                game_id,
+                user_id,
+                e
+            );
+            (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()).into_response()
+        }
+        Err(e) => {
+            tracing::error!("Client trace writer task panicked: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
 }
 
 /// WebSocket upgrade handler

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -16,6 +16,7 @@ pub mod region_cache;
 pub mod replay;
 pub mod replication;
 pub mod season;
+pub mod sync_trace;
 pub mod user_cache;
 pub mod ws_matchmaking;
 pub mod ws_server;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod cluster_singleton;
 pub mod db;
+pub mod game_bus;
 pub mod game_executor;
 pub mod game_server;
 pub mod grpc_server;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,7 +4,6 @@ use server::api::jwt::{JwtManager, ProductionJwtVerifier};
 use server::db::{Database, dynamodb::DynamoDatabase};
 use server::game_server::{GameServer, GameServerConfig};
 use server::http_server::run_http_server;
-use server::pubsub_manager::PubSubManager;
 use server::redis_utils::create_connection_manager;
 use server::region_cache::RegionCache;
 use server::ws_server::TestJwtVerifier;

--- a/server/src/matchmaking.rs
+++ b/server/src/matchmaking.rs
@@ -1215,8 +1215,9 @@ async fn create_game_from_lobbies(
         game_state: game_state.clone(),
     };
 
+    // stream_seq 0: the executor owning the game loop assigns the stream.
     pubsub
-        .publish_snapshot(partition_id, game_id, &game_state)
+        .publish_snapshot(partition_id, game_id, &game_state, 0)
         .await
         .context("Failed to publish initial game snapshot")?;
 
@@ -1325,8 +1326,9 @@ pub async fn create_custom_match(
         game_state: game_state.clone(),
     };
 
+    // stream_seq 0: the executor owning the game loop assigns the stream.
     pubsub
-        .publish_snapshot(partition_id, game_id, &game_state)
+        .publish_snapshot(partition_id, game_id, &game_state, 0)
         .await?;
 
     pubsub.publish_command(partition_id, &event).await?;

--- a/server/src/matchmaking.rs
+++ b/server/src/matchmaking.rs
@@ -10,11 +10,11 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 
 use crate::db::Database;
+use crate::game_bus::GameBus;
 use crate::game_executor::PARTITION_COUNT;
 use crate::game_executor::StreamEvent;
 use crate::lobby_manager::LobbyManager;
 use crate::matchmaking_manager::{ActiveMatch, MatchStatus, MatchmakingManager, QueuedPlayer};
-use crate::pubsub_manager::PubSubManager;
 
 // --- Configuration Constants ---
 const GAME_START_DELAY_MS: i64 = 3000; // 3 second countdown before game starts
@@ -669,7 +669,7 @@ fn find_ffa_combination(
 /// Main matchmaking loop
 pub async fn run_matchmaking_loop(
     mut matchmaking_manager: MatchmakingManager,
-    mut pubsub: PubSubManager,
+    bus: Arc<GameBus>,
     cancellation_token: CancellationToken,
     lobby_manager: Arc<LobbyManager>,
     db: Arc<dyn Database>,
@@ -735,7 +735,7 @@ pub async fn run_matchmaking_loop(
             // Try lobby-based matchmaking for quickmatch
             match create_lobby_matches(
                 &mut matchmaking_manager,
-                &mut pubsub,
+                &bus,
                 game_type.clone(),
                 common::QueueMode::Quickmatch,
                 lobby_manager.clone(),
@@ -763,7 +763,7 @@ pub async fn run_matchmaking_loop(
             // Try lobby-based matchmaking for competitive
             match create_lobby_matches(
                 &mut matchmaking_manager,
-                &mut pubsub,
+                &bus,
                 game_type.clone(),
                 common::QueueMode::Competitive,
                 lobby_manager.clone(),
@@ -865,7 +865,7 @@ fn filter_compatible_lobbies(
 /// Create matches from lobbies in the queue using advanced combination matching
 async fn create_lobby_matches(
     matchmaking_manager: &mut MatchmakingManager,
-    pubsub: &mut PubSubManager,
+    bus: &GameBus,
     game_type: GameType,
     queue_mode: common::QueueMode,
     lobby_manager: Arc<LobbyManager>,
@@ -1007,7 +1007,7 @@ async fn create_lobby_matches(
         // Create game from this combination
         match create_game_from_lobbies(
             matchmaking_manager,
-            pubsub,
+            bus,
             &game_type,
             &queue_mode,
             &combination,
@@ -1071,7 +1071,7 @@ async fn create_lobby_matches(
 /// Create a game from a combination of lobbies with proper team assignments
 async fn create_game_from_lobbies(
     matchmaking_manager: &mut MatchmakingManager,
-    pubsub: &mut PubSubManager,
+    bus: &GameBus,
     game_type: &GameType,
     queue_mode: &common::QueueMode,
     combination: &MatchmakingCombination,
@@ -1216,13 +1216,11 @@ async fn create_game_from_lobbies(
     };
 
     // stream_seq 0: the executor owning the game loop assigns the stream.
-    pubsub
-        .publish_snapshot(partition_id, game_id, &game_state, 0)
+    bus.publish_snapshot(partition_id, game_id, &game_state, 0)
         .await
         .context("Failed to publish initial game snapshot")?;
 
-    pubsub
-        .publish_command(partition_id, &event)
+    bus.publish_command(partition_id, &event)
         .await
         .context("Failed to publish GameCreated event")?;
 
@@ -1272,7 +1270,7 @@ async fn publish_lobby_match_notifications(
 /// Create a match from a specific set of players (for custom games)
 pub async fn create_custom_match(
     matchmaking_manager: &mut MatchmakingManager,
-    pubsub: &mut PubSubManager,
+    bus: &GameBus,
     db: &dyn Database,
     players: Vec<QueuedPlayer>,
     game_type: GameType,
@@ -1327,11 +1325,10 @@ pub async fn create_custom_match(
     };
 
     // stream_seq 0: the executor owning the game loop assigns the stream.
-    pubsub
-        .publish_snapshot(partition_id, game_id, &game_state, 0)
+    bus.publish_snapshot(partition_id, game_id, &game_state, 0)
         .await?;
 
-    pubsub.publish_command(partition_id, &event).await?;
+    bus.publish_command(partition_id, &event).await?;
 
     info!(
         game_id,

--- a/server/src/pubsub_manager.rs
+++ b/server/src/pubsub_manager.rs
@@ -24,12 +24,33 @@ pub struct ChannelReceiver {
 }
 
 impl ChannelReceiver {
+    /// Receive the next message for this channel.
+    ///
+    /// Only a closed broadcast (shutdown) returns an error. Lagging behind
+    /// the shared Redis push firehose and malformed payloads are logged and
+    /// skipped — before this, either one propagated as a fatal error and the
+    /// subscription task above us broke its loop, permanently and silently
+    /// severing a partition's entire event/command feed on this server. Lost
+    /// messages surface downstream as stream_seq gaps, which trigger a
+    /// snapshot resync.
     pub async fn recv<T>(&mut self) -> Result<T>
     where
         T: DeserializeOwned + Send + 'static,
     {
         loop {
-            let PushInfo { kind, data } = self.inner.recv().await?;
+            let PushInfo { kind, data } = match self.inner.recv().await {
+                Ok(info) => info,
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        "Redis push receiver for channel {} lagged, {} pushes skipped; continuing (downstream gap detection will resync)",
+                        self.channel, skipped
+                    );
+                    continue;
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    return Err(anyhow!("Redis push broadcast closed"));
+                }
+            };
 
             if !matches!(kind, PushKind::Message) {
                 continue;
@@ -39,25 +60,25 @@ impl ChannelReceiver {
                 continue;
             };
 
-            let channel =
-                String::from_utf8(ch.clone()).context("Failed to parse channel name as UTF-8")?;
+            let channel = match String::from_utf8(ch.clone()) {
+                Ok(channel) => channel,
+                Err(e) => {
+                    warn!("Skipping Redis push with non-UTF-8 channel name: {}", e);
+                    continue;
+                }
+            };
 
             if channel != self.channel {
                 continue;
             }
 
-            let payload_str =
-                String::from_utf8(payload.clone()).context("Failed to parse payload as UTF-8")?;
-
-            let msg = serde_json::from_slice::<T>(payload).map_err(|e| {
-                anyhow!(
-                    "Failed to deserialize message from channel {}: {}",
-                    channel,
-                    e
-                )
-            })?;
-
-            return Ok(msg);
+            match serde_json::from_slice::<T>(payload) {
+                Ok(msg) => return Ok(msg),
+                Err(e) => {
+                    warn!("Skipping malformed message on channel {}: {}", channel, e);
+                    continue;
+                }
+            }
         }
     }
 }
@@ -147,18 +168,25 @@ impl PubSubManager {
         Ok(())
     }
 
-    /// Publish a snapshot to a partition channel and store in Redis
+    /// Publish a snapshot to a partition channel and store in Redis.
+    ///
+    /// `stream_seq` is the executor-assigned transport sequence for this
+    /// message (0 for pre-executor publishes, e.g. match creation). Returns
+    /// the constructed snapshot event so callers can trace exactly what was
+    /// published without rebuilding it.
     pub async fn publish_snapshot(
         &self,
         partition_id: u32,
         game_id: u32,
         snapshot: &GameState,
-    ) -> Result<()> {
+        stream_seq: u64,
+    ) -> Result<GameEventMessage> {
         // Create a snapshot event
         let event = GameEventMessage {
             game_id,
             tick: snapshot.tick,
             sequence: snapshot.event_sequence,
+            stream_seq,
             user_id: None,
             event: GameEvent::Snapshot {
                 game_state: snapshot.clone(),
@@ -178,27 +206,30 @@ impl PubSubManager {
         self.store_snapshot(game_id, snapshot).await?;
 
         info!(
-            "Published snapshot for game {} at tick {} to partition {}",
-            game_id, snapshot.tick, partition_id
+            "Published snapshot for game {} at tick {} to partition {} (stream_seq {})",
+            game_id, snapshot.tick, partition_id, stream_seq
         );
 
-        Ok(())
+        Ok(event)
     }
 
-    /// Store a reload snapshot without broadcasting it.
+    /// Store a game snapshot in Redis WITHOUT publishing it to subscribers.
     ///
-    /// The executor uses this to establish the terminal Redis fallback before publishing
-    /// completion events and, once persistence succeeds, releasing the in-memory copy.
+    /// Two callers rely on this: the game loop refreshes it periodically so a
+    /// takeover executor can resume in-flight games from near-current state
+    /// (see game_executor::resume_partition_games), and the completion path
+    /// stores the terminal state as the reload fallback before publishing
+    /// completion events and releasing the in-memory copy. 5-minute TTL: a
+    /// game whose executor stays dead longer than that is not resumable.
     pub async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
         let key = RedisKeys::game_snapshot(game_id);
-        let snapshot_data =
+        let data =
             serde_json::to_vec(snapshot).context("Failed to serialize snapshot for storage")?;
         let mut redis = self.redis.clone();
         let _: () = redis
-            .set_ex(&key, snapshot_data, 300)
+            .set_ex(&key, data, 300)
             .await
             .context("Failed to store snapshot")?;
-
         Ok(())
     }
 

--- a/server/src/pubsub_manager.rs
+++ b/server/src/pubsub_manager.rs
@@ -1,11 +1,9 @@
 use crate::game_executor::StreamEvent;
 use crate::redis_keys::RedisKeys;
-use crate::redis_utils;
 use anyhow::{Context, Result, anyhow};
-use common::{GameCommandMessage, GameEvent, GameEventMessage, GameState, GameStatus};
-use futures_util::{Stream, StreamExt};
-use redis::aio::{ConnectionManager, PubSub};
-use redis::{AsyncCommands, Client, PushInfo, PushKind, Value};
+use common::{GameEvent, GameEventMessage, GameState};
+use redis::aio::ConnectionManager;
+use redis::{AsyncCommands, PushInfo, PushKind, Value};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/server/src/redis_keys.rs
+++ b/server/src/redis_keys.rs
@@ -178,6 +178,23 @@ impl RedisKeys {
         format!("game:creation-ack:{}", game_id)
     }
 
+    // === Game Bus Streams Keys (SNAKETRON_BUS=streams) ===
+
+    /// Stream carrying game events for a partition
+    pub fn stream_events(partition_id: u32) -> String {
+        format!("snaketron:stream:events:{}", partition_id)
+    }
+
+    /// Stream carrying commands (GameCreated, GameCommandSubmitted, ...) for a partition
+    pub fn stream_commands(partition_id: u32) -> String {
+        format!("snaketron:stream:commands:{}", partition_id)
+    }
+
+    /// Stream carrying snapshot requests for a partition
+    pub fn stream_snapshot_requests(partition_id: u32) -> String {
+        format!("snaketron:stream:snapreq:{}", partition_id)
+    }
+
     // === Cluster Singleton Keys ===
 
     /// Lease key for a singleton service

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -11,6 +11,11 @@ use tracing::{debug, error, info, warn};
 /// In-memory game state storage
 pub type GameStateStore = Arc<RwLock<HashMap<u32, GameState>>>;
 
+/// Per-game last-seen transport stream_seq (the replica watermark).
+/// Updated together with `GameStateStore` while holding the state write lock,
+/// so a state clone and its watermark are always mutually consistent.
+pub type GameStreamSeqs = Arc<RwLock<HashMap<u32, u64>>>;
+
 /// Game event broadcast channels
 pub type GameEventBroadcasters = Arc<RwLock<HashMap<u32, broadcast::Sender<GameEventMessage>>>>;
 
@@ -21,11 +26,16 @@ pub struct ReplicationStatus {
     pub is_ready: bool,
 }
 
-/// A wrapper around broadcast::Receiver that filters out events before a certain sequence number
+/// A wrapper around broadcast::Receiver that filters out events already
+/// contained in the snapshot handed out alongside it.
+///
+/// Filtering uses the transport-level stream_seq when both the message and the
+/// snapshot watermark carry one (> 0); otherwise it falls back to the legacy
+/// engine event sequence, which is not reliably monotonic across snapshots.
 pub struct FilteredEventReceiver {
     inner: broadcast::Receiver<GameEventMessage>,
-    // sender: Arc<broadcast::Sender<GameEventMessage>>,
     min_sequence: u64,
+    min_stream_seq: u64,
     game_id: u32,
 }
 
@@ -33,47 +43,67 @@ impl FilteredEventReceiver {
     /// Create a new FilteredEventReceiver
     pub fn new(
         inner: broadcast::Receiver<GameEventMessage>,
-        sender: Arc<broadcast::Sender<GameEventMessage>>,
         min_sequence: u64,
+        min_stream_seq: u64,
         game_id: u32,
     ) -> Self {
         Self {
             inner,
-            // sender,
             min_sequence,
+            min_stream_seq,
             game_id,
         }
     }
 
-    /// Receive the next event that passes the filter
+    /// Receive the next event that passes the filter.
+    ///
+    /// `Err(Lagged(n))` is surfaced to the caller instead of being silently
+    /// swallowed: a lagged receiver has lost events, and the caller must
+    /// resync its downstream consumer (e.g. send a fresh snapshot). The
+    /// receiver stays usable afterwards and continues from the oldest
+    /// retained message.
     pub async fn recv(&mut self) -> Result<GameEventMessage, broadcast::error::RecvError> {
         loop {
-            let event = match self.inner.recv().await {
-                Ok(event) => event,
-                Err(broadcast::error::RecvError::Lagged(skipped)) => {
-                    warn!(
-                        "Broadcast receiver for game {} lagged and skipped {} messages - receiver too slow!",
-                        self.game_id, skipped
-                    );
-                    continue;
-                }
-                Err(e) => return Err(e),
-            };
+            let event = self.inner.recv().await?;
 
-            // Only forward events after our snapshot sequence
-            if event.sequence > self.min_sequence {
+            // Snapshots re-anchor the stream unconditionally. A restarted
+            // executor (failover/resume) begins a NEW stream_seq sequence
+            // starting near 1; filtering its snapshot as "stale" against the
+            // old stream's high watermark would wedge this subscriber — and
+            // its client — forever. Forward the snapshot and adopt its
+            // stream as the new baseline (mirrors the client engine, which
+            // also resets its watermark on every snapshot).
+            if matches!(event.event, GameEvent::Snapshot { .. }) {
+                self.min_stream_seq = event.stream_seq;
+                self.min_sequence = event.sequence;
                 debug!(
-                    "Forwarding event for game {} with sequence {} (min_sequence: {})",
-                    self.game_id, event.sequence, self.min_sequence
+                    "Forwarding snapshot for game {} and re-anchoring stream (stream_seq {})",
+                    self.game_id, event.stream_seq
                 );
                 return Ok(event);
-            } else {
-                debug!(
-                    "Filtering out stale event for game {} with sequence {} (min_sequence: {})",
-                    self.game_id, event.sequence, self.min_sequence
-                );
-                // Continue to next event
             }
+
+            let is_fresh = if event.stream_seq > 0 && self.min_stream_seq > 0 {
+                event.stream_seq > self.min_stream_seq
+            } else {
+                event.sequence > self.min_sequence
+            };
+
+            if is_fresh {
+                debug!(
+                    "Forwarding event for game {} (sequence {}, stream_seq {})",
+                    self.game_id, event.sequence, event.stream_seq
+                );
+                return Ok(event);
+            }
+            debug!(
+                "Filtering out stale event for game {} (sequence {} <= {}, stream_seq {} <= {})",
+                self.game_id,
+                event.sequence,
+                self.min_sequence,
+                event.stream_seq,
+                self.min_stream_seq
+            );
         }
     }
 }
@@ -84,8 +114,12 @@ pub struct PartitionReplica {
     pubsub: Arc<Mutex<PubSubManager>>,
     game_states: GameStateStore,
     game_event_broadcasters: GameEventBroadcasters,
+    game_stream_seqs: GameStreamSeqs,
     status: Arc<RwLock<ReplicationStatus>>,
     cancellation_token: CancellationToken,
+    /// Wall-clock ms of the last gap-triggered snapshot request, for
+    /// rate-limiting self-heal requests under sustained loss.
+    last_gap_request_ms: std::sync::atomic::AtomicI64,
 }
 
 impl PartitionReplica {
@@ -94,6 +128,7 @@ impl PartitionReplica {
         pubsub: Arc<Mutex<PubSubManager>>,
         game_states: GameStateStore,
         game_event_broadcasters: GameEventBroadcasters,
+        game_stream_seqs: GameStreamSeqs,
         cancellation_token: CancellationToken,
     ) -> Self {
         let status = Arc::new(RwLock::new(ReplicationStatus {
@@ -106,8 +141,10 @@ impl PartitionReplica {
             pubsub,
             game_states,
             game_event_broadcasters,
+            game_stream_seqs,
             status,
             cancellation_token,
+            last_gap_request_ms: std::sync::atomic::AtomicI64::new(0),
         }
     }
 
@@ -125,6 +162,10 @@ impl PartitionReplica {
             let mut broadcasters = self.game_event_broadcasters.write().await;
             broadcasters.remove(&game_id);
         }
+        {
+            let mut seqs = self.game_stream_seqs.write().await;
+            seqs.remove(&game_id);
+        }
         info!(
             "Game {} durably completed; evicted from replication cache and dropped broadcasters",
             game_id
@@ -139,11 +180,44 @@ impl PartitionReplica {
             game_id, self.partition_id
         );
 
+        // Transport-integrity check. Redis pub/sub is at-most-once: a gap in
+        // stream_seq means this replica lost messages and its state can no
+        // longer be trusted, so ask the executor for fresh snapshots. Stale
+        // or duplicate messages are dropped instead of double-applied.
+        let is_snapshot = matches!(&event_msg.event, GameEvent::Snapshot { .. });
+        if event_msg.stream_seq > 0 {
+            let last = {
+                let seqs = self.game_stream_seqs.read().await;
+                seqs.get(&game_id).copied().unwrap_or(0)
+            };
+            if !is_snapshot && last > 0 {
+                if event_msg.stream_seq <= last {
+                    debug!(
+                        "Replica for partition {} dropping stale message for game {} (stream_seq {} <= {})",
+                        self.partition_id, game_id, event_msg.stream_seq, last
+                    );
+                    return Ok(());
+                }
+                if event_msg.stream_seq > last + 1 {
+                    warn!(
+                        "Replica for partition {} detected stream gap for game {}: expected {}, got {} ({} messages lost); requesting snapshots",
+                        self.partition_id,
+                        game_id,
+                        last + 1,
+                        event_msg.stream_seq,
+                        event_msg.stream_seq - last - 1
+                    );
+                    self.request_snapshots_rate_limited().await;
+                }
+            }
+        }
+
+
         match &event_msg.event {
             GameEvent::Snapshot { game_state } => {
                 info!(
-                    "Received snapshot for game {} at tick {}",
-                    game_id, event_msg.tick
+                    "Received snapshot for game {} at tick {} (stream_seq {})",
+                    game_id, event_msg.tick, event_msg.stream_seq
                 );
                 // Always update with the latest snapshot
                 let mut states = self.game_states.write().await;
@@ -152,10 +226,15 @@ impl PartitionReplica {
             _ => {
                 let mut states = self.game_states.write().await;
                 if let Some(game_state) = states.get_mut(&game_id) {
-                    // Tick forward until we reach the event's tick
-                    if event_msg.tick > game_state.tick {
+                    // Tick forward until we reach the event's tick. This must
+                    // loop: events can arrive more than one tick apart (quiet
+                    // stretches emit nothing), and catching up a single tick
+                    // per event leaves the replica permanently behind —
+                    // corrupting every join snapshot served from it.
+                    while game_state.tick < event_msg.tick {
                         if let Err(e) = game_state.tick_forward(true) {
                             error!("Error during tick_forward: {:?}", e);
+                            break;
                         }
                     }
 
@@ -169,6 +248,14 @@ impl PartitionReplica {
                     warn!("Received event for unknown game {}", game_id);
                 }
             }
+        }
+
+        // Record the watermark AFTER the state update so a concurrent
+        // subscribe_to_game (which reads watermark first, then state) can
+        // only over-deliver, never under-deliver.
+        if event_msg.stream_seq > 0 {
+            let mut seqs = self.game_stream_seqs.write().await;
+            seqs.insert(game_id, event_msg.stream_seq);
         }
 
         // Broadcast the event to any local subscribers
@@ -192,7 +279,33 @@ impl PartitionReplica {
             }
         }
 
+
         Ok(())
+    }
+
+    /// Ask the executor to republish snapshots for this partition, at most
+    /// once per second, so sustained loss doesn't turn into a request storm.
+    async fn request_snapshots_rate_limited(&self) {
+        use std::sync::atomic::Ordering;
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let last = self.last_gap_request_ms.load(Ordering::Relaxed);
+        if now_ms - last < 1000 {
+            return;
+        }
+        if self
+            .last_gap_request_ms
+            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
+            .is_err()
+        {
+            return; // Another task just requested.
+        }
+        let mut pubsub = self.pubsub.lock().await;
+        if let Err(e) = pubsub.request_partition_snapshots(self.partition_id).await {
+            error!(
+                "Failed to request snapshots for partition {} after stream gap: {}",
+                self.partition_id, e
+            );
+        }
     }
 
     /// Run the replication worker
@@ -301,6 +414,7 @@ pub struct ReplicationManager {
     workers: Vec<tokio::task::JoinHandle<Result<()>>>,
     game_states: GameStateStore,
     game_event_broadcasters: GameEventBroadcasters,
+    game_stream_seqs: GameStreamSeqs,
     statuses: Arc<RwLock<HashMap<u32, Arc<RwLock<ReplicationStatus>>>>>,
     pubsub: Arc<Mutex<PubSubManager>>,
 }
@@ -349,39 +463,55 @@ impl ReplicationManager {
         pubsub.get_stored_snapshot(game_id).await
     }
 
-    /// Subscribe to game events for a specific game
-    /// Returns the current game state as a snapshot and a receiver for subsequent events
+    /// Subscribe to game events for a specific game.
+    /// Returns the current game state, its transport watermark (the
+    /// stream_seq already reflected in that state — stamp it onto snapshots
+    /// derived from the state), and a receiver for subsequent events.
+    ///
+    /// Ordering matters: the broadcast subscription is created BEFORE the
+    /// state is read. A broadcast receiver only sees messages sent after
+    /// `subscribe()`, so subscribing first guarantees no event between
+    /// snapshot and subscription can be missed; events already contained in
+    /// the snapshot are dropped by the stream_seq filter instead.
     pub async fn subscribe_to_game(
         &self,
         game_id: u32,
-    ) -> Result<(GameState, FilteredEventReceiver)> {
-        // Get state from memory or fail
+    ) -> Result<(GameState, u64, FilteredEventReceiver)> {
+        let receiver = {
+            let mut broadcasters = self.game_event_broadcasters.write().await;
+            broadcasters
+                .entry(game_id)
+                .or_insert_with(|| {
+                    let (tx, _) = broadcast::channel(1028);
+                    tx
+                })
+                .subscribe()
+        };
+
+        // Watermark is read BEFORE the state (separate locks): if an event
+        // lands in between, the filter under-estimates and re-delivers an
+        // event already in the state — harmless, receivers skip stale
+        // stream_seqs. The reverse order could silently drop an event.
+        let watermark = self.get_stream_seq(game_id).await;
         let game_state = self
             .get_game_state(game_id)
             .await
             .context("Game not available in replication manager")?;
 
-        // Get or create broadcast channel for this game. Acquires lock.
-        {
-            let mut broadcasters = self.game_event_broadcasters.write().await;
-            let sender = broadcasters.entry(game_id).or_insert_with(|| {
-                let (tx, _) = broadcast::channel(1028);
-                tx
-            });
+        let filtered_receiver = FilteredEventReceiver {
+            inner: receiver,
+            min_sequence: game_state.event_sequence,
+            min_stream_seq: watermark,
+            game_id,
+        };
 
-            let receiver = sender.subscribe();
+        Ok((game_state, watermark, filtered_receiver))
+    }
 
-            // Create filtered receiver
-            let snapshot_sequence = game_state.event_sequence;
-            let filtered_receiver = FilteredEventReceiver {
-                inner: receiver,
-                // sender: sender.clone(),
-                min_sequence: snapshot_sequence,
-                game_id,
-            };
-
-            Ok((game_state, filtered_receiver))
-        }
+    /// Last transport stream_seq applied to the replica state of a game.
+    pub async fn get_stream_seq(&self, game_id: u32) -> u64 {
+        let seqs = self.game_stream_seqs.read().await;
+        seqs.get(&game_id).copied().unwrap_or(0)
     }
 
     /// Get a game state, always ready with PubSub
@@ -441,6 +571,7 @@ impl ReplicationManager {
     ) -> Result<Self> {
         let game_states = Arc::new(RwLock::new(HashMap::new()));
         let game_event_broadcasters = Arc::new(RwLock::new(HashMap::new()));
+        let game_stream_seqs: GameStreamSeqs = Arc::new(RwLock::new(HashMap::new()));
         let statuses = Arc::new(RwLock::new(HashMap::new()));
         let mut workers = Vec::new();
 
@@ -464,6 +595,7 @@ impl ReplicationManager {
                 pubsub.clone(),
                 game_states.clone(),
                 game_event_broadcasters.clone(),
+                game_stream_seqs.clone(),
                 cancellation_token.clone(),
             );
 
@@ -482,6 +614,7 @@ impl ReplicationManager {
             workers,
             game_states,
             game_event_broadcasters,
+            game_stream_seqs,
             statuses,
             pubsub,
         })
@@ -514,5 +647,93 @@ impl ReplicationManager {
             worker.await??;
         }
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FilteredEventReceiver;
+    use common::{GameEvent, GameEventMessage, GameState, GameType, QueueMode};
+    use tokio::sync::broadcast;
+
+    fn event(sequence: u64, stream_seq: u64) -> GameEventMessage {
+        GameEventMessage {
+            game_id: 1,
+            tick: 1,
+            sequence,
+            stream_seq,
+            user_id: None,
+            event: GameEvent::TickHash {
+                hash: 0,
+                server_ts_ms: 0,
+            },
+        }
+    }
+
+    fn snapshot(sequence: u64, stream_seq: u64) -> GameEventMessage {
+        let state = GameState::new(
+            10,
+            10,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            None,
+            0,
+        );
+        GameEventMessage {
+            game_id: 1,
+            tick: 1,
+            sequence,
+            stream_seq,
+            user_id: None,
+            event: GameEvent::Snapshot { game_state: state },
+        }
+    }
+
+    #[tokio::test]
+    async fn filter_drops_stale_and_passes_fresh_by_stream_seq() {
+        let (tx, rx) = broadcast::channel(16);
+        let mut filtered = FilteredEventReceiver::new(rx, 0, 500, 1);
+
+        tx.send(event(0, 400)).unwrap(); // stale: absorbed by the snapshot
+        tx.send(event(0, 501)).unwrap(); // fresh
+        let got = filtered.recv().await.unwrap();
+        assert_eq!(got.stream_seq, 501);
+    }
+
+    #[tokio::test]
+    async fn snapshot_re_anchors_stream_after_executor_restart() {
+        // Subscriber anchored to the OLD executor's stream at watermark 500.
+        let (tx, rx) = broadcast::channel(16);
+        let mut filtered = FilteredEventReceiver::new(rx, 0, 500, 1);
+
+        // A restarted executor begins a new stream: snapshot at stream_seq 2,
+        // then ordinary events 3, 4. Without re-anchoring, ALL of these would
+        // be filtered as stale (< 500) and the client would be wedged.
+        tx.send(snapshot(7, 2)).unwrap();
+        tx.send(event(8, 3)).unwrap();
+        tx.send(event(8, 2)).unwrap(); // duplicate/stale vs the new anchor
+        tx.send(event(9, 4)).unwrap();
+
+        let got = filtered.recv().await.unwrap();
+        assert!(matches!(got.event, GameEvent::Snapshot { .. }));
+        assert_eq!(got.stream_seq, 2);
+
+        let got = filtered.recv().await.unwrap();
+        assert_eq!(got.stream_seq, 3);
+
+        // The stale seq-2 event is skipped; next delivered is 4.
+        let got = filtered.recv().await.unwrap();
+        assert_eq!(got.stream_seq, 4);
+    }
+
+    #[tokio::test]
+    async fn legacy_messages_without_stream_seq_filter_by_engine_sequence() {
+        let (tx, rx) = broadcast::channel(16);
+        let mut filtered = FilteredEventReceiver::new(rx, 10, 0, 1);
+
+        tx.send(event(9, 0)).unwrap(); // stale by engine sequence
+        tx.send(event(11, 0)).unwrap(); // fresh
+        let got = filtered.recv().await.unwrap();
+        assert_eq!(got.sequence, 11);
     }
 }

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -1,3 +1,4 @@
+use crate::game_bus::{BusKind, GameBus};
 use crate::game_executor::{PARTITION_COUNT, StreamEvent};
 use crate::pubsub_manager::{PartitionSubscription, PubSubManager};
 use anyhow::{Context, Result};
@@ -111,7 +112,7 @@ impl FilteredEventReceiver {
 /// PartitionReplica subscribes to partition events via PubSub and maintains game states
 pub struct PartitionReplica {
     partition_id: u32,
-    pubsub: Arc<Mutex<PubSubManager>>,
+    bus: Arc<GameBus>,
     game_states: GameStateStore,
     game_event_broadcasters: GameEventBroadcasters,
     game_stream_seqs: GameStreamSeqs,
@@ -125,7 +126,7 @@ pub struct PartitionReplica {
 impl PartitionReplica {
     pub fn new(
         partition_id: u32,
-        pubsub: Arc<Mutex<PubSubManager>>,
+        bus: Arc<GameBus>,
         game_states: GameStateStore,
         game_event_broadcasters: GameEventBroadcasters,
         game_stream_seqs: GameStreamSeqs,
@@ -138,7 +139,7 @@ impl PartitionReplica {
 
         Self {
             partition_id,
-            pubsub,
+            bus,
             game_states,
             game_event_broadcasters,
             game_stream_seqs,
@@ -212,7 +213,6 @@ impl PartitionReplica {
             }
         }
 
-
         match &event_msg.event {
             GameEvent::Snapshot { game_state } => {
                 info!(
@@ -279,7 +279,6 @@ impl PartitionReplica {
             }
         }
 
-
         Ok(())
     }
 
@@ -299,8 +298,11 @@ impl PartitionReplica {
         {
             return; // Another task just requested.
         }
-        let mut pubsub = self.pubsub.lock().await;
-        if let Err(e) = pubsub.request_partition_snapshots(self.partition_id).await {
+        if let Err(e) = self
+            .bus
+            .request_partition_snapshots(self.partition_id)
+            .await
+        {
             error!(
                 "Failed to request snapshots for partition {} after stream gap: {}",
                 self.partition_id, e
@@ -316,14 +318,12 @@ impl PartitionReplica {
         );
 
         // Subscribe to the partition
-        let mut pubsub = self.pubsub.lock().await;
-        let subscription = pubsub.subscribe_to_partition(self.partition_id).await?;
+        let subscription = self.bus.subscribe_to_partition(self.partition_id).await?;
 
         // Request initial snapshots for this partition
-        pubsub
+        self.bus
             .request_partition_snapshots(self.partition_id)
             .await?;
-        drop(pubsub); // Release lock
 
         // Destructure subscription so each receiver can be borrowed independently in select!
         let PartitionSubscription {
@@ -416,7 +416,7 @@ pub struct ReplicationManager {
     game_event_broadcasters: GameEventBroadcasters,
     game_stream_seqs: GameStreamSeqs,
     statuses: Arc<RwLock<HashMap<u32, Arc<RwLock<ReplicationStatus>>>>>,
-    pubsub: Arc<Mutex<PubSubManager>>,
+    bus: Arc<GameBus>,
 }
 
 /// API for querying replicated game states
@@ -459,8 +459,7 @@ impl ReplicationManager {
     /// while their final snapshot remains in Redis for a short grace period. Callers can use
     /// this method before falling back to durable storage.
     pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
-        let mut pubsub = self.pubsub.lock().await;
-        pubsub.get_stored_snapshot(game_id).await
+        self.bus.get_stored_snapshot(game_id).await
     }
 
     /// Subscribe to game events for a specific game.
@@ -568,6 +567,7 @@ impl ReplicationManager {
         partitions: Vec<u32>,
         cancellation_token: CancellationToken,
         redis_url: &str,
+        bus_kind: BusKind,
     ) -> Result<Self> {
         let game_states = Arc::new(RwLock::new(HashMap::new()));
         let game_event_broadcasters = Arc::new(RwLock::new(HashMap::new()));
@@ -575,24 +575,29 @@ impl ReplicationManager {
         let statuses = Arc::new(RwLock::new(HashMap::new()));
         let mut workers = Vec::new();
 
-        // Create Redis client and connection manager
+        // The replication workers get their own Redis connection (and thus
+        // their own push firehose under pubsub), isolated from the main
+        // server's connection.
         let redis_client = redis::Client::open(redis_url)?;
         let (pubsub_tx, _pubsub_rx) = tokio::sync::broadcast::channel(5000);
         let redis =
-            crate::redis_utils::create_connection_manager(redis_client, pubsub_tx.clone()).await?;
+            crate::redis_utils::create_connection_manager(redis_client.clone(), pubsub_tx.clone())
+                .await?;
 
-        // Create PubSub manager
-        let pubsub = Arc::new(Mutex::new(PubSubManager::new(
+        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, cancellation_token.clone());
+        let bus = Arc::new(GameBus::new(
+            bus_kind,
+            pubsub,
             redis,
-            pubsub_tx,
+            redis_client,
             cancellation_token.clone(),
-        )));
+        ));
 
         for partition_id in partitions {
             // Create worker
             let worker = PartitionReplica::new(
                 partition_id,
-                pubsub.clone(),
+                bus.clone(),
                 game_states.clone(),
                 game_event_broadcasters.clone(),
                 game_stream_seqs.clone(),
@@ -616,7 +621,7 @@ impl ReplicationManager {
             game_event_broadcasters,
             game_stream_seqs,
             statuses,
-            pubsub,
+            bus,
         })
     }
 

--- a/server/src/sync_trace.rs
+++ b/server/src/sync_trace.rs
@@ -1,0 +1,337 @@
+//! Server-side flight recorder for game sync traces.
+//!
+//! Wraps `common::trace::TraceWriter` with environment-driven configuration,
+//! file rotation (oldest traces pruned beyond a cap), and hard fault
+//! isolation: recorder failures log, disable the recorder, and never
+//! propagate into the game loop.
+
+use anyhow::{Context, Result, bail};
+use common::trace::{TraceRecord, TraceWriter};
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+use tracing::warn;
+
+pub const DEFAULT_TRACE_DIR: &str = "./traces";
+pub const DEFAULT_TRACE_MAX_FILES: usize = 200;
+
+#[derive(Debug, Clone)]
+pub struct TraceConfig {
+    pub enabled: bool,
+    pub dir: PathBuf,
+    pub max_files: usize,
+}
+
+impl TraceConfig {
+    /// Tracing is enabled by default; `SNAKETRON_TRACE_DISABLE=1` disables it,
+    /// `SNAKETRON_TRACE_DIR` overrides the directory, and
+    /// `SNAKETRON_TRACE_MAX_FILES` caps the number of retained trace files.
+    pub fn from_env() -> Self {
+        let enabled = std::env::var("SNAKETRON_TRACE_DISABLE")
+            .map(|v| v != "1")
+            .unwrap_or(true);
+        let dir =
+            std::env::var("SNAKETRON_TRACE_DIR").unwrap_or_else(|_| DEFAULT_TRACE_DIR.to_string());
+        let max_files = std::env::var("SNAKETRON_TRACE_MAX_FILES")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_TRACE_MAX_FILES);
+        Self {
+            enabled,
+            dir: dir.into(),
+            max_files,
+        }
+    }
+}
+
+fn unix_ts() -> u64 {
+    SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Delete the oldest `.jsonl` files in `dir` until at most `keep` remain.
+/// Sorted by modification time (name as tiebreaker) so freshly written traces
+/// survive.
+fn prune_trace_files(dir: &Path, keep: usize) -> Result<()> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        // Directory not created yet: nothing to prune.
+        Err(_) => return Ok(()),
+    };
+
+    let mut files: Vec<(SystemTime, PathBuf)> = Vec::new();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let modified = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or(SystemTime::UNIX_EPOCH);
+        files.push((modified, path));
+    }
+
+    if files.len() <= keep {
+        return Ok(());
+    }
+
+    files.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    let excess = files.len() - keep;
+    for (_, path) in files.into_iter().take(excess) {
+        std::fs::remove_file(&path)
+            .with_context(|| format!("Failed to prune trace file {:?}", path))?;
+    }
+    Ok(())
+}
+
+/// Flight recorder for a single game. All methods are infallible from the
+/// caller's perspective: any I/O error logs a warning and disables the
+/// recorder for the rest of the game.
+pub struct GameTraceRecorder {
+    writer: Option<TraceWriter>,
+    game_id: u32,
+}
+
+impl GameTraceRecorder {
+    pub fn for_server_game(game_id: u32) -> Self {
+        Self::new(&TraceConfig::from_env(), game_id)
+    }
+
+    pub fn new(config: &TraceConfig, game_id: u32) -> Self {
+        if !config.enabled {
+            return Self {
+                writer: None,
+                game_id,
+            };
+        }
+
+        // Leave room for the file about to be created.
+        if let Err(e) = prune_trace_files(&config.dir, config.max_files.saturating_sub(1)) {
+            warn!("Failed to prune trace files in {:?}: {}", config.dir, e);
+        }
+
+        let path = config
+            .dir
+            .join(format!("game_{}_server_{}.jsonl", game_id, unix_ts()));
+        let writer = match TraceWriter::create(&path) {
+            Ok(writer) => Some(writer),
+            Err(e) => {
+                warn!(
+                    "Failed to create trace file for game {}: {}; tracing disabled for this game",
+                    game_id, e
+                );
+                None
+            }
+        };
+        Self { writer, game_id }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.writer.is_some()
+    }
+
+    pub fn path(&self) -> Option<&Path> {
+        self.writer.as_ref().map(|w| w.path())
+    }
+
+    pub fn record(&mut self, record: &TraceRecord) {
+        if let Some(writer) = self.writer.as_mut() {
+            if let Err(e) = writer.record(record) {
+                warn!(
+                    "Trace write failed for game {}: {}; tracing disabled for this game",
+                    self.game_id, e
+                );
+                self.writer = None;
+            }
+        }
+    }
+
+    pub fn note(&mut self, note: impl Into<String>) {
+        self.record(&TraceRecord::Note {
+            ts_ms: chrono::Utc::now().timestamp_millis(),
+            note: note.into(),
+        });
+    }
+
+    pub fn flush(&mut self) {
+        if let Some(writer) = self.writer.as_mut() {
+            if let Err(e) = writer.flush() {
+                warn!(
+                    "Trace flush failed for game {}: {}; tracing disabled for this game",
+                    self.game_id, e
+                );
+                self.writer = None;
+            }
+        }
+    }
+}
+
+/// Write a client-uploaded trace into the shared trace directory as
+/// `game_<id>_client_<user>_<unix_ts>.jsonl`. Unlike `GameTraceRecorder`,
+/// failures here are surfaced to the caller (the HTTP handler reports them).
+pub fn write_client_trace(
+    config: &TraceConfig,
+    game_id: u32,
+    user_id: u32,
+    records: &[TraceRecord],
+) -> Result<PathBuf> {
+    if !config.enabled {
+        bail!("tracing is disabled (SNAKETRON_TRACE_DISABLE=1)");
+    }
+
+    if let Err(e) = prune_trace_files(&config.dir, config.max_files.saturating_sub(1)) {
+        warn!("Failed to prune trace files in {:?}: {}", config.dir, e);
+    }
+
+    let path = config.dir.join(format!(
+        "game_{}_client_{}_{}.jsonl",
+        game_id,
+        user_id,
+        unix_ts()
+    ));
+    let mut writer = TraceWriter::create(&path)?;
+    for record in records {
+        writer.record(record)?;
+    }
+    writer.flush()?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use common::trace::{TRACE_FORMAT_VERSION, TraceSide, read_trace};
+
+    fn test_dir(name: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "snaketron_sync_trace_{}_{}",
+            name,
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn config(dir: &Path, max_files: usize) -> TraceConfig {
+        TraceConfig {
+            enabled: true,
+            dir: dir.to_path_buf(),
+            max_files,
+        }
+    }
+
+    #[test]
+    fn recorder_writes_readable_trace() {
+        let dir = test_dir("write");
+        let mut recorder = GameTraceRecorder::new(&config(&dir, 10), 42);
+        assert!(recorder.is_enabled());
+
+        recorder.record(&TraceRecord::Meta {
+            version: TRACE_FORMAT_VERSION,
+            side: TraceSide::Server,
+            game_id: 42,
+            session: "1".into(),
+            ts_ms: 100,
+            build: "test".into(),
+            tick_duration_ms: 100,
+        });
+        recorder.note("hello");
+        recorder.flush();
+
+        let path = recorder.path().unwrap().to_path_buf();
+        let records = read_trace(&path).unwrap();
+        assert_eq!(records.len(), 2);
+        assert!(matches!(records[0], TraceRecord::Meta { game_id: 42, .. }));
+        assert!(matches!(&records[1], TraceRecord::Note { note, .. } if note == "hello"));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn disabled_recorder_writes_nothing() {
+        let dir = test_dir("disabled");
+        let mut recorder = GameTraceRecorder::new(
+            &TraceConfig {
+                enabled: false,
+                dir: dir.clone(),
+                max_files: 10,
+            },
+            1,
+        );
+        assert!(!recorder.is_enabled());
+        recorder.note("ignored");
+        recorder.flush();
+
+        let count = std::fs::read_dir(&dir).unwrap().count();
+        assert_eq!(count, 0);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn recorder_prunes_oldest_files() {
+        let dir = test_dir("prune");
+        // Pre-create 5 trace files; creation order gives increasing mtimes
+        // (name is the tiebreaker when the filesystem truncates timestamps).
+        for i in 1..=5 {
+            std::fs::write(dir.join(format!("game_1_server_{}.jsonl", i)), "{}\n").unwrap();
+        }
+
+        let recorder = GameTraceRecorder::new(&config(&dir, 3), 99);
+        assert!(recorder.is_enabled());
+
+        let mut names: Vec<String> = std::fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        names.sort();
+        assert_eq!(names.len(), 3, "expected 3 files, got {:?}", names);
+        // The three oldest pre-existing files are gone; the two newest remain
+        // along with the newly created recorder file.
+        assert!(names.contains(&"game_1_server_4.jsonl".to_string()));
+        assert!(names.contains(&"game_1_server_5.jsonl".to_string()));
+        assert!(names.iter().any(|n| n.starts_with("game_99_server_")));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn client_trace_roundtrip() {
+        let dir = test_dir("client");
+        let records = vec![TraceRecord::Fingerprint {
+            ts_ms: 1,
+            tick: 2,
+            hash: 3,
+        }];
+        let path = write_client_trace(&config(&dir, 10), 7, 8, &records).unwrap();
+        let name = path.file_name().unwrap().to_string_lossy().into_owned();
+        assert!(name.starts_with("game_7_client_8_"));
+
+        let read = read_trace(&path).unwrap();
+        assert_eq!(read.len(), 1);
+        assert!(matches!(read[0], TraceRecord::Fingerprint { hash: 3, .. }));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn client_trace_rejected_when_disabled() {
+        let dir = test_dir("client_disabled");
+        let result = write_client_trace(
+            &TraceConfig {
+                enabled: false,
+                dir: dir.clone(),
+                max_files: 10,
+            },
+            1,
+            2,
+            &[],
+        );
+        assert!(result.is_err());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -1,5 +1,6 @@
 use crate::api::auth::validate_username;
 use crate::db::Database;
+use crate::game_bus::GameBus;
 use crate::game_executor::PARTITION_COUNT;
 use crate::game_executor::StreamEvent;
 use crate::lobby_manager;
@@ -327,6 +328,7 @@ pub async fn handle_websocket(
     redis: ConnectionManager,
     redis_url: String,
     pubsub_manager: Arc<PubSubManager>,
+    game_bus: Arc<GameBus>,
     matchmaking_manager: Arc<Mutex<MatchmakingManager>>,
     replication_manager: Arc<crate::replication::ReplicationManager>,
     cancellation_token: CancellationToken,
@@ -341,6 +343,7 @@ pub async fn handle_websocket(
         db,
         user_cache.clone(),
         pubsub_manager,
+        game_bus,
         matchmaking_manager,
         jwt_verifier,
         cancellation_token,
@@ -362,6 +365,7 @@ async fn handle_websocket_connection(
     db: Arc<dyn Database>,
     user_cache: UserCache,
     pubsub_manager: Arc<PubSubManager>,
+    game_bus: Arc<GameBus>,
     matchmaking_manager: Arc<Mutex<MatchmakingManager>>,
     jwt_verifier: Arc<dyn JwtVerifier>,
     cancellation_token: CancellationToken,
@@ -565,7 +569,7 @@ async fn handle_websocket_connection(
                                         &db,
                                         user_cache.clone(),
                                         &ws_tx,
-                                        &pubsub_manager,
+                                        &game_bus,
                                         &matchmaking_manager,
                                         &replication_manager,
                                         &redis,
@@ -1565,6 +1569,7 @@ async fn send_game_snapshot(
         game_id,
         tick: game_state.tick,
         sequence: game_state.event_sequence,
+        stream_seq: 0, // terminal snapshot; no live stream follows
         user_id: Some(user_id),
         event: GameEvent::Snapshot {
             game_state: game_state.clone(),
@@ -1758,7 +1763,7 @@ async fn process_ws_message(
     db: &Arc<dyn Database>,
     user_cache: UserCache,
     ws_tx: &mpsc::Sender<Message>,
-    pubsub_manager: &Arc<PubSubManager>,
+    game_bus: &Arc<GameBus>,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
     replication_manager: &Arc<crate::replication::ReplicationManager>,
     redis: &ConnectionManager,
@@ -2860,11 +2865,11 @@ async fn process_ws_message(
                             command: command_message,
                         };
 
-                        // Send command via PubSub
-                        match pubsub_manager.publish_command(partition_id, &event).await {
+                        // Send command via the game bus
+                        match game_bus.publish_command(partition_id, &event).await {
                             Ok(_) => {
                                 debug!(
-                                    "Successfully submitted game command via PubSub: {:?}",
+                                    "Successfully submitted game command via the game bus: {:?}",
                                     event
                                 );
                                 Ok(ConnectionState::Authenticated {

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -7,6 +7,7 @@ use crate::lobby_manager::{LeaveLobbyResult, Lobby, LobbyJoinHandle, LobbyMember
 use crate::matchmaking_manager::MatchmakingManager;
 use crate::pubsub_manager::PubSubManager;
 use crate::redis_keys::RedisKeys;
+use crate::replication::GameStateReader;
 use crate::user_cache::UserCache;
 use crate::ws_matchmaking::remove_from_matchmaking_queue;
 use anyhow::{Context, Result, anyhow};
@@ -70,6 +71,12 @@ pub enum WSMessage {
         messages: Vec<GameChatBroadcast>,
     },
     Shutdown,
+    /// Client -> server: the client detected message loss or state divergence
+    /// (stream_seq gap, repeated TickHash mismatch, or a silent feed) and
+    /// needs its event subscription restarted with a fresh snapshot.
+    RequestResync {
+        game_id: u32,
+    },
     Ping {
         client_time: i64,
     },
@@ -383,6 +390,8 @@ async fn handle_websocket_connection(
 
     // Will be used to track Redis stream subscription for game events
     let mut game_event_handle: Option<JoinHandle<()>> = None;
+    // Rate limit for client-initiated resyncs (RequestResync).
+    let mut last_resync_at: Option<tokio::time::Instant> = None;
 
     // Will be used to track lobby update forwarding to the websocket
     let mut lobby_update_handle: Option<JoinHandle<()>> = None;
@@ -490,6 +499,53 @@ async fn handle_websocket_connection(
                         // Process the message
                         if let Message::Text(text) = tungstenite_msg {
                             match serde_json::from_str::<WSMessage>(&text) {
+                                Ok(WSMessage::RequestResync { game_id: resync_game_id }) => {
+                                    // The client detected loss or divergence (stream
+                                    // gap, repeated fingerprint mismatch, or a dead
+                                    // feed). Restart its event forwarder — which
+                                    // sends a fresh watermarked snapshot as its
+                                    // first message — instead of trusting whatever
+                                    // subscription state it had. Rate-limited so a
+                                    // stuck client cannot spam resubscriptions.
+                                    let in_this_game = matches!(
+                                        &state,
+                                        ConnectionState::Authenticated { game_id: Some(g), .. } if *g == resync_game_id
+                                    );
+                                    let now = tokio::time::Instant::now();
+                                    let allowed = last_resync_at
+                                        .map(|t| now.duration_since(t) >= Duration::from_millis(500))
+                                        .unwrap_or(true);
+                                    if in_this_game && allowed {
+                                        last_resync_at = Some(now);
+                                        if let ConnectionState::Authenticated { metadata, .. } = &state {
+                                            info!(
+                                                "Resync requested by user {} for game {}; restarting event subscription",
+                                                metadata.user_id, resync_game_id
+                                            );
+                                            if let Some(handle) = game_event_handle.take() {
+                                                handle.abort();
+                                            }
+                                            let user_id = metadata.user_id as u32;
+                                            let ws_tx_clone = ws_tx.clone();
+                                            let replication_manager_clone = replication_manager.clone();
+                                            let db_clone = db.clone();
+                                            game_event_handle = Some(tokio::spawn(async move {
+                                                subscribe_to_game_events(
+                                                    resync_game_id,
+                                                    user_id,
+                                                    ws_tx_clone,
+                                                    replication_manager_clone,
+                                                    db_clone,
+                                                ).await;
+                                            }));
+                                        }
+                                    } else if !in_this_game {
+                                        debug!(
+                                            "Ignoring resync request for game {} from connection not in that game",
+                                            resync_game_id
+                                        );
+                                    }
+                                }
                                 Ok(ws_message) => {
                                     // Check state before consuming it
                                     let was_in_game = matches!(&state, ConnectionState::Authenticated { game_id: Some(_), .. });
@@ -1223,7 +1279,10 @@ async fn subscribe_to_game_events(
         game_id, user_id
     );
 
-    let (game_state, mut rx) = match replication_manager.subscribe_to_game(game_id).await {
+    let (game_state, stream_watermark, mut rx) = match replication_manager
+        .subscribe_to_game(game_id)
+        .await
+    {
         Ok(result) => result,
         Err(e) => {
             // Durably completed games are eventually evicted from replication memory. Their
@@ -1345,11 +1404,13 @@ async fn subscribe_to_game_events(
         return;
     }
 
-    // Send the snapshot
+    // Send the snapshot, stamped with the replica's transport watermark so
+    // the client's gap detection starts from the right point.
     let snapshot_event = GameEventMessage {
         game_id: game_id,
         tick: game_state.tick,
         sequence: 0,
+        stream_seq: stream_watermark,
         user_id: Some(user_id),
         event: GameEvent::Snapshot {
             game_state: game_state.clone(),
@@ -1381,33 +1442,84 @@ async fn subscribe_to_game_events(
         }
     }
 
-    while let Ok(event_msg) = rx.recv().await {
-        // Check if the game has ended
-        if let GameEvent::StatusUpdated { status } = &event_msg.event {
-            if matches!(status, GameStatus::Complete { .. }) {
-                info!("Game {} completed, stopping event subscription", game_id);
-                // Send the final event before breaking
-                let json = serde_json::to_string(&WSMessage::GameEvent(event_msg)).unwrap();
-                if let Err(e) = ws_tx.try_send(Message::Text(json.into())) {
-                    match e {
-                        mpsc::error::TrySendError::Full(msg) => {
-                            warn!(
-                                "WebSocket send channel full on game complete for game {}, blocking send",
-                                game_id
-                            );
-                            let _ = ws_tx.send(msg).await;
-                        }
-                        mpsc::error::TrySendError::Closed(_) => {
+    loop {
+        let event_msg = match rx.recv().await {
+            Ok(event_msg) => event_msg,
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
+                // This connection fell behind the broadcast and lost events.
+                // Recover by sending a fresh snapshot (with its watermark) so
+                // the client re-anchors instead of silently diverging.
+                warn!(
+                    "Event forwarder for game {} (user {}) lagged, {} events lost; resyncing client with fresh snapshot",
+                    game_id, user_id, skipped
+                );
+                match replication_manager.subscribe_to_game(game_id).await {
+                    Ok((state, watermark, new_rx)) => {
+                        rx = new_rx;
+                        let resync = GameEventMessage {
+                            game_id,
+                            tick: state.tick,
+                            sequence: 0,
+                            stream_seq: watermark,
+                            user_id: Some(user_id),
+                            event: GameEvent::Snapshot { game_state: state },
+                        };
+                        let json = serde_json::to_string(&WSMessage::GameEvent(resync)).unwrap();
+                        if ws_tx.send(Message::Text(json.into())).await.is_err() {
                             debug!(
-                                "WebSocket send channel closed on game complete for game {}",
+                                "WebSocket send channel closed for game {} during lag resync",
                                 game_id
                             );
+                            return;
                         }
+                        continue;
+                    }
+                    Err(e) => {
+                        // Game likely completed and was evicted mid-lag.
+                        error!(
+                            "Failed to resubscribe to game {} after lag: {}; ending subscription",
+                            game_id, e
+                        );
+                        return;
                     }
                 }
-                break;
             }
-        }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                // Broadcaster dropped. If the game is still live in the
+                // replica, hand the client one last authoritative snapshot so
+                // it can at least resync via RequestResync; either way, log
+                // loudly — a silent exit here is how ghost games are born.
+                if let Some(state) = replication_manager.get_game_state(game_id).await {
+                    error!(
+                        "Event broadcaster closed for live game {} (user {}); sending final snapshot",
+                        game_id, user_id
+                    );
+                    let final_snapshot = GameEventMessage {
+                        game_id,
+                        tick: state.tick,
+                        sequence: 0,
+                        stream_seq: replication_manager.get_stream_seq(game_id).await,
+                        user_id: Some(user_id),
+                        event: GameEvent::Snapshot { game_state: state },
+                    };
+                    let json =
+                        serde_json::to_string(&WSMessage::GameEvent(final_snapshot)).unwrap();
+                    let _ = ws_tx.send(Message::Text(json.into())).await;
+                } else {
+                    info!(
+                        "Event broadcaster closed for game {} (game evicted); ending subscription",
+                        game_id
+                    );
+                }
+                return;
+            }
+        };
+
+        // Check if the game has ended
+        let is_final = matches!(
+            &event_msg.event,
+            GameEvent::StatusUpdated { status } if matches!(status, GameStatus::Complete { .. })
+        );
 
         let json = serde_json::to_string(&WSMessage::GameEvent(event_msg)).unwrap();
         let msg = Message::Text(json.into());
@@ -1434,6 +1546,11 @@ async fn subscribe_to_game_events(
                     break;
                 }
             }
+        }
+
+        if is_final {
+            info!("Game {} completed, stopping event subscription", game_id);
+            break;
         }
     }
 }

--- a/server/tests/common/test_environment.rs
+++ b/server/tests/common/test_environment.rs
@@ -50,6 +50,25 @@ impl TestEnvironment {
         }
         info!("Using unique table prefix for test: {}", unique_prefix);
 
+        // Each environment gets a fresh database, so game IDs REPEAT across
+        // tests — but Redis is shared and persistent. Without this flush,
+        // stale game:snapshot:{id} keys (300s TTL), singleton leases from
+        // dead test processes, and stream entries leak into later tests:
+        // joins serve a previous test's snapshot for a reused game ID, and
+        // executor takeover can resume a previous test's synthetic game.
+        // Tests are serialized (TEST_LOCK / --test-threads=1), so flushing
+        // the test database here is safe.
+        let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")
+            .context("Failed to open Redis for test flush")?;
+        let mut redis_conn = redis_client
+            .get_multiplexed_async_connection()
+            .await
+            .context("Failed to connect to Redis for test flush")?;
+        let _: () = redis::cmd("FLUSHDB")
+            .query_async(&mut redis_conn)
+            .await
+            .context("Failed to flush test Redis database")?;
+
         // Create DynamoDB instance for testing
         let db = Arc::new(
             DynamoDatabase::new()

--- a/server/tests/completed_game_snapshot_tests.rs
+++ b/server/tests/completed_game_snapshot_tests.rs
@@ -65,7 +65,7 @@ async fn completed_game_snapshot_round_trips_through_redis() -> Result<()> {
     let expected = completed_game_state();
 
     manager
-        .publish_snapshot(game_id % PARTITION_COUNT, game_id, &expected)
+        .publish_snapshot(game_id % PARTITION_COUNT, game_id, &expected, 0)
         .await?;
 
     let actual = manager

--- a/server/tests/duel_game_test.rs
+++ b/server/tests/duel_game_test.rs
@@ -3,9 +3,45 @@ mod common;
 use crate::common::{TestClient, TestEnvironment};
 use ::common::{GameEvent, GameStatus, GameType, TeamId};
 use anyhow::Result;
-use redis::AsyncCommands;
 use server::ws_server::WSMessage;
 use tokio::time::{Duration, timeout};
+
+/// Wait for a JoinGame message, skipping unrelated messages (e.g. UserCountUpdate).
+async fn wait_for_join_game(client: &mut TestClient, label: &str) -> Result<u32> {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            match client.receive_message().await? {
+                WSMessage::JoinGame(id) => break Ok::<u32, anyhow::Error>(id),
+                other => println!(
+                    "{}: ignoring message while waiting for JoinGame: {:?}",
+                    label, other
+                ),
+            }
+        }
+    })
+    .await?
+}
+
+/// Wait for a GameEvent carrying a Snapshot, skipping unrelated messages.
+async fn wait_for_snapshot(client: &mut TestClient, label: &str) -> Result<WSMessage> {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            let msg = client.receive_message().await?;
+            match &msg {
+                WSMessage::GameEvent(event)
+                    if matches!(event.event, GameEvent::Snapshot { .. }) =>
+                {
+                    break Ok::<WSMessage, anyhow::Error>(msg);
+                }
+                other => println!(
+                    "{}: ignoring message while waiting for snapshot: {:?}",
+                    label, other
+                ),
+            }
+        }
+    })
+    .await?
+}
 
 #[tokio::test]
 async fn test_duel_game() -> Result<()> {
@@ -53,32 +89,16 @@ async fn test_duel_game() -> Result<()> {
 
     println!("Clients queued for duel mode");
 
-    // Wait for JoinGame messages first
-    let join_msg1 = timeout(Duration::from_secs(10), async {
-        client1.receive_message().await
-    })
-    .await??;
+    // Wait for JoinGame messages first, skipping unrelated messages
+    let join_id1 = wait_for_join_game(&mut client1, "Client1").await?;
+    println!("Client1 received JoinGame({})", join_id1);
 
-    println!("Client1 received: {:?}", join_msg1);
-
-    let join_msg2 = timeout(Duration::from_secs(10), async {
-        client2.receive_message().await
-    })
-    .await??;
-
-    println!("Client2 received: {:?}", join_msg2);
+    let join_id2 = wait_for_join_game(&mut client2, "Client2").await?;
+    println!("Client2 received JoinGame({})", join_id2);
 
     // Verify both clients received JoinGame messages for the same game
-    let game_id = match (&join_msg1, &join_msg2) {
-        (WSMessage::JoinGame(id1), WSMessage::JoinGame(id2)) => {
-            assert_eq!(id1, id2, "Both clients should join the same game");
-            *id1
-        }
-        _ => panic!(
-            "Expected JoinGame messages, got {:?} and {:?}",
-            join_msg1, join_msg2
-        ),
-    };
+    assert_eq!(join_id1, join_id2, "Both clients should join the same game");
+    let game_id = join_id1;
 
     println!("Both clients joined game {}", game_id);
 
@@ -88,19 +108,11 @@ async fn test_duel_game() -> Result<()> {
 
     println!("Clients acknowledged join");
 
-    // Now wait for game snapshots after joining
-    let msg1 = timeout(Duration::from_secs(10), async {
-        client1.receive_message().await
-    })
-    .await??;
-
+    // Now wait for game snapshots after joining, skipping unrelated messages
+    let msg1 = wait_for_snapshot(&mut client1, "Client1").await?;
     println!("Client1 received after join: {:?}", msg1);
 
-    let msg2 = timeout(Duration::from_secs(10), async {
-        client2.receive_message().await
-    })
-    .await??;
-
+    let msg2 = wait_for_snapshot(&mut client2, "Client2").await?;
     println!("Client2 received after join: {:?}", msg2);
 
     // Verify both clients received game snapshots and extract game_id and snake_ids
@@ -223,10 +235,13 @@ async fn test_duel_game() -> Result<()> {
                         snake2_head, snake2.team_id
                     );
 
-                    // Verify starting positions in endzones
-                    // One snake should be in left endzone (x=5), one in right endzone (x=35 for 40-width arena)
-                    let expected_left_x = 5;
-                    let expected_right_x = state1.arena.width as i16 - 5;
+                    // Verify starting positions in endzones.
+                    // Snakes spawn one cell inside their endzone boundary, facing the
+                    // goal gate: left head at end_zone_depth - 2, right head at
+                    // width - end_zone_depth + 1 (see calculate_team_starting_positions).
+                    let end_zone_depth = team_config.end_zone_depth as i16;
+                    let expected_left_x = end_zone_depth - 2;
+                    let expected_right_x = state1.arena.width as i16 - end_zone_depth + 1;
 
                     // Check that one snake is in left endzone and one in right
                     let has_left_snake =
@@ -247,7 +262,7 @@ async fn test_duel_game() -> Result<()> {
 
                     // Verify directions match positions
                     // Note: Team assignments alternate - first player gets TeamA, second gets TeamB
-                    // TeamA starts in left endzone (x=5), TeamB starts in right endzone (x=55)
+                    // TeamA (TeamId(0)) starts in the left endzone, TeamB (TeamId(1)) in the right
                     if snake1_head.x == expected_left_x {
                         assert_eq!(
                             snake1.direction,

--- a/server/tests/executor_resume_test.rs
+++ b/server/tests/executor_resume_test.rs
@@ -1,0 +1,111 @@
+//! Executor failover: resuming in-flight games from stored Redis snapshots.
+//!
+//! The pure selection logic (partition/status filtering, replica-over-snapshot
+//! precedence) is unit-tested in game_executor.rs. This test covers the
+//! Redis-facing half against a real Redis (started via test-deps.sh): a game
+//! whose executor died leaves only its periodically refreshed stored snapshot
+//! behind, and a takeover executor must discover it through the same
+//! store/scan path the production code uses.
+//!
+//! Isolation note: this test only writes/reads uniquely numbered
+//! game:snapshot:* keys — it publishes nothing on the shared pub/sub
+//! channels, so it cannot interfere with (or be affected by) a dev server
+//! running against the same Redis.
+
+use anyhow::Result;
+use common::{GameState, GameStatus, GameType, QueueMode};
+use server::game_executor::PARTITION_COUNT;
+use server::pubsub_manager::PubSubManager;
+use tokio::time::{Duration, timeout};
+use tokio_util::sync::CancellationToken;
+
+const REDIS_URL: &str = "redis://127.0.0.1:6379/1?protocol=resp3";
+
+fn unique_game_id(partition: u32) -> u32 {
+    // Unique per run, aligned to the requested partition.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    // Keep well away from small hand-assigned ids; preserve partition residue.
+    let base = 1_000_000 + (nanos % 500_000);
+    base - (base % PARTITION_COUNT) + partition
+}
+
+fn started_state(tick: u32) -> GameState {
+    let mut state = GameState::new(
+        20,
+        20,
+        GameType::TeamMatch { per_team: 1 },
+        QueueMode::Quickmatch,
+        Some(7),
+        0,
+    );
+    state.status = GameStatus::Started { server_id: 42 };
+    state.tick = tick;
+    state
+}
+
+#[tokio::test]
+async fn stored_snapshot_is_discoverable_for_resume() -> Result<()> {
+    timeout(Duration::from_secs(10), async {
+        let redis_client = redis::Client::open(REDIS_URL)?;
+        let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(64);
+        let mut redis =
+            server::redis_utils::create_connection_manager(redis_client, pubsub_tx.clone()).await?;
+
+        let token = CancellationToken::new();
+        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
+
+        let partition = 4;
+        let game_id = unique_game_id(partition);
+        let dead_executor_state = started_state(137);
+
+        // The dying executor's last act: the TickHash-cadence snapshot store.
+        pubsub.store_snapshot(game_id, &dead_executor_state).await?;
+
+        // A takeover executor discovers it through the same scan path
+        // run_game_executor uses, with an empty (cold) replica.
+        let discovered = server::game_executor::load_stored_snapshots(&mut redis).await;
+        let resumable =
+            server::game_executor::select_resumable_games(partition, Vec::new(), discovered);
+
+        let resumed = resumable
+            .iter()
+            .find(|(id, _)| *id == game_id)
+            .unwrap_or_else(|| panic!("game {} not discovered for resume", game_id));
+        assert_eq!(resumed.1.tick, 137, "resume must use the stored state");
+        assert!(matches!(
+            resumed.1.status,
+            GameStatus::Started { server_id: 42 }
+        ));
+
+        // A game whose stored snapshot says Complete must not be resurrected.
+        let complete_id = unique_game_id(partition) + PARTITION_COUNT;
+        let mut complete_state = started_state(200);
+        complete_state.status = GameStatus::Complete {
+            winning_snake_id: None,
+        };
+        pubsub.store_snapshot(complete_id, &complete_state).await?;
+
+        let discovered = server::game_executor::load_stored_snapshots(&mut redis).await;
+        let resumable =
+            server::game_executor::select_resumable_games(partition, Vec::new(), discovered);
+        assert!(
+            !resumable.iter().any(|(id, _)| *id == complete_id),
+            "completed game must not be selected for resume"
+        );
+
+        // Clean up our keys.
+        use redis::AsyncCommands;
+        let _: () = redis
+            .del(server::redis_keys::RedisKeys::game_snapshot(game_id))
+            .await?;
+        let _: () = redis
+            .del(server::redis_keys::RedisKeys::game_snapshot(complete_id))
+            .await?;
+
+        Ok(())
+    })
+    .await?
+}

--- a/server/tests/game_bus_test.rs
+++ b/server/tests/game_bus_test.rs
@@ -1,0 +1,391 @@
+//! Integration tests for the Streams game-bus transport (SNAKETRON_BUS=streams).
+//!
+//! Run against the test-deps Redis (test-deps.sh). Isolation: these tests use
+//! partition ids far outside the live range (game partitions are 0..10) so
+//! their stream keys cannot collide with a dev server or other tests sharing
+//! the same Redis.
+//!
+//! The headline test is `paused_consumer_loses_nothing`: the exact scenario —
+//! a subscriber that stops draining for a while — where Pub/Sub drops
+//! messages (broadcast lag / at-most-once) and Streams must not.
+
+use anyhow::Result;
+use common::{GameEvent, GameEventMessage};
+use server::game_bus::{BusKind, GameBus};
+use server::game_executor::StreamEvent;
+use server::pubsub_manager::PubSubManager;
+use server::redis_keys::RedisKeys;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+const REDIS_URL: &str = "redis://127.0.0.1:6379/1?protocol=resp3";
+
+/// Unique high partition id per test run, far above the live range 0..10.
+fn test_partition(salt: u32) -> u32 {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .subsec_nanos();
+    1_000_000 + (nanos % 100_000) + salt * 1_000_000
+}
+
+async fn streams_bus(token: CancellationToken) -> Result<GameBus> {
+    let client = redis::Client::open(REDIS_URL)?;
+    let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(64);
+    let redis =
+        server::redis_utils::create_connection_manager(client.clone(), pubsub_tx.clone()).await?;
+    let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
+    Ok(GameBus::new(BusKind::Streams, pubsub, redis, client, token))
+}
+
+fn event(game_id: u32, stream_seq: u64) -> GameEventMessage {
+    GameEventMessage {
+        game_id,
+        tick: stream_seq as u32,
+        sequence: stream_seq,
+        stream_seq,
+        user_id: None,
+        event: GameEvent::TickHash {
+            hash: stream_seq,
+            server_ts_ms: 0,
+        },
+    }
+}
+
+async fn cleanup(partition: u32) {
+    if let Ok(client) = redis::Client::open(REDIS_URL) {
+        if let Ok(mut conn) = client.get_multiplexed_async_connection().await {
+            use redis::AsyncCommands;
+            let _: std::result::Result<(), _> = conn
+                .del::<_, ()>(&[
+                    RedisKeys::stream_events(partition),
+                    RedisKeys::stream_commands(partition),
+                    RedisKeys::stream_snapshot_requests(partition),
+                ])
+                .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn paused_consumer_loses_nothing() -> Result<()> {
+    timeout(Duration::from_secs(10), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(1);
+        let game_id = partition;
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+        // Give the reader task a moment to issue its first XREAD ("$").
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Publish MORE messages than the subscriber channel holds (2000)
+        // while the consumer is completely paused. Under Pub/Sub this
+        // overflows and drops; under Streams the reader backpressure-blocks
+        // and the log holds the rest (3000 < the 8192 trim bound).
+        const TOTAL: u64 = 3000;
+        for seq in 1..=TOTAL {
+            bus.publish_event(partition, &event(game_id, seq)).await?;
+        }
+
+        // Resume consuming: every message must arrive, in order.
+        for expected in 1..=TOTAL {
+            let msg = sub
+                .recv_event()
+                .await
+                .expect("stream ended before all messages were delivered");
+            assert_eq!(
+                msg.stream_seq, expected,
+                "expected contiguous stream_seq {} but got {} — a streams transport must never lose or reorder",
+                expected, msg.stream_seq
+            );
+        }
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+#[tokio::test]
+async fn three_streams_route_to_their_channels_in_order() -> Result<()> {
+    timeout(Duration::from_secs(10), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(2);
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        for seq in 1..=5u64 {
+            bus.publish_event(partition, &event(partition, seq)).await?;
+            bus.publish_command(
+                partition,
+                &StreamEvent::StatusUpdated {
+                    game_id: seq as u32,
+                    status: common::GameStatus::Stopped,
+                },
+            )
+            .await?;
+        }
+        bus.request_partition_snapshots(partition).await?;
+
+        for expected in 1..=5u64 {
+            let msg = sub.recv_event().await.expect("event stream ended");
+            assert_eq!(msg.stream_seq, expected);
+        }
+        for expected in 1..=5u32 {
+            let cmd = sub.recv_command().await.expect("command stream ended");
+            match cmd {
+                StreamEvent::StatusUpdated { game_id, .. } => assert_eq!(game_id, expected),
+                other => panic!("unexpected command: {:?}", other),
+            }
+        }
+        let req = sub
+            .recv_snapshot_request()
+            .await
+            .expect("request stream ended");
+        assert_eq!(req.partition_id, partition);
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+#[tokio::test]
+async fn subscription_starts_at_now_not_history() -> Result<()> {
+    timeout(Duration::from_secs(10), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(3);
+
+        // History that must NOT be delivered: subscriptions anchor on
+        // snapshots (like the pubsub transport), not on stream history.
+        for seq in 1..=50u64 {
+            bus.publish_event(partition, &event(partition, seq)).await?;
+        }
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        bus.publish_event(partition, &event(partition, 100)).await?;
+        let msg = sub.recv_event().await.expect("event stream ended");
+        assert_eq!(
+            msg.stream_seq, 100,
+            "a new subscription must start at the tail, got historical seq {}",
+            msg.stream_seq
+        );
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+#[tokio::test]
+async fn streams_are_trimmed_at_publish_time() -> Result<()> {
+    timeout(Duration::from_secs(30), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(4);
+
+        // Publish past the events MAXLEN (8192). `MAXLEN ~` trims at node
+        // granularity, so allow slack above the bound — the point is that
+        // length is bounded, not unbounded like the 2025 implementation.
+        for seq in 1..=9500u64 {
+            bus.publish_event(partition, &event(partition, seq)).await?;
+        }
+
+        let client = redis::Client::open(REDIS_URL)?;
+        let mut conn = client.get_multiplexed_async_connection().await?;
+        use redis::AsyncCommands;
+        let len: u64 = conn.xlen(RedisKeys::stream_events(partition)).await?;
+        assert!(
+            len < 9200,
+            "stream length {} suggests MAXLEN trimming is not applied",
+            len
+        );
+        assert!(len >= 8000, "stream over-trimmed: {}", len);
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+/// The performance gate: end-to-end XADD -> subscriber delivery latency at
+/// game-like rates. The 2025 Streams implementation measured 100-900 ms here
+/// because blocking reads were multiplexed onto shared connections; the
+/// current design must be push-like. Thresholds are generous for CI noise
+/// while still catching any reintroduction of poll-quantized delivery.
+#[tokio::test]
+async fn delivery_latency_is_push_like() -> Result<()> {
+    timeout(Duration::from_secs(60), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(5);
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        // Game-like cadence: bursts of 4 events every 50 ms (executor poll
+        // interval), 100 rounds = 400 samples over ~5 s.
+        let mut latencies_us: Vec<u128> = Vec::with_capacity(400);
+        for round in 0..100u64 {
+            let sent = Instant::now();
+            for i in 0..4u64 {
+                bus.publish_event(partition, &event(partition, round * 4 + i + 1))
+                    .await?;
+            }
+            for _ in 0..4 {
+                sub.recv_event().await.expect("event stream ended");
+            }
+            latencies_us.push(sent.elapsed().as_micros() / 4);
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        latencies_us.sort_unstable();
+        let p50 = latencies_us[latencies_us.len() / 2];
+        let p99 = latencies_us[latencies_us.len() * 99 / 100];
+        println!(
+            "streams delivery latency: p50={}us p99={}us (n={})",
+            p50,
+            p99,
+            latencies_us.len()
+        );
+
+        assert!(
+            p50 < 10_000,
+            "p50 delivery latency {}us — streams should be push-like (<10ms)",
+            p50
+        );
+        assert!(
+            p99 < 50_000,
+            "p99 delivery latency {}us — smells like poll-quantized or blocked-connection delivery",
+            p99
+        );
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+/// Kill the reader's dedicated connection mid-stream and verify it resumes
+/// from its last-delivered ID with no loss and no duplicates — the property
+/// Pub/Sub fundamentally cannot provide across a reconnect.
+#[tokio::test]
+async fn reader_reconnect_resumes_without_loss_or_duplicates() -> Result<()> {
+    timeout(Duration::from_secs(15), async {
+        let token = CancellationToken::new();
+        let bus = streams_bus(token.clone()).await?;
+        let partition = test_partition(7);
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+
+        for seq in 1..=100u64 {
+            bus.publish_event(partition, &event(partition, seq)).await?;
+        }
+        for expected in 1..=50u64 {
+            let msg = sub.recv_event().await.expect("stream ended");
+            assert_eq!(msg.stream_seq, expected);
+        }
+
+        // Sever every parked XREAD connection on this Redis. Readers are
+        // designed to reconnect and resume from their last-delivered ID, so
+        // even collateral kills of other tests' readers are harmless.
+        let client = redis::Client::open(REDIS_URL)?;
+        let mut admin = client.get_multiplexed_async_connection().await?;
+        let list: String = redis::cmd("CLIENT")
+            .arg("LIST")
+            .query_async(&mut admin)
+            .await?;
+        let mut killed = 0;
+        for line in list.lines() {
+            if line.contains("cmd=xread") {
+                if let Some(id) = line.split_whitespace().find_map(|f| f.strip_prefix("id=")) {
+                    let _: i64 = redis::cmd("CLIENT")
+                        .arg("KILL")
+                        .arg("ID")
+                        .arg(id)
+                        .query_async(&mut admin)
+                        .await?;
+                    killed += 1;
+                }
+            }
+        }
+        assert!(
+            killed > 0,
+            "expected to kill at least the reader's parked XREAD"
+        );
+
+        for seq in 101..=200u64 {
+            bus.publish_event(partition, &event(partition, seq)).await?;
+        }
+
+        // Everything from 51 onward must arrive exactly once, in order,
+        // across the reconnect boundary.
+        for expected in 51..=200u64 {
+            let msg = sub.recv_event().await.expect("stream ended after kill");
+            assert_eq!(
+                msg.stream_seq, expected,
+                "reconnect must resume from the last-delivered ID: expected {}, got {}",
+                expected, msg.stream_seq
+            );
+        }
+
+        token.cancel();
+        cleanup(partition).await;
+        Ok(())
+    })
+    .await?
+}
+
+/// Manual A/B benchmark across both transports; ignored in normal runs.
+/// cargo test -p server --test game_bus_test bench_both -- --ignored --nocapture
+#[tokio::test]
+#[ignore]
+async fn bench_both_transports() -> Result<()> {
+    for kind in [BusKind::PubSub, BusKind::Streams] {
+        let token = CancellationToken::new();
+        let client = redis::Client::open(REDIS_URL)?;
+        let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(5000);
+        let redis =
+            server::redis_utils::create_connection_manager(client.clone(), pubsub_tx.clone())
+                .await?;
+        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
+        let bus = GameBus::new(kind, pubsub, redis, client, token.clone());
+        let partition = test_partition(6);
+
+        let mut sub = bus.subscribe_to_partition(partition).await?;
+        tokio::time::sleep(Duration::from_millis(300)).await;
+
+        let mut latencies_us: Vec<u128> = Vec::new();
+        for round in 0..200u64 {
+            let sent = Instant::now();
+            bus.publish_event(partition, &event(partition, round + 1))
+                .await?;
+            sub.recv_event().await.expect("stream ended");
+            latencies_us.push(sent.elapsed().as_micros());
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+        latencies_us.sort_unstable();
+        println!(
+            "{:?}: p50={}us p90={}us p99={}us",
+            kind,
+            latencies_us[latencies_us.len() / 2],
+            latencies_us[latencies_us.len() * 90 / 100],
+            latencies_us[latencies_us.len() * 99 / 100],
+        );
+        token.cancel();
+        cleanup(partition).await;
+    }
+    Ok(())
+}

--- a/server/tests/game_load_failure_tests.rs
+++ b/server/tests/game_load_failure_tests.rs
@@ -2,6 +2,7 @@ use ::common::{GameEvent, GameState, GameStatus, GameType, QueueMode};
 use anyhow::{Context, Result};
 use redis::AsyncCommands;
 use server::db::DURABLE_GAME_ID_FLOOR;
+use server::game_bus::{BusKind, GameBus};
 use server::game_executor::{PARTITION_COUNT, StreamEvent, run_game_executor};
 use server::matchmaking_manager::MatchmakingManager;
 use server::pubsub_manager::PubSubManager;
@@ -245,7 +246,18 @@ async fn live_game_join_is_authorized_before_enabling_game_chat() -> Result<()> 
     let (push_tx, _) = broadcast::channel(16);
     let publisher_connection =
         create_connection_manager(redis_client.clone(), push_tx.clone()).await?;
-    let publisher = PubSubManager::new(publisher_connection, push_tx, CancellationToken::new());
+    // Publish on the same transport the test server's replicas subscribe to.
+    let publisher = GameBus::new(
+        BusKind::from_env(),
+        PubSubManager::new(
+            publisher_connection.clone(),
+            push_tx,
+            CancellationToken::new(),
+        ),
+        publisher_connection,
+        redis_client.clone(),
+        CancellationToken::new(),
+    );
     let partition_id = game_id % PARTITION_COUNT;
 
     // Pub/Sub startup is asynchronous. Republish until this server's replica proves the live
@@ -253,7 +265,7 @@ async fn live_game_join_is_authorized_before_enabling_game_chat() -> Result<()> 
     timeout(Duration::from_secs(10), async {
         loop {
             publisher
-                .publish_snapshot(partition_id, game_id, &live_state)
+                .publish_snapshot(partition_id, game_id, &live_state, 0)
                 .await?;
             if env
                 .server(0)
@@ -328,8 +340,20 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
         .await?;
 
     let (push_tx, _) = broadcast::channel(16);
-    let publisher_connection = create_connection_manager(redis_client, push_tx.clone()).await?;
-    let publisher = PubSubManager::new(publisher_connection, push_tx, CancellationToken::new());
+    let publisher_connection =
+        create_connection_manager(redis_client.clone(), push_tx.clone()).await?;
+    // Publish on the same transport the test server's replicas subscribe to.
+    let publisher = GameBus::new(
+        BusKind::from_env(),
+        PubSubManager::new(
+            publisher_connection.clone(),
+            push_tx,
+            CancellationToken::new(),
+        ),
+        publisher_connection,
+        redis_client.clone(),
+        CancellationToken::new(),
+    );
 
     let server_addr = env.ws_addr(0).expect("test server should be running");
     let mut client = TestClient::connect(&server_addr).await?;
@@ -341,7 +365,7 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
     // snapshot after GameCreated was already acknowledged.
     tokio::time::sleep(Duration::from_millis(200)).await;
     publisher
-        .publish_snapshot(game_id % PARTITION_COUNT, game_id, &live_state)
+        .publish_snapshot(game_id % PARTITION_COUNT, game_id, &live_state, 0)
         .await?;
 
     let loaded_state = receive_snapshot(&mut client).await?;
@@ -493,6 +517,15 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
         push_tx.clone(),
         cancellation_token.clone(),
     );
+    // This test drives hand-built Pub/Sub publishers, so the executor's bus
+    // is pinned to pubsub independent of the SNAKETRON_BUS test matrix.
+    let executor_bus = Arc::new(GameBus::new(
+        BusKind::PubSub,
+        executor_pubsub,
+        executor_connection.clone(),
+        redis_client.clone(),
+        cancellation_token.clone(),
+    ));
     let publisher_pubsub = PubSubManager::new(
         executor_connection.clone(),
         push_tx,
@@ -503,6 +536,7 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
             vec![partition_id],
             cancellation_token.clone(),
             &std::env::var("SNAKETRON_REDIS_URL")?,
+            BusKind::PubSub,
         )
         .await?,
     );
@@ -513,7 +547,7 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
             4242,
             partition_id,
             executor_connection,
-            executor_pubsub,
+            executor_bus,
             executor_db,
             replication_manager,
             executor_token,

--- a/server/tests/replay_test.rs
+++ b/server/tests/replay_test.rs
@@ -76,6 +76,7 @@ async fn test_replay_with_tick_forward() -> Result<()> {
         game_id: 100,
         tick: 1,
         sequence: 1,
+        stream_seq: 0,
         user_id: Some(1),
         event: GameEvent::CommandScheduled { command_message: command_msg },
     });
@@ -84,6 +85,7 @@ async fn test_replay_with_tick_forward() -> Result<()> {
         game_id: 100,
         tick: 3,
         sequence: 2,
+        stream_seq: 0,
         user_id: None,
         event: GameEvent::SnakeTurned { snake_id: 0, direction: Direction::Up },
     });

--- a/server/tests/simple_game_test.rs
+++ b/server/tests/simple_game_test.rs
@@ -5,17 +5,53 @@ use ::common::{
     CommandId, Direction, GameCommand, GameCommandMessage, GameEvent, GameStatus, GameType,
 };
 use anyhow::Result;
-use redis::AsyncCommands;
 use server::ws_server::WSMessage;
 use tokio::time::{Duration, timeout};
+
+/// Wait for a JoinGame message, skipping unrelated messages (e.g. UserCountUpdate).
+async fn wait_for_join_game(client: &mut TestClient, label: &str) -> Result<u32> {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            match client.receive_message().await? {
+                WSMessage::JoinGame(id) => break Ok::<u32, anyhow::Error>(id),
+                other => println!(
+                    "{}: ignoring message while waiting for JoinGame: {:?}",
+                    label, other
+                ),
+            }
+        }
+    })
+    .await?
+}
+
+/// Wait for a GameEvent carrying a Snapshot, skipping unrelated messages.
+async fn wait_for_snapshot(client: &mut TestClient, label: &str) -> Result<WSMessage> {
+    timeout(Duration::from_secs(10), async {
+        loop {
+            let msg = client.receive_message().await?;
+            match &msg {
+                WSMessage::GameEvent(event)
+                    if matches!(event.event, GameEvent::Snapshot { .. }) =>
+                {
+                    break Ok::<WSMessage, anyhow::Error>(msg);
+                }
+                other => println!(
+                    "{}: ignoring message while waiting for snapshot: {:?}",
+                    label, other
+                ),
+            }
+        }
+    })
+    .await?
+}
 
 #[tokio::test]
 async fn test_simple_game() -> Result<()> {
     // Initialize tracing
     let _ = tracing_subscriber::fmt::try_init();
 
-    // Clean up Redis before starting the test
-    let redis_client = redis::Client::open("redis://localhost:6379")?;
+    // Clean up the Redis test database (db 1, used by TestEnvironment) before starting
+    let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
     let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
 
@@ -55,32 +91,16 @@ async fn test_simple_game() -> Result<()> {
 
     println!("Clients queued");
 
-    // Wait for JoinGame messages first
-    let join_msg1 = timeout(Duration::from_secs(10), async {
-        client1.receive_message().await
-    })
-    .await??;
+    // Wait for JoinGame messages first, skipping unrelated messages
+    let join_id1 = wait_for_join_game(&mut client1, "Client1").await?;
+    println!("Client1 received JoinGame({})", join_id1);
 
-    println!("Client1 received: {:?}", join_msg1);
-
-    let join_msg2 = timeout(Duration::from_secs(10), async {
-        client2.receive_message().await
-    })
-    .await??;
-
-    println!("Client2 received: {:?}", join_msg2);
+    let join_id2 = wait_for_join_game(&mut client2, "Client2").await?;
+    println!("Client2 received JoinGame({})", join_id2);
 
     // Verify both clients received JoinGame messages for the same game
-    let game_id = match (&join_msg1, &join_msg2) {
-        (WSMessage::JoinGame(id1), WSMessage::JoinGame(id2)) => {
-            assert_eq!(id1, id2, "Both clients should join the same game");
-            *id1
-        }
-        _ => panic!(
-            "Expected JoinGame messages, got {:?} and {:?}",
-            join_msg1, join_msg2
-        ),
-    };
+    assert_eq!(join_id1, join_id2, "Both clients should join the same game");
+    let game_id = join_id1;
 
     println!("Both clients joined game {}", game_id);
 
@@ -90,19 +110,11 @@ async fn test_simple_game() -> Result<()> {
 
     println!("Clients acknowledged join");
 
-    // Now wait for game snapshots after joining
-    let msg1 = timeout(Duration::from_secs(10), async {
-        client1.receive_message().await
-    })
-    .await??;
-
+    // Now wait for game snapshots after joining, skipping unrelated messages
+    let msg1 = wait_for_snapshot(&mut client1, "Client1").await?;
     println!("Client1 received after join: {:?}", msg1);
 
-    let msg2 = timeout(Duration::from_secs(10), async {
-        client2.receive_message().await
-    })
-    .await??;
-
+    let msg2 = wait_for_snapshot(&mut client2, "Client2").await?;
     println!("Client2 received after join: {:?}", msg2);
 
     // Verify both clients received game snapshots and extract game_id and snake_ids
@@ -221,14 +233,22 @@ async fn test_simple_game() -> Result<()> {
         }
     };
 
-    // Store which snake should win (the one that turns)
-    let expected_winner = turning_snake_id;
-
-    // Send turn command early to ensure the snake turns before hitting the wall
-    // Both snakes start 35 cells from opposite walls, so they'd hit at tick 35
-    // But they're dying at tick 15, which suggests a different issue
-    // Let's turn very early - within first few ticks
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // The two snakes spawn facing each other on the same row, so if neither
+    // turns they collide head-on at ~tick 15. The game also begins with a ~3s
+    // countdown (GAME_START_DELAY_MS) during which it stays at tick 0;
+    // commands sent during the countdown would all be scheduled for the same
+    // tick (and the two turns would cancel out), so wait until ticking has
+    // started before turning.
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let WSMessage::GameEvent(event) = turning_player_client.receive_message().await? {
+                if event.tick >= 1 {
+                    break Ok::<(), anyhow::Error>(());
+                }
+            }
+        }
+    })
+    .await??;
 
     turning_player_client
         .send_message(WSMessage::GameCommand(GameCommandMessage {
@@ -245,15 +265,32 @@ async fn test_simple_game() -> Result<()> {
         }))
         .await?;
 
-    // Wait then turn left to continue avoiding walls
-    tokio::time::sleep(Duration::from_millis(300)).await;
+    // Wait until the Up turn has actually executed before scheduling the next
+    // turn, so the two turns land on different ticks.
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let WSMessage::GameEvent(event) = turning_player_client.receive_message().await? {
+                if let GameEvent::SnakeTurned {
+                    snake_id,
+                    direction: Direction::Up,
+                } = event.event
+                {
+                    if snake_id == turning_snake_id {
+                        break Ok::<(), anyhow::Error>(());
+                    }
+                }
+            }
+        }
+    })
+    .await??;
 
+    // Turn left to continue avoiding walls
     turning_player_client
         .send_message(WSMessage::GameCommand(GameCommandMessage {
             command_id_client: CommandId {
                 tick: 0,
                 user_id: turning_user_id,
-                sequence_number: 0,
+                sequence_number: 1,
             },
             command_id_server: None,
             command: GameCommand::Turn {
@@ -263,146 +300,76 @@ async fn test_simple_game() -> Result<()> {
         }))
         .await?;
 
-    // Continue the game and collect events
-    let mut snake1_died = false;
-    let mut snake2_died = false;
-    let start_time = tokio::time::Instant::now();
+    // Track deaths and wait for the game to complete.
+    // Current FFA semantics: the game completes only when ALL snakes are dead,
+    // and the final status carries no winner (winning_snake_id is None; XP is
+    // awarded to players instead). The snake that turned should simply outlive
+    // the snake that kept going straight into the head-on collision course.
+    let mut snake1_death_tick: Option<u32> = None;
+    let mut snake2_death_tick: Option<u32> = None;
+    let mut final_winning_snake_id: Option<Option<u32>> = None;
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(20);
 
-    // Run for up to 10 seconds to see the outcome
-    while start_time.elapsed() < Duration::from_secs(10) && (!snake1_died || !snake2_died) {
-        // Try to receive events from both clients
-        tokio::select! {
-            msg = timeout(Duration::from_millis(100), client1.receive_message()) => {
-                if let Ok(Ok(WSMessage::GameEvent(event))) = msg {
-                    match &event.event {
-                        GameEvent::SnakeDied { snake_id } => {
-                            if *snake_id == snake1_id {
-                                println!("Snake 1 (id={}) died at tick {}! Initial direction was {:?}",
-                                    snake1_id, event.tick, snake1_dir);
-                                snake1_died = true;
-                            } else if *snake_id == snake2_id {
-                                println!("Snake 2 (id={}) died at tick {}! Initial direction was {:?}",
-                                    snake2_id, event.tick, snake2_dir);
-                                snake2_died = true;
-                            }
-                        }
-                        GameEvent::StatusUpdated { status } => {
-                            println!("Client1: Game status updated to {:?}", status);
-                            if let GameStatus::Complete { winning_snake_id } = status {
-                                println!("Game complete! Winner: {:?}", winning_snake_id);
-                                assert_ne!(*winning_snake_id, None, "Game should not end in a draw");
-                                assert_eq!(*winning_snake_id, Some(expected_winner), "The snake that turned should win");
-                                return Ok::<(), anyhow::Error>(());
-                            }
-                        }
-                        _ => {
-                            println!("Client1 received event: {:?}", event.event);
-                        }
-                    }
+    while final_winning_snake_id.is_none() && tokio::time::Instant::now() < deadline {
+        let msg = tokio::select! {
+            msg = timeout(Duration::from_millis(500), client1.receive_message()) => msg,
+            msg = timeout(Duration::from_millis(500), client2.receive_message()) => msg,
+        };
+        let Ok(Ok(WSMessage::GameEvent(event))) = msg else {
+            continue;
+        };
+        match &event.event {
+            GameEvent::SnakeDied { snake_id } => {
+                if *snake_id == snake1_id && snake1_death_tick.is_none() {
+                    println!(
+                        "Snake 1 (id={}) died at tick {}! Initial direction was {:?}",
+                        snake1_id, event.tick, snake1_dir
+                    );
+                    snake1_death_tick = Some(event.tick);
+                } else if *snake_id == snake2_id && snake2_death_tick.is_none() {
+                    println!(
+                        "Snake 2 (id={}) died at tick {}! Initial direction was {:?}",
+                        snake2_id, event.tick, snake2_dir
+                    );
+                    snake2_death_tick = Some(event.tick);
                 }
             }
-            msg = timeout(Duration::from_millis(100), client2.receive_message()) => {
-                if let Ok(Ok(WSMessage::GameEvent(event))) = msg {
-                    match &event.event {
-                        GameEvent::SnakeDied { snake_id } => {
-                            if *snake_id == snake1_id {
-                                println!("Snake 1 (id={}) died at tick {}! Initial direction was {:?}",
-                                    snake1_id, event.tick, snake1_dir);
-                                snake1_died = true;
-                            } else if *snake_id == snake2_id {
-                                println!("Snake 2 (id={}) died at tick {}! Initial direction was {:?}",
-                                    snake2_id, event.tick, snake2_dir);
-                                snake2_died = true;
-                            }
-                        }
-                        GameEvent::StatusUpdated { status } => {
-                            println!("Client2: Game status updated to {:?}", status);
-                            if let GameStatus::Complete { winning_snake_id } = status {
-                                println!("Game complete! Winner: {:?}", winning_snake_id);
-                                assert_ne!(*winning_snake_id, None, "Game should not end in a draw");
-                                assert_eq!(*winning_snake_id, Some(expected_winner), "The snake that turned should win");
-                                return Ok::<(), anyhow::Error>(());
-                            }
-                        }
-                        _ => {
-                            println!("Client2 received event: {:?}", event.event);
-                        }
-                    }
+            GameEvent::StatusUpdated { status } => {
+                println!("Game status updated to {:?}", status);
+                if let GameStatus::Complete { winning_snake_id } = status {
+                    final_winning_snake_id = Some(*winning_snake_id);
                 }
             }
-            else => {
-                // No messages available, continue
-            }
+            _ => {}
         }
     }
 
-    // Wait for game completion event
-    let game_ended = timeout(Duration::from_secs(5), async {
-        loop {
-            tokio::select! {
-                msg = client1.receive_message() => {
-                    if let Ok(WSMessage::GameEvent(event)) = msg {
-                        if let GameEvent::StatusUpdated { status } = &event.event {
-                            if matches!(status, GameStatus::Complete { .. }) {
-                                println!("Game completed with status: {:?}", status);
-                                return Ok::<(), anyhow::Error>(());
-                            }
-                        }
-                    }
-                }
-                msg = client2.receive_message() => {
-                    if let Ok(WSMessage::GameEvent(event)) = msg {
-                        if let GameEvent::StatusUpdated { status } = &event.event {
-                            if matches!(status, GameStatus::Complete { .. }) {
-                                println!("Game completed with status: {:?}", status);
-                                return Ok::<(), anyhow::Error>(());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    })
-    .await;
+    let winning_snake_id =
+        final_winning_snake_id.expect("Game should complete within the deadline");
 
-    assert!(
-        game_ended.is_ok(),
-        "Game should have ended with a completion status"
+    // Current FFA semantics: no winner is recorded in the final status.
+    assert_eq!(
+        winning_snake_id, None,
+        "FFA games complete with no winner recorded"
     );
 
-    // Debug final state
-    println!(
-        "Final state - Snake 1 (id {}) died: {}, Snake 2 (id {}) died: {}",
-        snake1_id, snake1_died, snake2_id, snake2_died
-    );
+    let snake1_death =
+        snake1_death_tick.expect("Snake 1 should have died before the game completed");
+    let snake2_death =
+        snake2_death_tick.expect("Snake 2 should have died before the game completed");
 
-    // The test should not end in a draw
-    assert!(
-        !(snake1_died && snake2_died),
-        "Game should not end in a draw - only one snake should die"
-    );
-
-    // The snake that went straight (RIGHT direction) should die hitting the wall
-    // The snake that turned (originally LEFT direction) should survive
-    let right_going_snake_died = if matches!(snake1_dir, Direction::Right) {
-        snake1_died
+    // The snake that kept going straight dies first (right wall at ~tick 36);
+    // the snake that turned avoids the head-on collision and outlives it.
+    let (turned_death, straight_death) = if turning_snake_id == snake1_id {
+        (snake1_death, snake2_death)
     } else {
-        snake2_died
+        (snake2_death, snake1_death)
     };
-
-    let left_going_snake_died = if matches!(snake1_dir, Direction::Left) {
-        snake1_died
-    } else {
-        snake2_died
-    };
-
     assert!(
-        right_going_snake_died,
-        "The snake going RIGHT should have died hitting the wall"
-    );
-    assert!(
-        !left_going_snake_died,
-        "The snake that turned (originally going LEFT) should survive"
+        turned_death > straight_death,
+        "The snake that turned (died at tick {}) should outlive the snake that went straight (died at tick {})",
+        turned_death,
+        straight_death
     );
 
     // Output the replay file location

--- a/server/tests/solo_game_test.rs
+++ b/server/tests/solo_game_test.rs
@@ -5,7 +5,6 @@ use ::common::{
     CommandId, Direction, GameCommand, GameCommandMessage, GameEvent, GameStatus, GameType,
 };
 use anyhow::Result;
-use redis::AsyncCommands;
 use server::ws_server::WSMessage;
 use tokio::time::{Duration, timeout};
 
@@ -14,8 +13,8 @@ async fn test_solo_game() -> Result<()> {
     // Initialize tracing
     let _ = tracing_subscriber::fmt::try_init();
 
-    // Clean up Redis before starting the test
-    let redis_client = redis::Client::open("redis://localhost:6379")?;
+    // Clean up the Redis test database (db 1, used by TestEnvironment) before starting
+    let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
     let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
 
@@ -35,29 +34,27 @@ async fn test_solo_game() -> Result<()> {
 
     println!("Client authenticated");
 
-    // Queue for a solo match (max_players: 1)
+    // Queue for a solo match. Solo games have a dedicated GameType now;
+    // a FreeForAll queue never matches with a single player.
     client
         .send_message(WSMessage::QueueForMatch {
-            game_type: GameType::FreeForAll { max_players: 1 },
+            game_type: GameType::Solo,
             queue_mode: ::common::QueueMode::Quickmatch,
         })
         .await?;
 
     println!("Client queued for solo game");
 
-    // Wait for JoinGame message
-    let join_msg = timeout(Duration::from_secs(10), async {
-        client.receive_message().await
+    // Wait for JoinGame message, skipping unrelated messages (e.g. UserCountUpdate)
+    let game_id = timeout(Duration::from_secs(10), async {
+        loop {
+            match client.receive_message().await? {
+                WSMessage::JoinGame(id) => break Ok::<u32, anyhow::Error>(id),
+                other => println!("Ignoring message while waiting for JoinGame: {:?}", other),
+            }
+        }
     })
     .await??;
-
-    println!("Client received: {:?}", join_msg);
-
-    // Verify client received JoinGame message
-    let game_id = match &join_msg {
-        WSMessage::JoinGame(id) => *id,
-        _ => panic!("Expected JoinGame message, got {:?}", join_msg),
-    };
 
     println!("Client joined game {}", game_id);
 
@@ -66,9 +63,19 @@ async fn test_solo_game() -> Result<()> {
 
     println!("Client acknowledged join");
 
-    // Now wait for game snapshot after joining
+    // Now wait for the game snapshot after joining, skipping unrelated messages
     let msg = timeout(Duration::from_secs(10), async {
-        client.receive_message().await
+        loop {
+            let msg = client.receive_message().await?;
+            match &msg {
+                WSMessage::GameEvent(event)
+                    if matches!(event.event, GameEvent::Snapshot { .. }) =>
+                {
+                    break Ok::<WSMessage, anyhow::Error>(msg);
+                }
+                other => println!("Ignoring message while waiting for snapshot: {:?}", other),
+            }
+        }
     })
     .await??;
 
@@ -149,6 +156,21 @@ async fn test_solo_game() -> Result<()> {
     let user_id = env.user_ids()[0] as u32;
     let mut sequence_number = 0;
 
+    // The game begins with a ~3s countdown (GAME_START_DELAY_MS) during which
+    // it stays at tick 0. Commands sent during the countdown are all scheduled
+    // for the same tick, so wait until ticking has actually started before
+    // sending the turn sequence.
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let WSMessage::GameEvent(event) = client.receive_message().await? {
+                if event.tick >= 1 {
+                    break Ok::<(), anyhow::Error>(());
+                }
+            }
+        }
+    })
+    .await??;
+
     // If snake is going towards a wall, turn to avoid it
     // Based on the test_simple_game, snakes typically start in the middle going left or right
     if matches!(initial_direction, Direction::Left | Direction::Right) {
@@ -214,8 +236,9 @@ async fn test_solo_game() -> Result<()> {
     let mut death_tick = 0;
     let start_time = tokio::time::Instant::now();
 
-    // Run for up to 10 seconds to see the outcome
-    while start_time.elapsed() < Duration::from_secs(10) && !snake_died {
+    // Run for up to 10 seconds to see the outcome. Keep listening after the
+    // snake dies: the Complete status update arrives after the SnakeDied event.
+    while start_time.elapsed() < Duration::from_secs(10) {
         // Try to receive events
         match timeout(Duration::from_millis(100), client.receive_message()).await {
             Ok(Ok(WSMessage::GameEvent(event))) => {

--- a/server/tests/sync_equivalence_test.rs
+++ b/server/tests/sync_equivalence_test.rs
@@ -1,0 +1,855 @@
+//! Chaos/equivalence tests for client<->server state synchronization.
+//!
+//! These tests run a fully in-process simulation of the production topology:
+//! an authoritative server-side `GameEngine` advanced on a virtual clock the
+//! way `game_executor::run_game` does, a deterministic transport with
+//! configurable latency/jitter/loss standing in for Redis pub/sub + WebSocket,
+//! and a client-side `GameEngine` that sees only what the transport delivers.
+//! No network, no Redis, no sleeps — a 60-virtual-second game runs in
+//! milliseconds and is bit-for-bit reproducible from its seeds.
+
+use anyhow::Result;
+use common::{
+    DEFAULT_TICK_INTERVAL_MS, Direction, GameCommand, GameCommandMessage, GameEngine, GameEvent,
+    GameEventMessage, GameState, GameStatus, GameType, MAX_PREDICTION_AHEAD_MS, PseudoRandom,
+    QueueMode,
+};
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
+use std::time::Duration;
+
+const GAME_ID: u32 = 777;
+/// Matches `EXECUTOR_POLL_INTERVAL_MS`: the executor advances the engine on a
+/// 50ms interval.
+const POLL_MS: i64 = 50;
+/// Client animation-frame cadence.
+const FRAME_MS: i64 = 16;
+/// The server emits a `TickHash` heartbeat every this many committed ticks.
+const PROBE_EVERY_TICKS: u32 = 10;
+/// `GameEngine`'s internal `committed_state_lag_ms` (not exported).
+const COMMITTED_LAG_MS: u32 = 500;
+
+// ---------------------------------------------------------------------------
+// Transport simulator
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Copy)]
+struct TransportConfig {
+    base_latency_ms: i64,
+    jitter_ms: i64,
+    /// Applied to server->client event messages only (commands ride the
+    /// client's own WebSocket; snapshots are exempt as the reliable join /
+    /// recovery path).
+    drop_probability: f32,
+    /// When false (the default topology), per-direction FIFO ordering is
+    /// enforced even under jitter, like a single TCP/WebSocket stream.
+    allow_reorder: bool,
+    seed: u64,
+}
+
+impl TransportConfig {
+    fn lossless() -> Self {
+        TransportConfig {
+            base_latency_ms: 120,
+            jitter_ms: 40,
+            drop_probability: 0.0,
+            allow_reorder: false,
+            seed: 7,
+        }
+    }
+}
+
+enum Wire {
+    ToClient(Box<GameEventMessage>),
+    ToServer(Box<GameCommandMessage>),
+    /// Client asking the executor for a fresh snapshot (resync protocol).
+    SnapshotRequest,
+}
+
+struct InFlight {
+    arrival_ms: i64,
+    order: u64,
+    payload: Wire,
+}
+
+impl PartialEq for InFlight {
+    fn eq(&self, other: &Self) -> bool {
+        (self.arrival_ms, self.order) == (other.arrival_ms, other.order)
+    }
+}
+impl Eq for InFlight {}
+impl PartialOrd for InFlight {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for InFlight {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        (self.arrival_ms, self.order).cmp(&(other.arrival_ms, other.order))
+    }
+}
+
+struct Transport {
+    cfg: TransportConfig,
+    rng: PseudoRandom,
+    queue: BinaryHeap<Reverse<InFlight>>,
+    next_order: u64,
+    last_to_client_arrival: i64,
+    last_to_server_arrival: i64,
+    /// Hard kill switch: when false every send is discarded (server silent).
+    delivery_enabled: bool,
+    dropped_to_client: u64,
+}
+
+impl Transport {
+    fn new(cfg: TransportConfig) -> Self {
+        Transport {
+            cfg,
+            rng: PseudoRandom::new(cfg.seed),
+            queue: BinaryHeap::new(),
+            next_order: 0,
+            last_to_client_arrival: 0,
+            last_to_server_arrival: 0,
+            delivery_enabled: true,
+            dropped_to_client: 0,
+        }
+    }
+
+    fn sample_latency(&mut self) -> i64 {
+        if self.cfg.jitter_ms == 0 {
+            return self.cfg.base_latency_ms;
+        }
+        let span = (self.cfg.jitter_ms * 2 + 1) as u32;
+        self.cfg.base_latency_ms - self.cfg.jitter_ms + (self.rng.next_u32() % span) as i64
+    }
+
+    fn enqueue(&mut self, now_ms: i64, latency_ms: i64, payload: Wire) {
+        if !self.delivery_enabled {
+            return;
+        }
+        let mut arrival = now_ms + latency_ms.max(1);
+        if !self.cfg.allow_reorder {
+            let last = match payload {
+                Wire::ToClient(_) => &mut self.last_to_client_arrival,
+                Wire::ToServer(_) | Wire::SnapshotRequest => &mut self.last_to_server_arrival,
+            };
+            arrival = arrival.max(*last);
+            *last = arrival;
+        }
+        let order = self.next_order;
+        self.next_order += 1;
+        self.queue.push(Reverse(InFlight {
+            arrival_ms: arrival,
+            order,
+            payload,
+        }));
+    }
+
+    fn send_to_client(&mut self, now_ms: i64, msg: GameEventMessage) {
+        // Snapshots are the reliable join/recovery path; everything else is
+        // at-most-once pub/sub and may be dropped.
+        let droppable = !matches!(msg.event, GameEvent::Snapshot { .. });
+        if droppable && self.cfg.drop_probability > 0.0 && self.delivery_enabled {
+            if self.rng.next_f32() < self.cfg.drop_probability {
+                self.dropped_to_client += 1;
+                return;
+            }
+        }
+        let latency = self.sample_latency();
+        self.enqueue(now_ms, latency, Wire::ToClient(Box::new(msg)));
+    }
+
+    fn send_to_server(&mut self, now_ms: i64, cmd: GameCommandMessage) {
+        let latency = self.sample_latency();
+        self.enqueue(now_ms, latency, Wire::ToServer(Box::new(cmd)));
+    }
+
+    fn send_to_server_with_latency(
+        &mut self,
+        now_ms: i64,
+        cmd: GameCommandMessage,
+        latency_ms: i64,
+    ) {
+        self.enqueue(now_ms, latency_ms, Wire::ToServer(Box::new(cmd)));
+    }
+
+    fn send_snapshot_request(&mut self, now_ms: i64) {
+        let latency = self.sample_latency();
+        self.enqueue(now_ms, latency, Wire::SnapshotRequest);
+    }
+
+    fn pop_due(&mut self, now_ms: i64) -> Option<Wire> {
+        if let Some(Reverse(head)) = self.queue.peek() {
+            if head.arrival_ms <= now_ms {
+                return self.queue.pop().map(|Reverse(f)| f.payload);
+            }
+        }
+        None
+    }
+
+    fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+
+    fn cut(&mut self) {
+        self.delivery_enabled = false;
+        self.queue.clear();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Simulation world: server engine + transport + client engine
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy)]
+struct ProbeResult {
+    tick: u32,
+    matched: bool,
+}
+
+struct SimWorld {
+    now_ms: i64,
+    server: GameEngine,
+    client: Option<GameEngine>,
+    transport: Transport,
+    /// Monotonic transport sequence, assigned at publish time like the
+    /// executor does. Starts at 1 for the initial join snapshot.
+    stream_seq: u64,
+    next_probe_tick: u32,
+    clock_drift_ms: i64,
+    /// Full published stream for determinism comparisons:
+    /// (tick, stream_seq, engine sequence, event as JSON value).
+    published: Vec<(u32, u64, u64, serde_json::Value)>,
+    record_published: bool,
+    /// Every server-confirmed command, in processing order.
+    confirmations: Vec<GameCommandMessage>,
+    probe_log: Vec<ProbeResult>,
+    ever_needed_resync: bool,
+    auto_resync: bool,
+    resync_in_flight: bool,
+}
+
+impl SimWorld {
+    fn new(game_seed: u64, cfg: TransportConfig) -> Self {
+        // Mirror the production game-creation path (matchmaking + executor):
+        // players join a Stopped tick-0 state, initial food is spawned from
+        // the seeded RNG, the executor flips it to Started and builds the
+        // engine from that state.
+        let mut state = GameState::new(
+            40,
+            40,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(game_seed),
+            0,
+        );
+        state
+            .add_player(1, Some("alice".to_string()))
+            .expect("add player 1");
+        state
+            .add_player(2, Some("bob".to_string()))
+            .expect("add player 2");
+        state.status = GameStatus::Started { server_id: 7 };
+        state.spawn_initial_food();
+
+        let server = GameEngine::new_from_state(GAME_ID, state);
+        let mut world = SimWorld {
+            now_ms: 0,
+            server,
+            client: None,
+            transport: Transport::new(cfg),
+            stream_seq: 0,
+            next_probe_tick: PROBE_EVERY_TICKS,
+            clock_drift_ms: 0,
+            published: Vec::new(),
+            record_published: false,
+            confirmations: Vec::new(),
+            probe_log: Vec::new(),
+            ever_needed_resync: false,
+            auto_resync: false,
+            resync_in_flight: false,
+        };
+
+        // Initial snapshot at t0, the way a client join does (stream_seq 1).
+        world.publish_snapshot();
+        world
+    }
+
+    fn tick_duration_ms(&self) -> i64 {
+        self.server.committed_state().properties.tick_duration_ms as i64
+    }
+
+    fn publish(&mut self, tick: u32, sequence: u64, event: GameEvent) {
+        self.stream_seq += 1;
+        if self.record_published {
+            self.published.push((
+                tick,
+                self.stream_seq,
+                sequence,
+                serde_json::to_value(&event).expect("event serializes"),
+            ));
+        }
+        let msg = GameEventMessage {
+            game_id: GAME_ID,
+            tick,
+            sequence,
+            stream_seq: self.stream_seq,
+            user_id: None,
+            event,
+        };
+        self.transport.send_to_client(self.now_ms, msg);
+    }
+
+    fn publish_snapshot(&mut self) {
+        let state = self.server.committed_state().clone();
+        let tick = state.tick;
+        let sequence = state.event_sequence;
+        self.publish(tick, sequence, GameEvent::Snapshot { game_state: state });
+    }
+
+    fn publish_probe(&mut self) {
+        let tick = self.server.current_tick();
+        let sequence = self.server.committed_state().event_sequence;
+        let event = GameEvent::TickHash {
+            hash: self.server.committed_sync_hash(),
+            server_ts_ms: self.now_ms,
+        };
+        self.publish(tick, sequence, event);
+    }
+
+    /// One executor poll: advance the authoritative engine by wall clock and
+    /// publish every emitted event, plus a TickHash heartbeat every
+    /// `PROBE_EVERY_TICKS` committed ticks.
+    fn server_poll(&mut self) {
+        let events = self
+            .server
+            .run_until(self.now_ms)
+            .expect("server run_until");
+        for (tick, sequence, event) in events {
+            self.publish(tick, sequence, event);
+        }
+        if self.server.current_tick() >= self.next_probe_tick {
+            self.publish_probe();
+            self.next_probe_tick = self.server.current_tick() + PROBE_EVERY_TICKS;
+        }
+    }
+
+    fn server_receive_command(&mut self, cmd: GameCommandMessage) {
+        let confirmed = self
+            .server
+            .process_command(cmd)
+            .expect("server process_command");
+        self.confirmations.push(confirmed.clone());
+        let tick = self.server.current_tick();
+        let sequence = self.server.committed_state().event_sequence + 1;
+        self.publish(
+            tick,
+            sequence,
+            GameEvent::CommandScheduled {
+                command_message: confirmed,
+            },
+        );
+    }
+
+    fn client_receive(&mut self, msg: GameEventMessage) {
+        if self.client.is_none() {
+            let GameEvent::Snapshot { game_state } = &msg.event else {
+                return; // not joined yet
+            };
+            let mut engine = GameEngine::new_from_state(GAME_ID, game_state.clone());
+            engine.set_local_player_id(1);
+            self.client = Some(engine);
+        }
+
+        let is_probe = matches!(msg.event, GameEvent::TickHash { .. });
+        let is_snapshot = matches!(msg.event, GameEvent::Snapshot { .. });
+
+        self.client
+            .as_mut()
+            .expect("client exists")
+            .process_server_event(&msg)
+            .expect("client process_server_event");
+
+        if is_snapshot {
+            self.resync_in_flight = false;
+        }
+
+        let (needs_resync, probe) = {
+            let status = self.client.as_ref().expect("client exists").sync_status();
+            let probe = if is_probe && status.last_probe_tick == Some(msg.tick) {
+                Some(ProbeResult {
+                    tick: msg.tick,
+                    matched: status.last_probe_matched.unwrap_or(false),
+                })
+            } else {
+                None
+            };
+            (status.needs_resync, probe)
+        };
+        if let Some(probe) = probe {
+            self.probe_log.push(probe);
+        }
+        if needs_resync {
+            self.ever_needed_resync = true;
+            if self.auto_resync && !self.resync_in_flight {
+                self.request_resync();
+            }
+        }
+    }
+
+    /// The resync protocol: clear the flag (request issued), ask the server
+    /// for a fresh snapshot over the transport.
+    fn request_resync(&mut self) {
+        if let Some(client) = self.client.as_mut() {
+            client.clear_needs_resync();
+        }
+        self.resync_in_flight = true;
+        self.transport.send_snapshot_request(self.now_ms);
+    }
+
+    fn deliver_due(&mut self) {
+        while let Some(wire) = self.transport.pop_due(self.now_ms) {
+            match wire {
+                Wire::ToClient(msg) => self.client_receive(*msg),
+                Wire::ToServer(cmd) => self.server_receive_command(*cmd),
+                Wire::SnapshotRequest => self.publish_snapshot(),
+            }
+        }
+    }
+
+    fn step_ms(&mut self) {
+        self.now_ms += 1;
+        if self.now_ms % POLL_MS == 0 {
+            self.server_poll();
+        }
+        self.deliver_due();
+        if self.now_ms % FRAME_MS == 0 {
+            let drift = self.clock_drift_ms;
+            let now = self.now_ms;
+            if let Some(client) = self.client.as_mut() {
+                client
+                    .rebuild_predicted_state(now - drift)
+                    .expect("rebuild_predicted_state");
+            }
+            if self.auto_resync && !self.resync_in_flight {
+                let needs = self
+                    .client
+                    .as_ref()
+                    .map(|c| c.sync_status().needs_resync)
+                    .unwrap_or(false);
+                if needs {
+                    self.ever_needed_resync = true;
+                    self.request_resync();
+                }
+            }
+        }
+    }
+
+    fn run_for(&mut self, duration_ms: i64) {
+        let end = self.now_ms + duration_ms;
+        while self.now_ms < end {
+            self.step_ms();
+        }
+    }
+
+    fn client_send_turn(&mut self, direction: Direction) -> GameCommandMessage {
+        let cmd = self
+            .client
+            .as_mut()
+            .expect("client joined")
+            .process_local_command(GameCommand::Turn {
+                snake_id: 0,
+                direction,
+            })
+            .expect("process_local_command");
+        self.transport.send_to_server(self.now_ms, cmd.clone());
+        cmd
+    }
+
+    fn client_send_turn_with_latency(
+        &mut self,
+        direction: Direction,
+        latency_ms: i64,
+    ) -> GameCommandMessage {
+        let cmd = self
+            .client
+            .as_mut()
+            .expect("client joined")
+            .process_local_command(GameCommand::Turn {
+                snake_id: 0,
+                direction,
+            })
+            .expect("process_local_command");
+        self.transport
+            .send_to_server_with_latency(self.now_ms, cmd.clone(), latency_ms);
+        cmd
+    }
+
+    /// Deliver everything still in flight (without advancing the game), then
+    /// emit one final fingerprint probe so both committed states end at the
+    /// same tick and can be compared directly.
+    fn drain_and_probe(&mut self) {
+        let mut guard = 0;
+        while !self.transport.is_empty() {
+            self.now_ms += 1;
+            self.deliver_due();
+            guard += 1;
+            assert!(guard < 1_000_000, "transport failed to drain");
+        }
+        self.publish_probe();
+        while !self.transport.is_empty() {
+            self.now_ms += 1;
+            self.deliver_due();
+        }
+    }
+
+    fn client(&self) -> &GameEngine {
+        self.client.as_ref().expect("client joined")
+    }
+}
+
+async fn with_timeout<F>(fut: F) -> Result<()>
+where
+    F: std::future::Future<Output = Result<()>>,
+{
+    tokio::time::timeout(Duration::from_secs(10), fut)
+        .await
+        .map_err(|_| anyhow::anyhow!("test timed out after 10s"))?
+}
+
+/// The shared lossless scenario: 60 virtual seconds, 120ms±40ms latency, no
+/// loss, several player commands routed client -> server -> broadcast.
+fn run_lossless_scenario(game_seed: u64, transport_seed: u64, record: bool) -> SimWorld {
+    let cfg = TransportConfig {
+        seed: transport_seed,
+        ..TransportConfig::lossless()
+    };
+    let mut world = SimWorld::new(game_seed, cfg);
+    world.record_published = record;
+
+    world.run_for(5_000);
+    for direction in [
+        Direction::Up,
+        Direction::Right,
+        Direction::Down,
+        Direction::Right,
+        Direction::Up,
+        Direction::Right,
+    ] {
+        world.client_send_turn(direction);
+        world.run_for(5_000);
+    }
+    world.run_for(25_000); // total: 60 virtual seconds
+    world.drain_and_probe();
+    world
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn lossless_transport_stays_in_sync() -> Result<()> {
+    with_timeout(async {
+        let world = run_lossless_scenario(0xC0FFEE, 7, false);
+
+        let status = world.client().sync_status();
+        assert!(
+            status.total_probes > 0,
+            "expected fingerprint probes to run, got none"
+        );
+        assert_eq!(
+            status.total_mismatches, 0,
+            "lossless transport must never diverge; probe log: {:?}",
+            world.probe_log
+        );
+        assert_eq!(status.stream_gap_count, 0, "no gaps on lossless transport");
+        assert!(
+            !status.needs_resync,
+            "no resync needed on lossless transport"
+        );
+        assert_eq!(
+            world.client().current_tick(),
+            world.server.current_tick(),
+            "final probe fast-forwards the client to the server tick"
+        );
+        assert_eq!(
+            world.client().committed_sync_hash(),
+            world.server.committed_sync_hash(),
+            "final committed states must be identical"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn lossy_transport_detects_gaps_and_resyncs() -> Result<()> {
+    with_timeout(async {
+        let cfg = TransportConfig {
+            drop_probability: 0.05,
+            seed: 21,
+            ..TransportConfig::lossless()
+        };
+        let mut world = SimWorld::new(0xBADF00D, cfg);
+
+        // Lossy phase: no commands needed, the game generates plenty of
+        // traffic (movement, deaths, respawns, food) on its own.
+        world.run_for(30_000);
+
+        let status = world.client().sync_status();
+        assert!(
+            world.transport.dropped_to_client > 0,
+            "transport should have dropped messages at 5%"
+        );
+        assert!(
+            status.stream_gap_count > 0,
+            "dropped messages must surface as stream gaps"
+        );
+        assert!(
+            status.needs_resync,
+            "a gap means the committed state can no longer be trusted"
+        );
+
+        // Recovery: stop the loss, run the resync protocol.
+        world.transport.cfg.drop_probability = 0.0;
+        let probes_before_resync = world.probe_log.len();
+        world.request_resync();
+        world.run_for(10_000);
+        world.drain_and_probe();
+
+        let status = world.client().sync_status();
+        assert!(
+            !status.needs_resync,
+            "snapshot must clear needs_resync: {status:?}"
+        );
+        let post_resync: Vec<ProbeResult> = world.probe_log[probes_before_resync..].to_vec();
+        assert!(
+            !post_resync.is_empty(),
+            "expected probes after the resync snapshot"
+        );
+        assert!(
+            post_resync.iter().all(|p| p.matched),
+            "probes after resync must match again: {post_resync:?}"
+        );
+        assert_eq!(
+            world.client().committed_sync_hash(),
+            world.server.committed_sync_hash(),
+            "resynced client must converge to the server state"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn targeted_event_loss_detected_by_tickhash() -> Result<()> {
+    with_timeout(async {
+        let mut world = SimWorld::new(0xFEED, TransportConfig::lossless());
+
+        // Establish a healthy baseline first.
+        world.run_for(15_000);
+        let baseline = world.client().sync_status().clone();
+        assert!(baseline.total_probes > 0, "baseline probes should have run");
+        assert_eq!(
+            baseline.total_mismatches, 0,
+            "baseline must be in sync before corrupting: {:?}",
+            world.probe_log
+        );
+
+        // With stream_seq, dropping a single FoodSpawned always also tells
+        // the client via the gap counter — so to exercise the hash path in
+        // isolation, corrupt the client's committed food set directly by one
+        // cell. stream_seq 0 bypasses the watermark (unassigned/legacy), and
+        // (0, 0) is outside the food spawn area so the server can never
+        // accidentally repair it.
+        let corruption = GameEventMessage {
+            game_id: GAME_ID,
+            tick: world.client().current_tick(),
+            sequence: 0,
+            stream_seq: 0,
+            user_id: None,
+            event: GameEvent::FoodSpawned {
+                position: common::Position { x: 0, y: 0 },
+            },
+        };
+        world
+            .client
+            .as_mut()
+            .expect("client joined")
+            .process_server_event(&corruption)
+            .expect("corruption event applies");
+
+        // Probes run every PROBE_EVERY_TICKS ticks (1 virtual second); give
+        // the heartbeat time for at least two of them.
+        world.run_for(4_000);
+
+        let status = world.client().sync_status();
+        assert_eq!(
+            status.last_probe_matched,
+            Some(false),
+            "TickHash must detect the corrupted food set: {status:?}"
+        );
+        assert!(
+            status.consecutive_hash_mismatches >= 2,
+            "mismatch must persist across probes: {status:?}"
+        );
+        assert!(
+            status.total_mismatches >= 2,
+            "expected repeated mismatches: {status:?}"
+        );
+        assert!(
+            status.first_mismatch_tick.is_some(),
+            "first mismatch tick recorded for RCA"
+        );
+        assert!(
+            status.needs_resync,
+            "2 consecutive mismatches must request a resync"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn prediction_freezes_when_server_goes_silent() -> Result<()> {
+    with_timeout(async {
+        let mut world = SimWorld::new(0xD1CE, TransportConfig::lossless());
+
+        // Healthy phase.
+        world.run_for(10_000);
+        let committed_at_cut = world.client().current_tick();
+        assert!(committed_at_cut > 0, "client should have advanced");
+
+        // Server goes silent: everything in flight is lost, nothing new
+        // arrives. The client keeps animating.
+        world.transport.cut();
+
+        let tick_ms = world.tick_duration_ms();
+        let cap_ticks = ((COMMITTED_LAG_MS + MAX_PREDICTION_AHEAD_MS) as i64 / tick_ms) as u32 + 1;
+
+        world.run_for(5_000);
+        let predicted_after_5s = world.client().get_predicted_tick();
+        let committed_after_5s = world.client().current_tick();
+        assert_eq!(
+            committed_after_5s, committed_at_cut,
+            "committed state must freeze without server messages"
+        );
+        assert!(
+            predicted_after_5s - committed_after_5s <= cap_ticks,
+            "prediction must stay within the cap: predicted {predicted_after_5s}, \
+             committed {committed_after_5s}, cap {cap_ticks}"
+        );
+
+        // 25 more virtual seconds of animation frames: prediction must have
+        // stopped growing entirely.
+        world.run_for(25_000);
+        let predicted_after_30s = world.client().get_predicted_tick();
+        assert_eq!(
+            predicted_after_30s, predicted_after_5s,
+            "prediction must freeze, not creep forward, while the server is silent"
+        );
+        assert!(
+            predicted_after_30s - world.client().current_tick() <= cap_ticks,
+            "cap still holds after 30 silent seconds"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn engine_determinism_across_reruns() -> Result<()> {
+    with_timeout(async {
+        let a = run_lossless_scenario(0xC0FFEE, 7, true);
+        let b = run_lossless_scenario(0xC0FFEE, 7, true);
+
+        assert_eq!(
+            a.published.len(),
+            b.published.len(),
+            "reruns must publish the same number of messages"
+        );
+        for (i, (ea, eb)) in a.published.iter().zip(b.published.iter()).enumerate() {
+            assert_eq!(
+                ea, eb,
+                "published stream diverged between identical reruns at index {i}"
+            );
+        }
+        assert_eq!(
+            a.server.current_tick(),
+            b.server.current_tick(),
+            "server ticks must match across reruns"
+        );
+        assert_eq!(
+            a.server.committed_sync_hash(),
+            b.server.committed_sync_hash(),
+            "final committed hashes must match across reruns"
+        );
+        Ok(())
+    })
+    .await
+}
+
+#[tokio::test]
+async fn late_command_reschedules() -> Result<()> {
+    with_timeout(async {
+        let cfg = TransportConfig {
+            base_latency_ms: 100,
+            jitter_ms: 0,
+            ..TransportConfig::lossless()
+        };
+        let mut world = SimWorld::new(0xABCDEF, cfg);
+        world.auto_resync = true;
+
+        world.run_for(5_000);
+
+        // One command stuck in the network for 800ms — well past the 500ms
+        // committed-lag window the client's optimistic schedule relies on.
+        let late_cmd = world.client_send_turn_with_latency(Direction::Up, 800);
+        world.run_for(2_000);
+
+        let confirmation = world
+            .confirmations
+            .iter()
+            .find(|c| c.command_id_client == late_cmd.command_id_client)
+            .expect("server confirmed the late command");
+        let server_tick = confirmation
+            .command_id_server
+            .as_ref()
+            .expect("server assigned an id")
+            .tick;
+        // The phantom-death mechanism: the client already played the turn at
+        // its requested tick, but the server rescheduled it later — the two
+        // simulations executed the same command at different ticks.
+        assert!(
+            server_tick > late_cmd.command_id_client.tick,
+            "late command must be rescheduled: client tick {}, server tick {}",
+            late_cmd.command_id_client.tick,
+            server_tick
+        );
+
+        // The client must still converge: hash probes flag the divergence,
+        // the resync protocol heals it, and subsequent probes match.
+        world.run_for(20_000);
+        world.drain_and_probe();
+
+        let status = world.client().sync_status();
+        assert_eq!(
+            status.consecutive_hash_mismatches, 0,
+            "divergence must have cleared: {status:?}"
+        );
+        assert_eq!(
+            status.last_probe_matched,
+            Some(true),
+            "final probe must match after recovery: {status:?}"
+        );
+        assert!(!status.needs_resync, "no pending resync at the end");
+        assert_eq!(
+            world.client().committed_sync_hash(),
+            world.server.committed_sync_hash(),
+            "client must converge to the server state"
+        );
+        Ok(())
+    })
+    .await
+}

--- a/terminal/examples/render_demo.rs
+++ b/terminal/examples/render_demo.rs
@@ -20,6 +20,7 @@ fn main() {
                 direction: Direction::Up,
                 is_alive: true,
                 food: 0,
+                team_id: None,
             },
             Snake {
                 body: vec![
@@ -29,6 +30,7 @@ fn main() {
                 direction: Direction::Right,
                 is_alive: true,
                 food: 0,
+                team_id: None,
             },
             Snake {
                 body: vec![
@@ -38,6 +40,7 @@ fn main() {
                 direction: Direction::Down,
                 is_alive: true,
                 food: 0,
+                team_id: None,
             },
         ],
         food: vec![
@@ -45,6 +48,7 @@ fn main() {
             Position { x: 2, y: 2 },
             Position { x: 17, y: 8 },
         ],
+        team_zone_config: None,
     };
 
     println!("=== 1x1 Rendering (Classic) ===");

--- a/terminal/tests/render_test.rs
+++ b/terminal/tests/render_test.rs
@@ -8,7 +8,7 @@ use terminal::render::{
 #[test]
 fn test_2x1_rendering() {
     // Create a simple arena with one snake and one food
-    let mut arena = Arena {
+    let arena = Arena {
         width: 10,
         height: 10,
         snakes: vec![Snake {
@@ -19,8 +19,10 @@ fn test_2x1_rendering() {
             direction: Direction::Right,
             is_alive: true,
             food: 0,
+            team_id: None,
         }],
         food: vec![Position { x: 7, y: 7 }],
+        team_zone_config: None,
     };
 
     // Create renderer with 2x1 configuration
@@ -63,8 +65,10 @@ fn test_1x1_rendering() {
             direction: Direction::Right,
             is_alive: true,
             food: 0,
+            team_id: None,
         }],
         food: vec![Position { x: 3, y: 3 }],
+        team_zone_config: None,
     };
 
     // Create renderer with 1x1 configuration
@@ -101,6 +105,7 @@ fn test_custom_dimensions() {
         height: 3,
         snakes: vec![],
         food: vec![Position { x: 1, y: 1 }],
+        team_zone_config: None,
     };
 
     let char_dims = CharDimensions::new(3, 2);

--- a/terminal/tests/replay_player_test.rs
+++ b/terminal/tests/replay_player_test.rs
@@ -19,8 +19,8 @@ fn test_replay_player_with_tick_forward() -> Result<()> {
         Some(12345),
         start_ms,
     );
-    initial_state.add_player(1)?;
-    initial_state.add_player(2)?;
+    initial_state.add_player(1, None)?;
+    initial_state.add_player(2, None)?;
     initial_state.status = GameStatus::Started { server_id: 1 };
 
     // Create replay data
@@ -71,6 +71,7 @@ fn test_replay_player_with_tick_forward() -> Result<()> {
             game_id: 1,
             tick: 1,
             sequence: 1,
+            stream_seq: 0,
             user_id: Some(1),
             event: GameEvent::CommandScheduled {
                 command_message: command_msg,
@@ -86,6 +87,7 @@ fn test_replay_player_with_tick_forward() -> Result<()> {
             game_id: 1,
             tick: 3,
             sequence: 2,
+            stream_seq: 0,
             user_id: None,
             event: GameEvent::SnakeTurned {
                 snake_id: 0,


### PR DESCRIPTION
## What this is

Prod showed three state-sync symptoms — phantom wall deaths, drift so bad that periodic snapshots were the only workaround, and ghost games that kept running after the backend stopped (even in solo games). Rather than patching symptoms, this PR builds the debugging infrastructure that makes this bug class observable, reproducible, and self-healing — and the process of building it found and fixed the actual root causes.

**Start with [DEBUGGING.md](DEBUGGING.md)** — it documents the four sync primitives, the prod-debug runbook (trace → `trace_rca` → local repro test), the full root-cause inventory, and the postmortem on why none of this was caught before deploy.

## The infrastructure

- **State fingerprints + TickHash heartbeat** — the server broadcasts a 64-bit digest of its authoritative state ~1/s. Clients compare against their own committed state: divergence is detected within a second instead of never. Doubles as the liveness signal and a clock reference.
- **`stream_seq` transport sequencing** — every published message carries an executor-assigned monotonic sequence. Gaps (Redis pub/sub is at-most-once) trigger automatic snapshot resyncs at the replica and the client. This replaces the removed periodic-snapshot band-aid with resyncs that only happen when something was actually lost.
- **Flight recorders** — every server game appends a crash-safe JSONL trace (initial state including RNG seed, every command, every published message, fingerprints). The web client keeps a ring buffer, auto-uploads on the first detected desync, and exposes `window.snaketronDebug.downloadTrace()`.
- **`trace_rca` CLI** — replays captured traces deterministically through the real engine, cross-diffs the server and client perspectives, reports the first divergent tick / missing message ranges / per-command scheduling deltas / clock drift, prints a verdict (`TRANSPORT_LOSS` / `ENGINE_NONDETERMINISM` / `CLOCK_DRIFT` / `IN_SYNC`), and can emit a repro test (`--emit-test`) that freezes a prod bug as a local failing test.
- **Chaos suite** (`sync_equivalence_test.rs`) — drives a simulated client over a lossy/latent/jittery in-process transport and asserts hash equality, gap detection, resync, prediction freeze, and determinism. These are the tests that would have caught everything below before prod.

## Root causes fixed (each confirmed by an adversarial verification panel)

1. **Off-by-one event phase** — events were labeled with the pre-step tick, so clients applied movement effects (FoodEaten, SnakeDied…) one movement-step early, permanently forking body geometry. Found *empirically* when the replay harness's lossless-equivalence test failed. Events now carry post-step ticks.
2. **Transport task-death** — one tokio broadcast `Lagged` or one malformed payload permanently killed a partition's entire event/command feed (silent `?` propagation). Now logged and skipped; gap detection heals the loss downstream.
3. **Replica single-tick catch-up** (`if` vs `while`) — every mid-game join snapshot was geometrically corrupt. Plus a subscribe-before-read race that could silently drop events at join time.
4. **clockSync reset on reconnect** — snapped the time base by the full drift and could poison the command-tick ratchet so the snake stopped responding; drift now carries across reconnects and the ratchet is bounded.
5. **HashSet iteration nondeterminism** in multi-death processing (native vs WASM divergence) — deaths now processed in sorted order.
6. **No liveness anywhere** — the client free-ran on wall clock forever. Now: hard prediction cap in the engine plus a reconnect overlay with backed-off resync requests.

Known and documented, not fixed: commands arriving past the 500 ms committed-lag window get rescheduled later than the player saw them (inherent to the netcode model; now *measured* per-command by trace_rca rather than invisible).

## Executor failover

Previously a single Redis blip cancelled every running game permanently, and a health-check edge case could leave two servers running the same game. Now: 3 s lease with a split-brain-safe grace window for transient renewal errors (safety argument unit-tested), Lua own-lease reclaim, stored snapshots refreshed ~1/s, and full game resume on executor (re)start from replica or stored-snapshot state — which also recovers games whose `GameCreated` message was lost. Snapshots re-anchor `stream_seq` watermarks at every hop so a restarted executor's fresh stream is adopted instead of filtered as stale.

## Test-suite repair

`solo_game_test`, `duel_game_test`, `simple_game_test`, and the terminal crate's tests **did not compile on master** — dead coverage, and a big part of why these bugs shipped. All repaired and passing, plus a compile-only CI job (`cargo test --all --no-run`) so test binaries can never silently rot out of coverage again.

## Reviewer notes

- The wire format change (`stream_seq` field, `TickHash` event) is serde-default/backward-compatible; old messages parse fine.
- Event tick labels changed semantics (post-step): old recorded replays will be off by one tick when replayed.
- Integration tests share Redis with the dev stack; run them serially and stop the `snaketron-server` container first (pub/sub channels are global across Redis DBs — a live dev server cross-talks with tests).
- Verified: workspace builds clean, common 31/31, server lib 22/22, chaos 6/6, resume/failover tests, terminal 6/6, repaired game-flow tests 3/3 (serial), `tsc --noEmit` clean, WASM target builds, fmt/clippy clean on touched files.
- Observation for a future decision (not changed here): FFA/solo games always complete with `winning_snake_id: None`; only team games compute a winner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Addendum: configurable game bus — Redis Streams by default

A second commit replaces the game-critical transport with a configurable bus (`SNAKETRON_BUS=streams|pubsub`, **streams is the default**; chat/lobby fan-out stays on Pub/Sub). See [STREAMS_MIGRATION.md](STREAMS_MIGRATION.md) for the assessment, the git archaeology explaining why the 2025 Streams attempt was slow (blocking XREADs multiplexed on shared connections — not a property of Streams), and the rollout constraint (flip the fleet at once; mixed transports partition traffic).

Highlights:
- Ordered, trimmed, replayable log per partition: reconnects resume from the last-delivered ID (zero loss, verified by a `CLIENT KILL` test); slow consumers get backpressure instead of drops (verified with a 3000-message paused-consumer test); the `stream_seq` resync machinery becomes defense-in-depth rather than load-bearing.
- Measured latency parity with Pub/Sub: p50 1.3 ms / p99 3.6 ms vs 1.1/3.4 (the 2025 attempt was 340–900 ms), gated by a regression test.
- Hardened via adversarial review: synchronous stream anchoring (never `"$"` in the XREAD loop), `-LOADING`-safe anchor resolution (prevents full-history replay resurrecting completed games), trim-horizon loss detection, shutdown-aware backpressure.
- CI runs the full server suite as a matrix over both transports; 74/74 pass under each.
