### PR TITLE
Fix parallel-execution races in the matchmaking test binaries

### DIFF
--- a/server/src/db/dynamodb.rs
+++ b/server/src/db/dynamodb.rs
@@ -1,7 +1,8 @@
 use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use aws_sdk_dynamodb::Client;
-use aws_sdk_dynamodb::error::ProvideErrorMetadata;
+use aws_sdk_dynamodb::error::{ProvideErrorMetadata, SdkError};
+use aws_sdk_dynamodb::operation::create_table::{CreateTableError, CreateTableOutput};
 use aws_sdk_dynamodb::types::{
     AttributeDefinition, AttributeValue, BillingMode, CreateGlobalSecondaryIndexAction,
     GlobalSecondaryIndex, GlobalSecondaryIndexUpdate, KeySchemaElement, KeyType, Projection,
@@ -153,6 +154,37 @@ impl DynamoDatabase {
             DYNAMODB_CONTROL_PLANE_MAX_ATTEMPTS,
             last_observation
         ))
+    }
+
+    /// Completes a CreateTable call. The describe-then-create pattern in the
+    /// create_*_table_if_not_exists functions can lose a race against another
+    /// process bootstrapping the same tables (servers booting together, parallel
+    /// tests); a lost race surfaces as ResourceInUseException and is treated as
+    /// success once the winner's table is ACTIVE.
+    async fn finish_table_creation(
+        &self,
+        table_name: &str,
+        result: Result<CreateTableOutput, SdkError<CreateTableError>>,
+    ) -> Result<()> {
+        match result {
+            Ok(_) => {
+                info!("Created DynamoDB table: {}", table_name);
+                Ok(())
+            }
+            Err(error)
+                if error
+                    .as_service_error()
+                    .is_some_and(|error| error.is_resource_in_use_exception()) =>
+            {
+                debug!(
+                    "Table {} was created concurrently by another process",
+                    table_name
+                );
+                self.wait_for_table_active(table_name).await
+            }
+            Err(error) => Err(error)
+                .with_context(|| format!("Failed to create DynamoDB table {}", table_name)),
+        }
     }
 
     async fn ensure_main_table_ttl_enabled(&self) -> Result<()> {
@@ -423,7 +455,8 @@ impl DynamoDatabase {
             .build()?;
 
         // Create table
-        self.client
+        let result = self
+            .client
             .create_table()
             .table_name(&table_name)
             .attribute_definitions(pk_attr)
@@ -438,11 +471,8 @@ impl DynamoDatabase {
             .global_secondary_indexes(gsi2)
             .billing_mode(BillingMode::PayPerRequest)
             .send()
-            .await
-            .context("Failed to create main table")?;
-
-        info!("Created DynamoDB table: {}", table_name);
-        Ok(())
+            .await;
+        self.finish_table_creation(&table_name, result).await
     }
 
     async fn create_usernames_table_if_not_exists(&self) -> Result<()> {
@@ -482,18 +512,16 @@ impl DynamoDatabase {
             .key_type(KeyType::Hash)
             .build()?;
 
-        self.client
+        let result = self
+            .client
             .create_table()
             .table_name(&table_name)
             .attribute_definitions(username_attr)
             .key_schema(username_key)
             .billing_mode(BillingMode::PayPerRequest)
             .send()
-            .await
-            .context("Failed to create usernames table")?;
-
-        info!("Created DynamoDB table: {}", table_name);
-        Ok(())
+            .await;
+        self.finish_table_creation(&table_name, result).await
     }
 
     async fn create_game_codes_table_if_not_exists(&self) -> Result<()> {
@@ -533,18 +561,16 @@ impl DynamoDatabase {
             .key_type(KeyType::Hash)
             .build()?;
 
-        self.client
+        let result = self
+            .client
             .create_table()
             .table_name(&table_name)
             .attribute_definitions(game_code_attr)
             .key_schema(game_code_key)
             .billing_mode(BillingMode::PayPerRequest)
             .send()
-            .await
-            .context("Failed to create game codes table")?;
-
-        info!("Created DynamoDB table: {}", table_name);
-        Ok(())
+            .await;
+        self.finish_table_creation(&table_name, result).await
     }
 
     async fn generate_id_for_entity(&self, entity_type: &str) -> Result<i32> {
@@ -2397,7 +2423,8 @@ impl DynamoDatabase {
             .build()
             .context("Failed to build GameTypeSeasonIndex GSI for rankings")?;
 
-        self.client
+        let result = self
+            .client
             .create_table()
             .table_name(&table_name)
             .attribute_definitions(pk_attr)
@@ -2408,11 +2435,8 @@ impl DynamoDatabase {
             .global_secondary_indexes(game_type_season_gsi)
             .billing_mode(BillingMode::PayPerRequest)
             .send()
-            .await
-            .context("Failed to create rankings table")?;
-
-        info!("Successfully created rankings table: {}", table_name);
-        Ok(())
+            .await;
+        self.finish_table_creation(&table_name, result).await
     }
 
     async fn create_high_scores_table_if_not_exists(&self) -> Result<()> {
@@ -2583,7 +2607,8 @@ impl DynamoDatabase {
             .build()
             .context("Failed to build GameTypeSeasonIndex GSI")?;
 
-        self.client
+        let result = self
+            .client
             .create_table()
             .table_name(&table_name)
             .attribute_definitions(pk_attr)
@@ -2596,11 +2621,8 @@ impl DynamoDatabase {
             .global_secondary_indexes(game_type_season_gsi)
             .billing_mode(BillingMode::PayPerRequest)
             .send()
-            .await
-            .context("Failed to create high scores table")?;
-
-        info!("Successfully created high scores table: {}", table_name);
-        Ok(())
+            .await;
+        self.finish_table_creation(&table_name, result).await
     }
 }
 

--- a/server/tests/common/test_environment.rs
+++ b/server/tests/common/test_environment.rs
@@ -37,8 +37,9 @@ impl TestEnvironment {
                 .take(8)
                 .collect::<String>()
         );
-        // SAFETY: This is safe in tests because each test runs sequentially with TestEnvironment::new()
-        // being called at the start of the test before any other code accesses DYNAMODB_TABLE_PREFIX
+        // SAFETY: Tests using TestEnvironment must run serially (holding their
+        // binary's TEST_LOCK for the whole test, or --test-threads=1) so that no
+        // other thread reads or writes these process-wide env vars mid-test.
         unsafe {
             std::env::set_var("DYNAMODB_TABLE_PREFIX", &unique_prefix);
             // Use Redis database 1 for tests (tests flush database 1, so server should use it too)

--- a/server/tests/lobby_matchmaking_tests.rs
+++ b/server/tests/lobby_matchmaking_tests.rs
@@ -14,18 +14,19 @@ use tokio::{
 mod common;
 use self::common::{TestClient, TestEnvironment};
 
-use std::sync::Once;
 use tracing_subscriber::{EnvFilter, fmt};
 
-static INIT_TRACING: Once = Once::new();
+// Serializes the tests in this binary: TestEnvironment::new() sets process-wide
+// env vars (DYNAMODB_TABLE_PREFIX, SNAKETRON_REDIS_URL) and flushes the shared
+// Redis test database, so concurrently running tests corrupt each other.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 pub fn init_tracing() {
-    INIT_TRACING.call_once(|| {
-        fmt()
-            // allow configuring via RUST_LOG, e.g. RUST_LOG=trace
-            .with_env_filter(EnvFilter::from_default_env())
-            .init();
-    });
+    // try_init: another test may have already installed the global subscriber.
+    let _ = fmt()
+        // allow configuring via RUST_LOG, e.g. RUST_LOG=trace
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init();
 }
 
 fn test_redis_url() -> String {
@@ -263,6 +264,7 @@ async fn age_single_queued_lobby(
 
 #[tokio::test]
 async fn test_multi_member_lobby_queues_solo_host_only_player() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_multi_member_lobby_solo_host_only_player").await?;
@@ -340,6 +342,7 @@ async fn test_multi_member_lobby_queues_solo_host_only_player() -> Result<()> {
 
 #[tokio::test]
 async fn test_two_player_lobby_creates_1v1_with_split_teams() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_two_player_lobby_1v1_split").await?;
@@ -372,6 +375,7 @@ async fn test_two_player_lobby_creates_1v1_with_split_teams() -> Result<()> {
 
 #[tokio::test]
 async fn test_two_single_lobbies_create_1v1() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_two_single_lobbies_1v1").await?;
@@ -416,6 +420,7 @@ async fn test_two_single_lobbies_create_1v1() -> Result<()> {
 
 #[tokio::test]
 async fn test_single_lobby_waits_for_1v1_match() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_single_lobby_waits_1v1").await?;
     env.add_server().await?;
@@ -460,6 +465,7 @@ async fn test_single_lobby_waits_for_1v1_match() -> Result<()> {
 
 #[tokio::test]
 async fn test_two_player_lobbies_create_2v2_same_team() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_two_player_lobbies_2v2").await?;
     env.add_server().await?;
@@ -506,6 +512,7 @@ async fn test_two_player_lobbies_create_2v2_same_team() -> Result<()> {
 
 #[tokio::test]
 async fn test_three_plus_one_lobbies_create_2v2() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_three_plus_one_2v2").await?;
     env.add_server().await?;
@@ -551,6 +558,7 @@ async fn test_three_plus_one_lobbies_create_2v2() -> Result<()> {
 
 #[tokio::test]
 async fn test_four_player_lobby_creates_2v2() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_four_player_lobby_2v2").await?;
     env.add_server().await?;
@@ -592,6 +600,7 @@ async fn test_four_player_lobby_creates_2v2() -> Result<()> {
 
 #[tokio::test]
 async fn test_ffa_multiple_lobbies_combine() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_ffa_multiple_lobbies").await?;
     env.add_server().await?;
@@ -649,6 +658,7 @@ async fn test_ffa_multiple_lobbies_combine() -> Result<()> {
 
 #[tokio::test]
 async fn test_ffa_single_lobby() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     init_tracing();
 
     setup_test_redis().await?;
@@ -686,6 +696,7 @@ async fn test_ffa_single_lobby() -> Result<()> {
 
 #[tokio::test]
 async fn test_ffa_minimum_players() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_ffa_minimum_players").await?;
     env.add_server().await?;
@@ -726,6 +737,7 @@ async fn test_ffa_minimum_players() -> Result<()> {
 
 #[tokio::test]
 async fn test_ffa_two_player_lobby_matches_after_30_seconds() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env =
         TestEnvironment::new("test_ffa_two_player_lobby_matches_after_30_seconds").await?;
@@ -770,6 +782,7 @@ async fn test_ffa_two_player_lobby_matches_after_30_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn test_ffa_three_player_lobby_matches_after_15_seconds() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env =
         TestEnvironment::new("test_ffa_three_player_lobby_matches_after_15_seconds").await?;
@@ -819,6 +832,7 @@ async fn test_ffa_three_player_lobby_matches_after_15_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn test_quickmatch_and_competitive_dont_mix() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_queue_modes_dont_mix").await?;
     env.add_server().await?;
@@ -888,6 +902,7 @@ async fn test_quickmatch_and_competitive_dont_mix() -> Result<()> {
 /// Test that add_lobby_to_queue with multiple game types registers the lobby in all queues
 #[tokio::test]
 async fn test_multi_type_lobby_appears_in_all_queues() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut mm = create_test_matchmaking_manager().await?;
 
@@ -945,6 +960,7 @@ async fn test_multi_type_lobby_appears_in_all_queues() -> Result<()> {
 /// Test that remove_lobby_from_all_queues removes lobby from all game type queues
 #[tokio::test]
 async fn test_remove_lobby_from_all_queues() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut mm = create_test_matchmaking_manager().await?;
 
@@ -1025,6 +1041,7 @@ async fn test_remove_lobby_from_all_queues() -> Result<()> {
 /// Test that get_queued_lobbies deduplicates lobbies appearing in multiple queues
 #[tokio::test]
 async fn test_get_queued_lobbies_deduplication() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut mm = create_test_matchmaking_manager().await?;
 
@@ -1074,6 +1091,7 @@ async fn test_get_queued_lobbies_deduplication() -> Result<()> {
 /// Test that when a lobby is matched in one queue, it doesn't get matched again in another
 #[tokio::test]
 async fn test_multi_type_lobby_no_double_matching() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
 
     let mut mm = create_test_matchmaking_manager().await?;
@@ -1158,6 +1176,7 @@ async fn test_multi_type_lobby_no_double_matching() -> Result<()> {
 /// Integration test: Two lobbies queued for [1v1, 2v2] should match for 1v1
 #[tokio::test]
 async fn test_multi_type_lobbies_match_for_1v1() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
     setup_test_redis().await?;
     let mut env = TestEnvironment::new("test_multi_type_1v1_match").await?;
@@ -1207,6 +1226,7 @@ async fn test_multi_type_lobbies_match_for_1v1() -> Result<()> {
 /// Test that a lobby in multiple queues gets properly cleaned up after matching
 #[tokio::test]
 async fn test_cleanup_after_match_creation() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
     let mut mm = create_test_matchmaking_manager().await?;
 

--- a/server/tests/matchmaking_integration_tests.rs
+++ b/server/tests/matchmaking_integration_tests.rs
@@ -10,6 +10,11 @@ use tokio::time::{Duration, timeout};
 mod common;
 use self::common::{TestClient, TestEnvironment};
 
+// Serializes the tests in this binary: TestEnvironment::new() sets process-wide
+// env vars (DYNAMODB_TABLE_PREFIX, SNAKETRON_REDIS_URL) and flushes the shared
+// Redis test database, so concurrently running tests corrupt each other.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 // #[tokio::test]
 #[allow(dead_code)]
 async fn test_minimal() -> Result<()> {
@@ -22,6 +27,7 @@ async fn test_minimal() -> Result<()> {
 
 #[tokio::test]
 async fn test_simple_two_player_match() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     // Set test environment
 
     // Clean up Redis before starting the test
@@ -129,6 +135,7 @@ async fn test_simple_two_player_match() -> Result<()> {
 
 #[tokio::test]
 async fn test_basic_matchmaking() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let mut env = TestEnvironment::new("test_basic_matchmaking").await?;
     env.add_server().await?;
     env.create_user().await?;
@@ -174,6 +181,7 @@ async fn test_basic_matchmaking() -> Result<()> {
 
 #[tokio::test]
 async fn test_leave_queue() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let mut env = TestEnvironment::new("test_leave_queue").await?;
     env.add_server().await?;
     env.create_user().await?;
@@ -209,6 +217,7 @@ async fn test_leave_queue() -> Result<()> {
 
 #[tokio::test]
 async fn test_team_matchmaking() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let mut env = TestEnvironment::new("test_team_matchmaking").await?;
     env.add_server().await?;
     for _ in 0..4 {
@@ -257,6 +266,7 @@ async fn test_team_matchmaking() -> Result<()> {
 
 #[tokio::test]
 async fn test_concurrent_matchmaking() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let mut env = TestEnvironment::new("test_concurrent_matchmaking").await?;
     env.add_server().await?;
 
@@ -339,6 +349,7 @@ async fn test_concurrent_matchmaking() -> Result<()> {
 
 #[tokio::test]
 async fn test_disconnect_during_queue() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     // Clean up Redis before starting the test
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
@@ -401,6 +412,7 @@ async fn test_disconnect_during_queue() -> Result<()> {
 
 #[tokio::test]
 async fn test_rejoin_active_game() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     // Clean up Redis before starting the test
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
@@ -521,6 +533,7 @@ async fn wait_for_snapshot(client: &mut TestClient) -> Result<()> {
 /// Test that two lobbies with similar MMR (both in silver range 500-600) match instantly
 #[tokio::test]
 async fn test_same_mmr_range_matches_instantly() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
 
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
@@ -595,6 +608,7 @@ async fn test_same_mmr_range_matches_instantly() -> Result<()> {
 /// Test that silver (600) and gold (900) lobbies match after ~10 seconds
 #[tokio::test]
 async fn test_silver_gold_matches_in_10_seconds() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
 
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
@@ -672,6 +686,7 @@ async fn test_silver_gold_matches_in_10_seconds() -> Result<()> {
 /// Test that silver (600) and diamond (1500) lobbies match after ~30 seconds (max wait)
 #[tokio::test]
 async fn test_silver_diamond_matches_in_30_seconds() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
 
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
@@ -749,6 +764,7 @@ async fn test_silver_diamond_matches_in_30_seconds() -> Result<()> {
 /// Test that extreme MMR differences still match within 30 seconds (max wait time)
 #[tokio::test]
 async fn test_extreme_mmr_difference_max_30_seconds() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     let _ = tracing_subscriber::fmt::try_init();
 
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
@@ -822,6 +838,7 @@ async fn test_extreme_mmr_difference_max_30_seconds() -> Result<()> {
 
 #[tokio::test]
 async fn test_mmr_based_matchmaking() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     // Clean up Redis before starting the test
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
@@ -980,6 +997,7 @@ async fn test_mmr_based_matchmaking() -> Result<()> {
 
 #[tokio::test]
 async fn test_matchmaking_load() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
     // Clean up Redis before starting the test
     let redis_client = redis::Client::open("redis://127.0.0.1:6379/1")?;
     let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;


### PR DESCRIPTION
## Problem

`lobby_matchmaking_tests` (19 tests) and `matchmaking_integration_tests` (13 tests) failed under default parallel `cargo test -p server` and only passed with `-- --test-threads=1` against a freshly restarted localstack.

Reproduced before fixing: 18/19 lobby tests failed with `ResourceInUseException: Table already exists: test_ec61c215-main` — note every failing test raced on the **same** table prefix.

## Root cause

`TestEnvironment::new` already generates a unique DynamoDB table prefix per test, but publishes it through a **process-global env var** (`DYNAMODB_TABLE_PREFIX`), so parallel tests all read the last writer's value and collide creating the same tables. The same constructor sets `SNAKETRON_REDIS_URL` and `FLUSHDB`s the shared Redis test database, which wipes state out from under any concurrently running test. Separately, the `init_tracing()` helper's `.init()` panicked ("a global default trace dispatcher has already been set") whenever another test's `try_init()` had already installed the subscriber — its `Once` guard only protected against racing itself.

## Fix

- **Per-binary `TEST_LOCK`** (the existing pattern from `game_load_failure_tests.rs`, already anticipated by a comment in `test_environment.rs`): a `static tokio::sync::Mutex<()>` acquired as the first line of all 32 tests, serializing each binary regardless of `--test-threads`. Corrected the stale `SAFETY` comment on the env-var writes to state the real constraint.
- **Idempotent DynamoDB table creation**: new `finish_table_creation` helper completes all five `create_*_table_if_not_exists` calls — a lost describe-then-create race (`ResourceInUseException`) is treated as success after waiting for the winner's table to become ACTIVE. This also hardens production, where multiple servers bootstrapping the same prefix concurrently had the same TOCTOU window.
- **Tracing**: `init_tracing()` now uses `try_init()`; dropped the redundant `Once`.

## Verification

- `docker restart snaketron-localstack`, then both binaries under default parallelism, twice in a row: 19/19 and 13/13 both runs.
- Full `cargo test -p server`: all green.
- `cargo clippy --all-targets --all-features` and `cargo fmt --all -- --check`: clean.

Serialization means the two binaries take ~66s and ~142s (same as `--test-threads=1` today) — the lock trades wall-clock time for correctness, matching the game_load_failure_tests.rs precedent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)