### PR TITLE
Fix enemy-respawn desync: lossless client event delivery

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -158,10 +158,11 @@ gaps mean engine nondeterminism — page someone.
 
 ## Root causes found and fixed (2026-07)
 
-Thirteen distinct defects were confirmed by a multi-agent audit (each verified
-by an independent 3-lens panel against the code). The fixes landed together
-with this infrastructure; the chaos suite and the replay harness lock each one
-in:
+Fourteen distinct defects have been confirmed — the first thirteen by a
+multi-agent audit (each verified by an independent 3-lens panel against the
+code), the fourteenth from the enemy-snake respawn-desync report. The fixes
+landed together with this infrastructure; the chaos suite and the replay
+harness lock each one in:
 
 | Defect | Fix |
 |---|---|
@@ -176,6 +177,7 @@ in:
 | One clock spike poisoned `last_command_tick` forever — all later commands scheduled in the far future (snake stops responding) | Ratchet bounded to predicted + 8 ticks ([game_engine.rs](common/src/game_engine.rs)) |
 | `HashSet` iteration order made multi-death respawn processing nondeterministic across native/WASM | Deaths processed in sorted order ([game_state.rs](common/src/game_state.rs)) |
 | Redis PING timeout `?`-exited the cluster singleton without stopping the service — zombie executor + split-brain duplicate games | Timeout takes the step-down path ([cluster_singleton.rs](server/src/cluster_singleton.rs)) |
+| The web UI delivered every WS game event to the engine through a single-slot React state (`lastGameEvent`); React's last-write-wins batching silently dropped events whenever two frames landed in one commit. A crash tick is exactly such a burst (`SnakeDied` + `SnakeRespawned` + score updates as adjacent frames): with `SnakeRespawned` dropped, the delivered `SnakeDied` re-kills the snake the client's committed catch-up had already respawned locally, and nothing revives it until the stream-gap snapshot resync — the "enemy vanishes on crash, reappears mid-screen seconds later" report. Per-event full-state `console.log` serialization amplified the trigger by stalling the main thread | Game events now flow through a lossless ref-based FIFO drained strictly in order ([useGameWebSocket.ts](client/web/hooks/useGameWebSocket.ts), [GameArena.tsx](client/web/components/GameArena.tsx)); the state-serializing debug logging is gone ([useGameEngine.ts](client/web/hooks/useGameEngine.ts)); the failure shape (respawn lost, death delivered) is frozen in `lost_enemy_respawn_is_detected_and_healed_by_resync` ([sync_equivalence_test.rs](server/tests/sync_equivalence_test.rs)) |
 | Executor lease loss cancelled every in-flight game permanently; a lost `GameCreated` message meant a game that never started | Full failover path: 3 s lease with a 60 % grace window for *transient* renewal errors (a Redis blip no longer cancels games — safety proof in `renew_error_should_step_down`), Lua own-lease reclaim after blips, stored snapshots refreshed at TickHash cadence, and `resume_partition_games` on executor (re)start restarts every non-complete game from replica or stored-snapshot state. Snapshots re-anchor `stream_seq` watermarks at every hop (`FilteredEventReceiver`, replica, client), so a restarted executor's new stream is adopted instead of filtered as stale ([game_executor.rs](server/src/game_executor.rs), [cluster_singleton.rs](server/src/cluster_singleton.rs), [replication.rs](server/src/replication.rs)) |
 
 Known, intentionally unfixed (documented behavior):

--- a/client/web/components/GameArena.tsx
+++ b/client/web/components/GameArena.tsx
@@ -23,14 +23,15 @@ export default function GameArena() {
   const containerRef = useRef<HTMLDivElement>(null);
   const joinedGameIdRef = useRef<string | null>(null);
   const previousGameIdRef = useRef<string | null>(null);
-  const processedGameEventRef = useRef<any | null>(null);
+  const drainingGameEventsRef = useRef(false);
   
   const {
     connected,
     currentGameId,
     sendGameCommand,
     joinGame,
-    lastGameEvent,
+    gameEventSignal,
+    takeGameEvents,
     gameLoadFailure,
     awaitingGameSnapshotForId,
     isGameSnapshotSynchronized,
@@ -478,29 +479,39 @@ export default function GameArena() {
     };
   }, [gameState, cellSize, rotation, user?.id]);
   
