### PR TITLE
Stabilize game_load_failure_tests: fix test race + executor completion-race guard

### DIFF
--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -717,6 +717,28 @@ pub async fn run_game_executor(
             );
         }
         for (game_id, game_state) in resumable {
+            // Completion-race guard: the durable store may already hold this
+            // game's terminal state while Redis still has the immediately
+            // preceding active snapshot (the previous executor died between
+            // persisting completion and the snapshot expiring). Resuming
+            // would resurrect a finished game and could re-complete it with
+            // a different outcome, so the durable verdict wins. DB errors
+            // fall through to resume: dropping a live game is worse than
+            // briefly resurrecting a finished one.
+            match db.get_game_by_id(game_id as i32).await {
+                Ok(Some(game)) if game.status == "complete" => {
+                    info!(
+                        "Partition {} not resuming game {}: durable store already records completion",
+                        partition_id, game_id
+                    );
+                    continue;
+                }
+                Ok(_) => {}
+                Err(e) => warn!(
+                    "Resume guard could not check durable state for game {}: {}",
+                    game_id, e
+                ),
+            }
             try_start_game(
                 game_id,
                 game_state,

--- a/server/tests/game_load_failure_tests.rs
+++ b/server/tests/game_load_failure_tests.rs
@@ -328,6 +328,11 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
     let mut live_state = completed_game_state(player_user_id as u32)?;
     live_state.status = GameStatus::Started { server_id };
     live_state.event_sequence = 17;
+    // completed_game_state backdates start_ms by 10s. An executor that adopts
+    // this orphaned Started game would catch up that whole backlog at once and
+    // could even complete the game mid-test, so anchor the game to now to keep
+    // any progression incremental.
+    live_state.start_ms = chrono::Utc::now().timestamp_millis();
 
     let redis_url = std::env::var("SNAKETRON_REDIS_URL")?;
     let redis_client = redis::Client::open(redis_url)?;
@@ -368,8 +373,21 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
 
     let loaded_state = receive_snapshot(&mut client).await?;
     assert_eq!(loaded_state.start_ms, live_state.start_ms);
-    assert_eq!(loaded_state.event_sequence, live_state.event_sequence);
-    assert_eq!(loaded_state.status, live_state.status);
+    // The failover-safe executor may adopt the orphaned Started game and
+    // advance it between the publish above and delivery, so the first
+    // snapshot the client sees can be at or past the published sequence —
+    // but never behind it, and never a load failure or a stale state.
+    assert!(
+        loaded_state.event_sequence >= live_state.event_sequence,
+        "client received a snapshot older than the published replica state: {} < {}",
+        loaded_state.event_sequence,
+        live_state.event_sequence
+    );
+    assert!(
+        matches!(loaded_state.status, GameStatus::Started { .. }),
+        "expected a live Started snapshot, got {:?}",
+        loaded_state.status
+    );
 
     let _: usize = redis.del(snapshot_key).await?;
     client.disconnect().await?;


### PR DESCRIPTION
## What changed

Fixes the two flakiest tests in CI (`game_load_failure_tests`), which have been intermittently failing both this repo's test matrix and the snaketron-io deploy gate. One is a test-side race; the other exposed a real product race in the failover-safe executor.

### 1. Test fix: `initial_join_waits_for_the_live_replica_after_executor_snapshot_storage`
Asserted exact equality with a hand-crafted snapshot (`event_sequence = 17`) published mid-race, but an adopting executor advances the game — the first snapshot the client sees is frequently past the published sequence (19 locally, 36 on GitHub runners). Now anchors `start_ms` to now (no 10s catch-up burst) and asserts the invariant instead: sequence `>=` published, status `Started`, never a load failure.

### 2. Product fix: executor resume could resurrect completed games
The partition-executor resume scan trusted the Redis snapshot's status alone. In the completion race (durable store already terminal, Redis still holding the immediately preceding active snapshot), a (re)starting executor resurrected the finished game and could **re-complete it with a different outcome** — observed in CI as a durably saved `Complete{Some(0)}` solo game re-completed as `Complete{None}` and served to a rejoining client.

The resume loop now checks the durable record and skips games already marked complete. DB errors fall through to resume (dropping a live game is worse than briefly resurrecting a finished one).

This is why `joining_a_durably_saved_completed_game_returns_its_final_snapshot` was flaky: whether the game's partition executor acquired its lease before or after the test wrote the stale snapshot was a timing lottery (partition = uuid-based game id mod 10), and slow CI runners lose it often.

## Verification
- `game_load_failure_tests`: 5 consecutive full-binary runs green (previously ~1-in-3 failure rate)
- `initial_join_waits...`: 6 isolated runs + 3 under 8-way CPU load, all green
- `executor_resume_test` and the `sync_equivalence_test` chaos suite (the sync regression barrier): green
- clippy `-D warnings` and fmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)