-  // Process server events through game engine
+  // Process server events through the game engine. Events arrive via a
+  // lossless queue (see useGameWebSocket): a single signal bump may cover
+  // several queued messages, so drain until empty, strictly in arrival
+  // order. Skipping or reordering even one message (e.g. the SnakeRespawned
+  // that follows a SnakeDied in the same tick) forks the committed state
+  // until a snapshot resync heals it.
   useEffect(() => {
-    if (
-      lastGameEvent &&
-      processServerEvent &&
-      processedGameEventRef.current !== lastGameEvent
-    ) {
-      processedGameEventRef.current = lastGameEvent;
-      console.log('Processing server event in GameArena:', lastGameEvent);
-      void processServerEvent(lastGameEvent).then((processed) => {
-        const event = lastGameEvent.event || lastGameEvent;
-        if (!processed || !event?.Snapshot) {
-          return;
-        }
-
-        const snapshotGameId = parseU32GameId(lastGameEvent.game_id);
-
-        if (snapshotGameId !== null) {
-          acknowledgeGameSnapshot(snapshotGameId);
-        }
-      });
+    if (!processServerEvent || drainingGameEventsRef.current) {
+      return;
     }
-  }, [lastGameEvent, processServerEvent, acknowledgeGameSnapshot]);
+    drainingGameEventsRef.current = true;
+    void (async () => {
+      try {
+        let events = takeGameEvents();
+        while (events.length > 0) {
+          for (const eventMessage of events) {
+            const processed = await processServerEvent(eventMessage);
+            const event = eventMessage.event || eventMessage;
+            if (processed && event?.Snapshot) {
+              const snapshotGameId = parseU32GameId(eventMessage.game_id);
+              if (snapshotGameId !== null) {
+                acknowledgeGameSnapshot(snapshotGameId);
+              }
+            }
+          }
+          // Pick up anything that arrived while we were processing.
+          events = takeGameEvents();
+        }
+      } finally {
+        drainingGameEventsRef.current = false;
+      }
+    })();
+  }, [gameEventSignal, takeGameEvents, processServerEvent, acknowledgeGameSnapshot]);
   
   // Update countdown display
   useEffect(() => {

--- a/client/web/hooks/useGameEngine.ts
+++ b/client/web/hooks/useGameEngine.ts
@@ -111,72 +111,10 @@ export const useGameEngine = ({
       const clockDrift = getClockDrift();
       const now = BigInt(Date.now() - Math.round(clockDrift));
       
-      // Run engine until current time
-      const lastTick = engineRef.current.getPredictedTick()
+      // Run engine until current time. Keep this loop lean: main-thread
+      // stalls delay WS message handling and can batch several server
+      // events into one React commit.
       engineRef.current.rebuildPredictedState(now);
-      const currentTick = engineRef.current.getPredictedTick();
-
-      if (currentTick !== lastTick) {
-        console.log("predicted tick changed", lastTick, "→", currentTick);
-        console.log(JSON.parse(engineRef.current.getGameStateJson()).arena.snakes[0]);
-
-        // Get both committed and predicted states
-        const committedStateJson = engineRef.current.getCommittedStateJson();
-        const predictedStateJson = engineRef.current.getGameStateJson();
-        const eventLogJson = engineRef.current.getEventLogJson();
-
-        // Parse the states
-        const committedState = JSON.parse(committedStateJson);
-        const predictedState = JSON.parse(predictedStateJson);
-        const eventLog = JSON.parse(eventLogJson);
-        
-        // Extract snake positions (deep clone)
-        const committedSnakes = JSON.parse(JSON.stringify(
-          committedState.arena.snakes.map((snake: any, idx: number) => ({
-            index: idx,
-            is_alive: snake.is_alive,
-            direction: snake.direction,
-            body: snake.body.slice(0, 5), // First 5 positions for brevity
-            length: snake.body.length
-          }))
-        ));
-        
-        const predictedSnakes = JSON.parse(JSON.stringify(
-          predictedState.arena.snakes.map((snake: any, idx: number) => ({
-            index: idx,
-            is_alive: snake.is_alive,
-            direction: snake.direction,
-            body: snake.body.slice(0, 5), // First 5 positions for brevity
-            length: snake.body.length
-          }))
-        ));
-        
-        // Extract pending commands from event log
-        const pendingCommands = JSON.parse(JSON.stringify(
-          eventLog
-            .filter((event: any) => event.event.CommandScheduled)
-            .map((event: any) => ({
-              tick: event.tick,
-              user_id: event.user_id,
-              command: event.event.CommandScheduled.command_message.command
-            }))
-        ));
-        
-        // Log the detailed state
-        // console.log(
-        //   `${new Date().toISOString()} Game State Update\n` +
-        //   `Tick: ${lastTick} → ${currentTick}\n` +
-        //   `Now: ${(Number(now))} (clock drift: ${clockDrift} ms)\n` +
-        //   `\n--- COMMITTED STATE (tick ${committedState.tick}, start_ms ${committedState.start_ms}) ---\n` +
-        //   `Snakes: ${JSON.stringify(committedSnakes, null, 2)}\n` +
-        //   `Command queue: ${JSON.stringify(committedState.command_queue, null, 2)}\n` +
-        //   `\n--- PREDICTED STATE (tick ${predictedState.tick}, start_ms ${predictedState.start_ms}) ---\n` +
-        //   `Snakes: ${JSON.stringify(predictedSnakes, null, 2)}\n` +
-        //   `Command queue: ${JSON.stringify(predictedState.command_queue, null, 2)}\n` +
-        //   `\n--- PENDING COMMANDS ---\n` +
-        //   `${pendingCommands.length > 0 ? JSON.stringify(pendingCommands, null, 2) : 'None'}\n`
-        // );
-      }
 
       // Update game state
       const stateJson = engineRef.current.getGameStateJson();
@@ -482,24 +420,9 @@ export const useGameEngine = ({
       });
 
       if (engineRef.current) {
-        console.log('Processing server event:', fullEventMessage);
-
-        // // DEBUG: Log XPAwarded events specifically
-        // if (fullEventMessage.event && 'XPAwarded' in fullEventMessage.event) {
-        //   console.log('🎯 Received XPAwarded event:', fullEventMessage.event.XPAwarded);
-        // }
-
         if (!isSnapshot) {
           engineRef.current.processServerEvent(JSON.stringify(fullEventMessage));
         }
-
-        // DEBUG: Log state after processing XPAwarded
-        // if (fullEventMessage.event && 'XPAwarded' in fullEventMessage.event) {
-        //   const committedState = JSON.parse(engineRef.current.getCommittedStateJson());
-        //   console.log('🎯 After processing XPAwarded, committed state player_xp:', committedState.player_xp);
-        // }
-
-        console.log('Current game status:', engineRef.current.getCommittedStateJson());
 
         if (isSnapshot) {
           // Synchronize React state before the caller dismisses its awaiting-snapshot overlay.

--- a/client/web/hooks/useGameWebSocket.ts
+++ b/client/web/hooks/useGameWebSocket.ts
@@ -10,7 +10,10 @@ interface UseGameWebSocketReturn {
   currentGameId: string | null;
   customGameCode: string | null;
   isHost: boolean;
-  lastGameEvent: any | null;
+  /** Bumped whenever new game events are queued; consumers drain with takeGameEvents. */
+  gameEventSignal: number;
+  /** Returns every queued game event in arrival order and empties the queue. */
+  takeGameEvents: () => any[];
   gameLoadFailure: GameLoadFailure | null;
   awaitingGameSnapshotForId: string | null;
   isGameSnapshotSynchronized: boolean;
@@ -40,7 +43,14 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
   const [currentGameId, setCurrentGameId] = useState<string | null>(null);
   const [customGameCode, setCustomGameCode] = useState<string | null>(null);
   const [isHost, setIsHost] = useState(false);
-  const [lastGameEvent, setLastGameEvent] = useState<any | null>(null);
+  // Game events are queued in a ref and drained by the consumer. Delivering
+  // them through a single useState slot loses events when React batches
+  // multiple WS frames into one commit (last write wins) — a crash tick's
+  // SnakeDied/SnakeRespawned burst is exactly such a case, and a dropped
+  // event forces a stream-gap resync. The state below is only a wake-up
+  // signal; the queue itself is lossless and ordered.
+  const gameEventQueueRef = useRef<any[]>([]);
+  const [gameEventSignal, setGameEventSignal] = useState(0);
   const [gameLoadFailure, setGameLoadFailure] = useState<GameLoadFailure | null>(null);
   const [awaitingGameSnapshotForId, setAwaitingGameSnapshotForId] = useState<string | null>(null);
   const [isGameSnapshotSynchronized, setIsGameSnapshotSynchronized] = useState(false);
@@ -61,6 +71,12 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     setIsGameSnapshotSynchronized(isSynchronized);
   }, []);
 
+  const takeGameEvents = useCallback(() => {
+    const events = gameEventQueueRef.current;
+    gameEventQueueRef.current = [];
+    return events;
+  }, []);
+
   // Handle game-specific messages
   useEffect(() => {
     const unsubscribers: (() => void)[] = [];
@@ -70,8 +86,6 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     // Game events (including game state updates)
     unsubscribers.push(
       onMessage('GameEvent', (message: any) => {
-        console.log('Received GameEvent message:', message);
-        
         // The message contains the full GameEventMessage from the server
         const eventMessage = message.GameEvent || message.data || message;
         
@@ -118,8 +132,11 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
           return;
         }
         
-        // Store the full event message (including tick) for the game engine to process
-        setLastGameEvent(eventMessage);
+        // Queue the full event message (including tick) for the game engine
+        // to process, and wake the consumer. Never deliver via a state slot
+        // directly: coalesced commits would silently drop events.
+        gameEventQueueRef.current.push(eventMessage);
+        setGameEventSignal((n) => n + 1);
         
         // Handle different event types
         // if (event.Snapshot) {
@@ -338,7 +355,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     if (parsedGameId === null) {
       requestedGameRef.current = null;
       updateGameSnapshotSynchronization(false);
-      setLastGameEvent(null);
+      gameEventQueueRef.current = [];
       updateAwaitingGameSnapshot(null);
       setIsJoiningGame(false);
       setGameLoadFailure({
@@ -355,7 +372,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     };
     updateGameSnapshotSynchronization(false);
     setCurrentGameId(parsedGameId.toString());
-    setLastGameEvent(null);
+    gameEventQueueRef.current = [];
     setGameLoadFailure(null);
     updateAwaitingGameSnapshot(gameId);
     setIsJoiningGame(true);
@@ -471,7 +488,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     requestedGameRef.current = null;
     serverAssignedGameRef.current = null;
     updateGameSnapshotSynchronization(false);
-    setLastGameEvent(null);
+    gameEventQueueRef.current = [];
     updateAwaitingGameSnapshot(null);
     setCurrentGameId(null);
     setIsHost(false);
@@ -510,7 +527,8 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     currentGameId,
     customGameCode,
     isHost,
-    lastGameEvent,
+    gameEventSignal,
+    takeGameEvents,
     gameLoadFailure,
     awaitingGameSnapshotForId,
     isGameSnapshotSynchronized,

--- a/server/tests/sync_equivalence_test.rs
+++ b/server/tests/sync_equivalence_test.rs
@@ -229,6 +229,14 @@ struct SimWorld {
     ever_needed_resync: bool,
     auto_resync: bool,
     resync_in_flight: bool,
+    /// When set, the first `SnakeRespawned` for snake 1 (the enemy from the
+    /// client's perspective) is dropped at publish time while still consuming
+    /// its stream_seq — modeling a failed executor publish or a client-side
+    /// delivery drop of exactly that message. The paired `SnakeDied` is
+    /// delivered normally.
+    drop_first_enemy_respawn: bool,
+    /// (tick, stream_seq) of the dropped respawn, once it happened.
+    dropped_respawn: Option<(u32, u64)>,
 }
 
 impl SimWorld {
@@ -270,6 +278,8 @@ impl SimWorld {
             ever_needed_resync: false,
             auto_resync: false,
             resync_in_flight: false,
+            drop_first_enemy_respawn: false,
+            dropped_respawn: None,
         };
 
         // Initial snapshot at t0, the way a client join does (stream_seq 1).
@@ -283,6 +293,13 @@ impl SimWorld {
 
     fn publish(&mut self, tick: u32, sequence: u64, event: GameEvent) {
         self.stream_seq += 1;
+        if self.drop_first_enemy_respawn
+            && self.dropped_respawn.is_none()
+            && matches!(event, GameEvent::SnakeRespawned { snake_id: 1, .. })
+        {
+            self.dropped_respawn = Some((tick, self.stream_seq));
+            return;
+        }
         if self.record_published {
             self.published.push((
                 tick,
@@ -707,6 +724,90 @@ async fn targeted_event_loss_detected_by_tickhash() -> Result<()> {
         assert!(
             status.needs_resync,
             "2 consecutive mismatches must request a resync"
+        );
+        Ok(())
+    })
+    .await
+}
+
+/// The enemy-respawn desync shape: at a TeamMatch crash tick the engine emits
+/// `SnakeDied` and `SnakeRespawned` as two adjacent messages. If exactly the
+/// respawn is lost (failed executor publish, or a client-side delivery drop),
+/// the delivered `SnakeDied` re-kills the snake the client's committed
+/// catch-up had already respawned locally — and nothing short of a snapshot
+/// ever revives it: the enemy stays dead on that client while it keeps
+/// playing on the server. The client must (a) detect the loss via the
+/// stream_seq gap and (b) fully converge after the resync snapshot.
+#[tokio::test]
+async fn lost_enemy_respawn_is_detected_and_healed_by_resync() -> Result<()> {
+    with_timeout(async {
+        let mut world = SimWorld::new(0xE5CA9E, TransportConfig::lossless());
+        world.drop_first_enemy_respawn = true;
+
+        // Passive snakes crash and respawn organically; run until the enemy's
+        // first respawn has been dropped at publish time.
+        let mut waited_ms = 0;
+        while world.dropped_respawn.is_none() && waited_ms < 60_000 {
+            world.run_for(1_000);
+            waited_ms += 1_000;
+        }
+        let (drop_tick, drop_seq) = world
+            .dropped_respawn
+            .expect("enemy snake should crash and respawn within 60 virtual seconds");
+
+        // Let the following messages arrive: the gap after the consumed
+        // stream_seq must be detected, and the divergence window — enemy
+        // alive on the server, dead on the client — must be observable.
+        world.run_for(1_000);
+        assert!(
+            world.server.committed_state().arena.snakes[1].is_alive,
+            "server-side enemy must be alive after its respawn at tick {drop_tick}"
+        );
+        assert!(
+            !world.client().committed_state().arena.snakes[1].is_alive,
+            "client-side enemy must be stranded dead after the lost respawn \
+             (seq {drop_seq}): the delivered SnakeDied re-kills the locally \
+             respawned snake and nothing else revives it"
+        );
+        let status = world.client().sync_status();
+        assert!(
+            status.stream_gap_count >= 1,
+            "the consumed-but-undelivered stream_seq must surface as a gap: {status:?}"
+        );
+        assert!(
+            status.needs_resync,
+            "a gap means the committed state can no longer be trusted: {status:?}"
+        );
+
+        // The resync protocol (debounced in the real UI) heals it.
+        let probes_before_resync = world.probe_log.len();
+        world.request_resync();
+        world.run_for(5_000);
+        world.drain_and_probe();
+
+        let status = world.client().sync_status();
+        assert!(
+            !status.needs_resync,
+            "snapshot must clear needs_resync: {status:?}"
+        );
+        let post_resync: Vec<ProbeResult> = world.probe_log[probes_before_resync..].to_vec();
+        assert!(
+            !post_resync.is_empty(),
+            "expected probes after the resync snapshot"
+        );
+        assert!(
+            post_resync.iter().all(|p| p.matched),
+            "probes after resync must match again: {post_resync:?}"
+        );
+        assert_eq!(
+            world.client().committed_state().arena.snakes[1].is_alive,
+            world.server.committed_state().arena.snakes[1].is_alive,
+            "enemy liveness must agree after the resync"
+        );
+        assert_eq!(
+            world.client().committed_sync_hash(),
+            world.server.committed_sync_hash(),
+            "resynced client must converge to the server state"
         );
         Ok(())
     })


### PR DESCRIPTION
## Problem

When an enemy snake crashed and respawned, it disappeared from other players' screens for several seconds, then reappeared mid-screen.

## Root cause

The web client delivered every WebSocket game event to the engine through a single React state slot (`lastGameEvent` in `useGameWebSocket.ts`, consumed by an effect in `GameArena.tsx`). React state is last-write-wins: when two WS frames land within one commit window, the earlier one is silently lost — there was no queue to recover it.

A crash tick is exactly such a burst: the server publishes `SnakeDied`, `SnakeRespawned`, and score updates as adjacent frames. The fatal split is losing exactly `SnakeRespawned`: the client's committed catch-up re-derives the death and respawn locally (deterministically), but then applies the delivered `SnakeDied` on top — re-killing the just-respawned snake. Nothing in the event model revives a dead snake except a respawn event or a snapshot, so the enemy stayed dead on screen until the stream-gap detector's debounced snapshot resync (~2–3s) restored it wherever it had since moved. Heavy per-event debug logging (serializing the full game state to the console) stalled the main thread and made the batching collapse far more likely.

## Changes

- **`useGameWebSocket.ts`** — game events now flow through a lossless ref-based FIFO; the React state is only a wake-up counter. Queue cleared on join/leave so stale-game events can't leak.
- **`GameArena.tsx`** — the consumer drains the queue strictly in arrival order with a re-entrancy guard, replacing the one-event-per-commit effect (which could also permanently skip an event if processing threw).
- **`useGameEngine.ts`** — removed the per-tick and per-event full-state serialization/logging.
- **`sync_equivalence_test.rs`** — new chaos test `lost_enemy_respawn_is_detected_and_healed_by_resync`: drops exactly the enemy's `SnakeRespawned` while consuming its `stream_seq`, asserts the stranded-dead divergence window occurs (enemy alive on server, dead on client), then asserts gap detection fires and the resync fully converges. Covers the same loss occurring at any hop, not just the React layer.
- **`DEBUGGING.md`** — defect added to the root-causes table.

## Reviewer notes

- All 7 chaos tests pass; `cargo test -p common` and every other server test binary are green; clippy/fmt clean; `tsc --noEmit` and the webpack bundle build pass.
- `lobby_matchmaking_tests` and `matchmaking_integration_tests` fail when run in parallel due to a pre-existing shared-Redis test-isolation issue (all pass with `--test-threads=1`) — unrelated to this change.
- A second, environmental hazard with the same symptom was confirmed during the investigation (a failed executor publish consumes its `stream_seq` with no retry); that hardening is being handled separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)