### PR TITLE
Remove the Pub/Sub game-bus transport: Redis Streams is the only bus

### DIFF
--- a/.github/workflows/github-action-test-simple-game.yml
+++ b/.github/workflows/github-action-test-simple-game.yml
@@ -62,16 +62,10 @@ jobs:
           cargo test --all --no-run
 
   test:
-    name: Run Tests (bus=${{ matrix.bus }})
+    name: Run Tests
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      fail-fast: false
-      matrix:
-        # Both game-bus transports must pass the full suite (see
-        # STREAMS_MIGRATION.md).
-        bus: [pubsub, streams]
-    
+
     services:
       postgres:
         image: postgres:13.3
@@ -164,11 +158,10 @@ jobs:
           AWS_ACCESS_KEY_ID: test
           AWS_SECRET_ACCESS_KEY: test
           DYNAMODB_TABLE_PREFIX: snaketron
-          SNAKETRON_BUS: ${{ matrix.bus }}
           RUST_LOG: info
           RUST_BACKTRACE: 1
         run: |
-          echo "Running all tests with SNAKETRON_BUS=${{ matrix.bus }}..."
+          echo "Running all tests..."
           cargo test --all -- --nocapture --test-threads=1
           
       - name: Upload test results

--- a/CODEX.md
+++ b/CODEX.md
@@ -10,7 +10,7 @@ This file guides ChatGPT/Codex when working on the Snaketron repository. The int
 
 Key architectural decisions:
 - Service discovery and health: servers self-register in the DB and emit heartbeats.
-- Real-time links: WebSocket for clients; Valkey pub/sub for server-to-server.
+- Real-time links: WebSocket for clients; Valkey Streams for game-critical server-to-server traffic (`server/src/game_bus.rs`), plain pub/sub only for loss-tolerant fan-out (chat, lobby updates, user counts).
 - Cluster coordination: Valkey-backed singleton management for matchmaking and load distribution.
 - Game logic parity: the `common` crate ensures server and client stay in sync.
 - Containerization: Docker workflows for both development and production (AWS Fargate target).

--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -11,7 +11,8 @@ production report into a local failing test.
 
 The authoritative game runs in a server-side executor
 ([game_executor.rs](server/src/game_executor.rs)) that advances a shared
-`GameEngine` by wall clock and publishes every event over Redis pub/sub.
+`GameEngine` by wall clock and publishes every event over the Redis Streams
+game bus ([game_bus.rs](server/src/game_bus.rs)).
 WebSocket servers hold replicas ([replication.rs](server/src/replication.rs))
 that apply those events and forward them to clients. The client runs the same
 engine compiled to WASM: its **committed** state advances only when server
@@ -52,11 +53,15 @@ committed hash + server timestamp. This one small message does three jobs:
 
 The executor stamps every published message with a per-game, strictly
 monotonic sequence number. Every consumer (replica, client engine) checks
-contiguity: a gap means messages were lost (Redis pub/sub is at-most-once) and
-triggers an automatic snapshot resync instead of silent divergence. Duplicates
-and stale messages are skipped instead of double-applied. This replaces the
-expensive "send a full snapshot every few seconds" workaround with resyncs
-that happen only when something was actually lost.
+contiguity: a gap means messages were lost and triggers an automatic snapshot
+resync instead of silent divergence. Duplicates and stale messages are
+skipped instead of double-applied. The Streams bus itself doesn't drop, so
+gaps can only come from the hops past it (broadcast fan-out lag, the
+WebSocket leg) or trim-horizon loss after a long outage — the counters
+should sit at ~0, and this machinery is defense-in-depth rather than
+load-bearing. This replaces the expensive "send a full snapshot every few
+seconds" workaround with resyncs that happen only when something was
+actually lost.
 
 Client-side health lives in `GameEngine::sync_status()` (gap counts, missed
 messages, probe results, `needs_resync`) and is surfaced to the UI via
@@ -146,7 +151,7 @@ logs (server):
 | Signal | Meaning | Healthy |
 |---|---|---|
 | TickHash mismatch rate | real divergence happening in prod | ~0 |
-| stream gap incidents / game | Redis pub/sub or broadcast loss | ~0 |
+| stream gap incidents / game | broadcast/WebSocket-leg loss (the Streams bus itself doesn't drop) | ~0 |
 | resync requests / game | self-healing frequency (masking loss) | < 1 |
 | commands rescheduled (server tick > client tick) | inputs arriving past the lag window | rare |
 | watchdog activations | dead streams noticed by clients | ~0 |
@@ -205,11 +210,13 @@ way to notice it had diverged.**
    server. Locally RTT ≈ 0, so the window never expired — prod-only by
    construction. (Clock-sync error has the same effect via mis-stamped
    command ticks.)
-2. **Cumulative drift needing periodic snapshots** — Redis pub/sub is
-   at-most-once; the broadcast fan-out drops messages when a receiver lags
-   (and one error path ended forwarding entirely, silently); nothing checked
-   `sequence` contiguity, so every lost event became permanent divergence.
-   Periodic snapshots masked the loss instead of detecting it.
+2. **Cumulative drift needing periodic snapshots** — the game bus was Redis
+   pub/sub at the time, which is at-most-once; the broadcast fan-out drops
+   messages when a receiver lags (and one error path ended forwarding
+   entirely, silently); nothing checked `sequence` contiguity, so every lost
+   event became permanent divergence. Periodic snapshots masked the loss
+   instead of detecting it. (The bus has since moved to Redis Streams, which
+   removed the at-most-once hop entirely.)
 3. **Ghost games** — the predicted state free-ran on the local clock with no
    bound and no liveness check, so a dead backend looked like a live game.
 
@@ -250,4 +257,3 @@ every hop; traces make any surviving bug replayable offline.
 | `SNAKETRON_TRACE_DIR` | `./traces` | Where server + uploaded client traces go |
 | `SNAKETRON_TRACE_DISABLE` | unset | `1` disables the server flight recorder |
 | `SNAKETRON_TRACE_MAX_FILES` | `200` | Trace-dir rotation limit |
-| `SNAKETRON_BUS` | `streams` | Game-critical transport: `streams` (default) or `pubsub` fallback (see STREAMS_MIGRATION.md). On `streams`, the gap/resync counters should sit at ~0 — nonzero values there mean a transport bug |

--- a/STREAMS_MIGRATION.md
+++ b/STREAMS_MIGRATION.md
@@ -1,27 +1,19 @@
 # Valkey Streams Migration
 
-**Status: IMPLEMENTED — streams is the default.** The game-critical
-transport is configurable via `SNAKETRON_BUS=pubsub|streams` (default
-`streams`; set `pubsub` to fall back to the previous transport). The seam is
-`server/src/game_bus.rs` (`GameBus`); the full server suite passes under both
-configs (CI runs a matrix over both); dedicated streams tests cover zero-loss
-under a paused consumer, reconnect resume via CLIENT KILL, ordering, tail
-anchoring, and trimming; measured delivery latency is p50 ~1.3 ms / p99
-~3.6 ms — within ~0.2 ms of Pub/Sub and ~300x faster than the abandoned 2025
-implementation. The sections below record the assessment, the design rules,
-and the operational rollout guidance.
-
-## Rollout constraint: the flip is per-process, not per-fleet
-
-`SNAKETRON_BUS` selects the transport for one process. Publishers on one
-transport are invisible to consumers on the other, so a **mixed fleet during
-a rolling restart silently partitions cross-server traffic** (a pubsub-mode
-WS server's commands never reach a streams-mode executor). Flip the whole
-fleet at once: set the new value everywhere, then restart all servers
-together (a brief maintenance window), or scale to a single server for the
-flip. The failover/resume machinery (stored snapshots + resume-on-start)
-recovers in-flight games across the restart. If zero-downtime flips ever
-matter, add a transitional dual-publish mode first.
+**Status: COMPLETE — streams is the only transport.** The Pub/Sub game-bus
+backend and the `SNAKETRON_BUS` flag were removed after streams proved out
+(Phase 5 below); `server/src/game_bus.rs` (`GameBus`) is now a plain Streams
+implementation, and Pub/Sub remains only for loss-tolerant fan-out (chat,
+lobby updates, user counts) in `pubsub_manager.rs`. The pubsub-era
+workarounds went with it — most notably the GameCreated ack/retry handshake,
+which existed because Pub/Sub drops messages published before the executor
+subscribes (under streams, a GameCreated missed during an executor restart
+is recovered by the stored-snapshot resume path). Dedicated streams tests
+cover zero-loss under a paused consumer, reconnect resume via CLIENT KILL,
+ordering, tail anchoring, and trimming; measured delivery latency is p50
+~1.3 ms / p99 ~3.6 ms — within ~0.2 ms of Pub/Sub and ~300x faster than the
+abandoned 2025 implementation. The sections below are kept as the historical
+record of the assessment, the design rules, and the rollout.
 
 ## Why the old Streams implementation was slow (git archaeology)
 
@@ -183,7 +175,9 @@ then flip prod. After confidence: consider relaxing the stored-snapshot
 refresh cadence and demoting the gap-driven snapshot-request path to
 cold-start only. Keep the Pub/Sub backend as the escape hatch until Streams
 has weeks of clean counters; remove it only when the flag has become dead
-weight.
+weight. *(Done: the Pub/Sub backend, the `SNAKETRON_BUS` flag, the enum
+dispatch, and the GameCreated ack handshake have all been removed —
+`GameBus` is streams-only.)*
 
 ## Effort estimate
 

--- a/server/src/game_bus.rs
+++ b/server/src/game_bus.rs
@@ -1,26 +1,23 @@
 //! The game-critical message bus: partition-scoped events, commands, and
 //! snapshot requests between game executors, replicas, and WebSocket servers.
 //!
-//! Two interchangeable transports, selected by `SNAKETRON_BUS`:
-//!
-//! - `streams` (default): Redis/Valkey Streams — an ordered, trimmed,
-//!   replayable log per partition. Readers resume from their last-delivered
-//!   entry, so subscriber blips lose nothing and slow consumers get real
-//!   backpressure instead of drops. The `stream_seq`/resync machinery
-//!   remains as defense-in-depth and should sit idle on this transport.
-//! - `pubsub` (fallback): Redis Pub/Sub — push-based, at-most-once. Loss is
-//!   detected downstream via `stream_seq` gaps and healed with snapshot
-//!   resyncs (see DEBUGGING.md).
+//! Backed by Redis/Valkey Streams — an ordered, trimmed, replayable log per
+//! partition. Readers resume from their last-delivered entry, so subscriber
+//! blips lose nothing and slow consumers get real backpressure instead of
+//! drops. The `stream_seq`/resync machinery remains as defense-in-depth for
+//! the hops beyond this bus (broadcast fan-out, the WebSocket leg) and for
+//! trim-horizon loss after a long outage; its counters should sit at ~0
+//! (see DEBUGGING.md).
 //!
 //! Loss-tolerant fan-out (chat, lobby updates, user counts) is NOT routed
-//! through this bus — it stays on plain Pub/Sub under either setting
+//! through this bus — it stays on plain Pub/Sub
 //! (see `PubSubManager::subscribe_to_channel`).
 //!
 //! ## Streams latency rules (learned the hard way — see STREAMS_MIGRATION.md)
 //!
-//! The 2025 Streams implementation was abandoned for Pub/Sub because blocking
-//! `XREAD`s were multiplexed onto shared connections, adding 100–900 ms per
-//! event. The rules encoded here:
+//! The 2025 Streams implementation was abandoned because blocking `XREAD`s
+//! were multiplexed onto shared connections, adding 100–900 ms per event.
+//! The rules encoded here:
 //! 1. Every blocking reader owns a DEDICATED connection; publishers use the
 //!    shared non-blocking `ConnectionManager` and never queue behind a
 //!    parked read.
@@ -32,158 +29,43 @@
 //!    position.
 
 use crate::game_executor::StreamEvent;
-use crate::pubsub_manager::{PartitionSubscription, PubSubManager, SnapshotRequest};
 use crate::redis_keys::RedisKeys;
 use anyhow::{Context, Result};
 use common::{GameEvent, GameEventMessage, GameState};
 use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
 use redis::streams::{StreamMaxlen, StreamReadOptions, StreamReadReply};
+use serde::{Deserialize, Serialize};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-/// Which transport backs the game bus. Parsed from `SNAKETRON_BUS`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum BusKind {
-    PubSub,
-    Streams,
+/// Snapshot request message for a partition
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct SnapshotRequest {
+    pub partition_id: u32,
+    pub requester_id: Option<u64>, // Optional server ID of requester
 }
 
-impl BusKind {
-    pub fn from_env() -> Self {
-        Self::parse(std::env::var("SNAKETRON_BUS").ok().as_deref())
-    }
-
-    fn parse(value: Option<&str>) -> Self {
-        match value.map(|v| v.trim().to_ascii_lowercase()) {
-            Some(v) if v == "pubsub" => BusKind::PubSub,
-            Some(v) if v == "streams" || v.is_empty() => BusKind::Streams,
-            Some(other) => {
-                // Deliberately loud: a typo here silently changes which
-                // transport carries every game message.
-                tracing::error!(
-                    "Unknown SNAKETRON_BUS value {:?} (expected \"pubsub\" or \"streams\"); falling back to the streams default",
-                    other
-                );
-                BusKind::Streams
-            }
-            None => BusKind::Streams,
-        }
-    }
+/// A subscription to a partition's events, commands and requests
+pub struct PartitionSubscription {
+    pub partition_id: u32,
+    pub event_receiver: mpsc::Receiver<GameEventMessage>,
+    pub command_receiver: mpsc::Receiver<StreamEvent>,
+    pub snapshot_request_receiver: mpsc::Receiver<SnapshotRequest>,
 }
 
-/// The configurable game-critical transport. All methods take `&self`;
-/// internal connections are cheaply cloneable handles.
-pub enum GameBus {
-    PubSub(PubSubManager),
-    Streams(StreamsTransport),
-}
-
-impl GameBus {
-    pub fn new(
-        kind: BusKind,
-        pubsub: PubSubManager,
-        redis: ConnectionManager,
-        redis_client: redis::Client,
-        cancellation_token: CancellationToken,
-    ) -> Self {
-        match kind {
-            BusKind::PubSub => GameBus::PubSub(pubsub),
-            BusKind::Streams => {
-                info!("Game bus: Redis Streams transport enabled");
-                GameBus::Streams(StreamsTransport {
-                    redis,
-                    redis_client,
-                    cancellation_token,
-                })
-            }
-        }
+impl PartitionSubscription {
+    pub async fn recv_event(&mut self) -> Option<GameEventMessage> {
+        self.event_receiver.recv().await
     }
 
-    pub fn kind(&self) -> BusKind {
-        match self {
-            GameBus::PubSub(_) => BusKind::PubSub,
-            GameBus::Streams(_) => BusKind::Streams,
-        }
+    pub async fn recv_command(&mut self) -> Option<StreamEvent> {
+        self.command_receiver.recv().await
     }
 
-    pub async fn publish_event(&self, partition_id: u32, event: &GameEventMessage) -> Result<()> {
-        match self {
-            GameBus::PubSub(manager) => {
-                let mut manager = manager.clone();
-                manager.publish_event(partition_id, event).await
-            }
-            GameBus::Streams(streams) => streams.publish_event(partition_id, event).await,
-        }
-    }
-
-    /// Publish a snapshot AND persist it under the game's snapshot key.
-    /// Returns the constructed message so callers can trace exactly what was
-    /// published.
-    pub async fn publish_snapshot(
-        &self,
-        partition_id: u32,
-        game_id: u32,
-        snapshot: &GameState,
-        stream_seq: u64,
-    ) -> Result<GameEventMessage> {
-        match self {
-            GameBus::PubSub(manager) => {
-                manager
-                    .publish_snapshot(partition_id, game_id, snapshot, stream_seq)
-                    .await
-            }
-            GameBus::Streams(streams) => {
-                streams
-                    .publish_snapshot(partition_id, game_id, snapshot, stream_seq)
-                    .await
-            }
-        }
-    }
-
-    pub async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
-        match self {
-            GameBus::PubSub(manager) => manager.publish_command(partition_id, command).await,
-            GameBus::Streams(streams) => streams.publish_command(partition_id, command).await,
-        }
-    }
-
-    pub async fn request_partition_snapshots(&self, partition_id: u32) -> Result<()> {
-        match self {
-            GameBus::PubSub(manager) => {
-                let mut manager = manager.clone();
-                manager.request_partition_snapshots(partition_id).await
-            }
-            GameBus::Streams(streams) => streams.request_partition_snapshots(partition_id).await,
-        }
-    }
-
-    pub async fn subscribe_to_partition(&self, partition_id: u32) -> Result<PartitionSubscription> {
-        match self {
-            GameBus::PubSub(manager) => {
-                let mut manager = manager.clone();
-                manager.subscribe_to_partition(partition_id).await
-            }
-            GameBus::Streams(streams) => streams.subscribe_to_partition(partition_id).await,
-        }
-    }
-
-    pub async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
-        match self {
-            GameBus::PubSub(manager) => manager.store_snapshot(game_id, snapshot).await,
-            GameBus::Streams(streams) => streams.store_snapshot(game_id, snapshot).await,
-        }
-    }
-
-    pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
-        match self {
-            GameBus::PubSub(manager) => {
-                let mut manager = manager.clone();
-                manager.get_stored_snapshot(game_id).await
-            }
-            GameBus::Streams(streams) => streams.get_stored_snapshot(game_id).await,
-        }
+    pub async fn recv_snapshot_request(&mut self) -> Option<SnapshotRequest> {
+        self.snapshot_request_receiver.recv().await
     }
 }
 
@@ -204,13 +86,15 @@ const SNAPREQ_MAXLEN: usize = 64;
 const XREAD_BLOCK_MS: usize = 5_000;
 /// Max entries drained per XREAD round trip.
 const XREAD_COUNT: usize = 512;
-/// Capacity of the mpsc channels handed to subscribers (matches the pubsub
-/// transport). When full, the reader awaits — backpressure, not drops.
+/// Capacity of the mpsc channels handed to subscribers. When full, the
+/// reader awaits — backpressure, not drops.
 const SUBSCRIBER_CHANNEL_CAPACITY: usize = 2000;
 /// Backoff before rebuilding a failed reader connection.
 const READER_RECONNECT_BACKOFF_MS: u64 = 100;
 
-pub struct StreamsTransport {
+/// The game-critical transport. All methods take `&self`; internal
+/// connections are cheaply cloneable handles.
+pub struct GameBus {
     /// Shared non-blocking connection for XADD/KV. Never used for blocking
     /// reads (rule #1).
     redis: ConnectionManager,
@@ -219,7 +103,19 @@ pub struct StreamsTransport {
     cancellation_token: CancellationToken,
 }
 
-impl StreamsTransport {
+impl GameBus {
+    pub fn new(
+        redis: ConnectionManager,
+        redis_client: redis::Client,
+        cancellation_token: CancellationToken,
+    ) -> Self {
+        Self {
+            redis,
+            redis_client,
+            cancellation_token,
+        }
+    }
+
     async fn xadd(&self, key: &str, maxlen: usize, payload: Vec<u8>) -> Result<()> {
         let mut redis = self.redis.clone();
         let _: String = redis
@@ -229,7 +125,7 @@ impl StreamsTransport {
         Ok(())
     }
 
-    async fn publish_event(&self, partition_id: u32, event: &GameEventMessage) -> Result<()> {
+    pub async fn publish_event(&self, partition_id: u32, event: &GameEventMessage) -> Result<()> {
         let payload = serde_json::to_vec(event).context("Failed to serialize event")?;
         self.xadd(
             &RedisKeys::stream_events(partition_id),
@@ -244,7 +140,10 @@ impl StreamsTransport {
         Ok(())
     }
 
-    async fn publish_snapshot(
+    /// Publish a snapshot AND persist it under the game's snapshot key.
+    /// Returns the constructed message so callers can trace exactly what was
+    /// published.
+    pub async fn publish_snapshot(
         &self,
         partition_id: u32,
         game_id: u32,
@@ -278,7 +177,7 @@ impl StreamsTransport {
         Ok(event)
     }
 
-    async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
+    pub async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
         let payload = serde_json::to_vec(command).context("Failed to serialize command")?;
         self.xadd(
             &RedisKeys::stream_commands(partition_id),
@@ -288,7 +187,7 @@ impl StreamsTransport {
         .await
     }
 
-    async fn request_partition_snapshots(&self, partition_id: u32) -> Result<()> {
+    pub async fn request_partition_snapshots(&self, partition_id: u32) -> Result<()> {
         let request = SnapshotRequest {
             partition_id,
             requester_id: None,
@@ -303,7 +202,15 @@ impl StreamsTransport {
         .await
     }
 
-    async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
+    /// Store a game snapshot in Redis WITHOUT publishing it to subscribers.
+    ///
+    /// Two callers rely on this: the game loop refreshes it periodically so a
+    /// takeover executor can resume in-flight games from near-current state
+    /// (see game_executor::resume_partition_games), and the completion path
+    /// stores the terminal state as the reload fallback before publishing
+    /// completion events and releasing the in-memory copy. 5-minute TTL: a
+    /// game whose executor stays dead longer than that is not resumable.
+    pub async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
         let key = RedisKeys::game_snapshot(game_id);
         let data =
             serde_json::to_vec(snapshot).context("Failed to serialize snapshot for storage")?;
@@ -315,7 +222,7 @@ impl StreamsTransport {
         Ok(())
     }
 
-    async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
+    pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
         let mut redis = self.redis.clone();
         let data: Option<Vec<u8>> = redis
             .get(RedisKeys::game_snapshot(game_id))
@@ -329,7 +236,7 @@ impl StreamsTransport {
         }
     }
 
-    async fn subscribe_to_partition(&self, partition_id: u32) -> Result<PartitionSubscription> {
+    pub async fn subscribe_to_partition(&self, partition_id: u32) -> Result<PartitionSubscription> {
         let (event_tx, event_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
         let (command_tx, command_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
         let (request_tx, request_rx) = mpsc::channel(SUBSCRIBER_CHANNEL_CAPACITY);
@@ -637,19 +544,7 @@ fn stream_id_less_than(a: &str, b: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{BusKind, stream_id_less_than};
-
-    #[test]
-    fn bus_kind_parse() {
-        assert_eq!(BusKind::parse(Some("streams")), BusKind::Streams);
-        assert_eq!(BusKind::parse(Some(" Streams ")), BusKind::Streams);
-        assert_eq!(BusKind::parse(Some("pubsub")), BusKind::PubSub);
-        assert_eq!(BusKind::parse(Some(" PubSub ")), BusKind::PubSub);
-        // Streams is the default: unset, empty, and unrecognized values.
-        assert_eq!(BusKind::parse(Some("")), BusKind::Streams);
-        assert_eq!(BusKind::parse(Some("nonsense")), BusKind::Streams);
-        assert_eq!(BusKind::parse(None), BusKind::Streams);
-    }
+    use super::stream_id_less_than;
 
     #[test]
     fn stream_id_ordering() {

--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -1,7 +1,5 @@
 use crate::db::Database;
-use crate::game_bus::GameBus;
-use crate::pubsub_manager::{PartitionSubscription, SnapshotRequest};
-use crate::redis_keys::RedisKeys;
+use crate::game_bus::{GameBus, PartitionSubscription, SnapshotRequest};
 use crate::replication::GameStateReader;
 use crate::sync_trace::GameTraceRecorder;
 use crate::xp_persistence;
@@ -11,7 +9,6 @@ use common::{
     EXECUTOR_POLL_INTERVAL_MS, GameCommandMessage, GameEngine, GameEvent, GameEventMessage,
     GameState, GameStatus, TICK_HASH_INTERVAL_TICKS,
 };
-use redis::AsyncCommands;
 use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -375,7 +372,7 @@ async fn run_game(
                             event,
                         };
 
-                        // Publish event via PubSub
+                        // Publish event on the game bus
                         let publish_result = publish_event_with_retry(&bus, partition_id, &event_msg).await;
                         recorder.record(&TraceRecord::EventOut {
                             ts_ms: now_ms,
@@ -468,7 +465,7 @@ async fn run_game(
                                 event: event.clone(),
                             };
 
-                            // Publish event via PubSub
+                            // Publish event on the game bus
                             let publish_result = publish_event_with_retry(&bus, partition_id, &event_msg).await;
                             recorder.record(&TraceRecord::EventOut {
                                 ts_ms: now_ms,
@@ -733,11 +730,6 @@ pub async fn run_game_executor(
         server_id, partition_id
     );
 
-    // Create PubSub manager
-    // let mut pubsub = PubSubManager::new(&redis_url)
-    //     .await
-    //     .context("Failed to create PubSub manager")?;
-
     // Subscribe to partition commands and snapshot requests
     let partition_sub = bus
         .subscribe_to_partition(partition_id)
@@ -820,9 +812,10 @@ pub async fn run_game_executor(
     // replica state (event-current) wins over stored Redis snapshots
     // (refreshed at TickHash cadence, so <=~1s stale); snapshots cover games
     // this server's replica never saw, including games whose GameCreated
-    // pub/sub message was lost while no executor was listening. run_game
-    // re-anchors clients by publishing a fresh snapshot first, which resets
-    // stream_seq watermarks all the way down.
+    // command was published while no executor was subscribed (subscriptions
+    // anchor at the stream tail, so earlier entries are not replayed).
+    // run_game re-anchors clients by publishing a fresh snapshot first,
+    // which resets stream_seq watermarks all the way down.
     {
         let replica_games = replication_manager.get_partition_games(partition_id).await;
         let snapshot_games = load_stored_snapshots(&mut redis).await;
@@ -878,11 +871,11 @@ pub async fn run_game_executor(
                 break;
             }
 
-            // Process events from partition channel
+            // Process events from the partition's event stream
             Some(event) = event_receiver.recv() => {
-                // Events flow through to replication manager automatically via PubSub
-                // The replication manager is subscribed to the same partition channel
-                // We just need to publish snapshots to PubSub
+                // Events flow to the replication manager through its own
+                // subscription to the same partition streams; nothing to do
+                // here beyond draining.
                 if let GameEvent::Snapshot { .. } = &event.event {
                     debug!("Received snapshot event for game {} on partition {}", event.game_id, partition_id);
                 }
@@ -899,38 +892,19 @@ pub async fn run_game_executor(
                 }
             }
 
-            // Process commands from PubSub
+            // Process commands from the partition's command stream
             Some(command_data) = command_receiver.recv() => {
                 match command_data {
                     StreamEvent::GameCreated { game_id, game_state } => {
                         info!("Received GameCreated event for game {}", game_id);
-                        let bus_clone = bus.clone();
-                        let db_clone = db.clone();
-                        let cancellation_token_clone = cancellation_token.clone();
-                        let accepted = try_start_game(
+                        try_start_game(
                             game_id,
                             game_state,
-                            bus_clone,
-                            db_clone,
-                            cancellation_token_clone,
+                            bus.clone(),
+                            db.clone(),
+                            cancellation_token.clone(),
                             &mut game_channels
                         );
-                        if accepted {
-                            let mut ack_redis = redis.clone();
-                            if let Err(e) = ack_redis
-                                .set_ex::<_, _, ()>(
-                                    RedisKeys::game_creation_ack(game_id),
-                                    server_id,
-                                    30,
-                                )
-                                .await
-                            {
-                                warn!(
-                                    "Failed to acknowledge GameCreated for game {}: {}",
-                                    game_id, e
-                                );
-                            }
-                        }
                     }
                     StreamEvent::StatusUpdated { game_id, status } => {
                         if let GameStatus::Complete { .. } = status {

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -8,7 +8,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::{error, info, trace, warn};
 
 use crate::api::jwt::JwtManager;
-use crate::game_bus::{BusKind, GameBus};
+use crate::game_bus::GameBus;
 use crate::game_executor::PARTITION_COUNT;
 use crate::http_server::run_http_server;
 use crate::lobby_manager::LobbyManager;
@@ -142,21 +142,12 @@ impl GameServer {
         let redis = create_connection_manager(redis_client, pubsub_tx.clone()).await?;
         info!("Redis connection manager created successfully");
 
-        // Create the PubsubManager
-        let pubsub_manager = Arc::new(PubSubManager::new(
-            redis.clone(),
-            pubsub_tx.clone(),
-            cancellation_token.clone(),
-        ));
+        // Create the PubsubManager for loss-tolerant fan-out
+        // (chat/lobby/counters).
+        let pubsub_manager = Arc::new(PubSubManager::new(redis.clone(), pubsub_tx.clone()));
 
-        // Create the game-critical message bus (transport per SNAKETRON_BUS).
-        // Loss-tolerant fan-out (chat/lobby/counters) stays on the
-        // PubSubManager regardless of this setting.
-        let bus_kind = BusKind::from_env();
-        info!("Game bus transport: {:?}", bus_kind);
+        // Create the game-critical message bus (Redis Streams).
         let game_bus = Arc::new(GameBus::new(
-            bus_kind,
-            (*pubsub_manager).clone(),
             redis.clone(),
             Client::open(redis_url.clone())
                 .context("Failed to create Redis client for game bus")?,
@@ -220,7 +211,6 @@ impl GameServer {
                 replication_partitions,
                 cancellation_token.clone(),
                 &redis_url,
-                bus_kind,
             )
             .await
             .context("Failed to create replication manager")?,

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -45,7 +45,7 @@ pub struct HttpServerState {
     pub redis_url: String,
     /// PubSub manager for loss-tolerant fan-out (chat, lobby, counters)
     pub pubsub_manager: Arc<crate::pubsub_manager::PubSubManager>,
-    /// Game-critical message bus (transport per SNAKETRON_BUS)
+    /// Game-critical message bus (Redis Streams)
     pub game_bus: Arc<GameBus>,
     /// Matchmaking manager for queue operations
     pub matchmaking_manager:

--- a/server/src/pubsub_manager.rs
+++ b/server/src/pubsub_manager.rs
@@ -1,18 +1,15 @@
-use crate::game_executor::StreamEvent;
-use crate::redis_keys::RedisKeys;
-use anyhow::{Context, Result, anyhow};
-use common::{GameEvent, GameEventMessage, GameState};
-use redis::aio::ConnectionManager;
-use redis::{AsyncCommands, PushInfo, PushKind, Value};
-use serde::de::DeserializeOwned;
-use serde::{Deserialize, Serialize};
-use tokio::sync::mpsc;
-use tokio::time::{Duration, Instant, sleep};
-use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+//! Loss-tolerant Redis Pub/Sub fan-out: chat, lobby updates, user counts.
+//!
+//! Game-critical traffic (partition events, commands, snapshot requests)
+//! does NOT go through here — it rides the Redis Streams bus in
+//! `game_bus.rs`, which is ordered, replayable, and backpressured. Pub/Sub
+//! is at-most-once by design; everything published here must tolerate loss.
 
-const GAME_CREATION_ACK_TIMEOUT: Duration = Duration::from_secs(10);
-const GAME_CREATION_RETRY_INTERVAL: Duration = Duration::from_millis(100);
+use anyhow::{Result, anyhow};
+use redis::aio::ConnectionManager;
+use redis::{PushInfo, PushKind, Value};
+use serde::de::DeserializeOwned;
+use tracing::warn;
 
 pub struct ChannelReceiver {
     inner: tokio::sync::broadcast::Receiver<PushInfo>,
@@ -26,9 +23,8 @@ impl ChannelReceiver {
     /// the shared Redis push firehose and malformed payloads are logged and
     /// skipped — before this, either one propagated as a fatal error and the
     /// subscription task above us broke its loop, permanently and silently
-    /// severing a partition's entire event/command feed on this server. Lost
-    /// messages surface downstream as stream_seq gaps, which trigger a
-    /// snapshot resync.
+    /// severing the channel's feed on this server. Everything on these
+    /// channels is loss-tolerant fan-out, so skipped messages are acceptable.
     pub async fn recv<T>(&mut self) -> Result<T>
     where
         T: DeserializeOwned + Send + 'static,
@@ -38,7 +34,7 @@ impl ChannelReceiver {
                 Ok(info) => info,
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
                     warn!(
-                        "Redis push receiver for channel {} lagged, {} pushes skipped; continuing (downstream gap detection will resync)",
+                        "Redis push receiver for channel {} lagged, {} pushes skipped; continuing (channel traffic is loss-tolerant)",
                         self.channel, skipped
                     );
                     continue;
@@ -79,41 +75,11 @@ impl ChannelReceiver {
     }
 }
 
-/// Snapshot request message for a partition
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct SnapshotRequest {
-    pub partition_id: u32,
-    pub requester_id: Option<u64>, // Optional server ID of requester
-}
-
-/// A subscription to a partition's events, commands and requests
-pub struct PartitionSubscription {
-    pub partition_id: u32,
-    pub event_receiver: mpsc::Receiver<GameEventMessage>,
-    pub command_receiver: mpsc::Receiver<StreamEvent>,
-    pub snapshot_request_receiver: mpsc::Receiver<SnapshotRequest>,
-}
-
-impl PartitionSubscription {
-    pub async fn recv_event(&mut self) -> Option<GameEventMessage> {
-        self.event_receiver.recv().await
-    }
-
-    pub async fn recv_command(&mut self) -> Option<StreamEvent> {
-        self.command_receiver.recv().await
-    }
-
-    pub async fn recv_snapshot_request(&mut self) -> Option<SnapshotRequest> {
-        self.snapshot_request_receiver.recv().await
-    }
-}
-
 /// Manager for PubSub operations
 #[derive(Clone)]
 pub struct PubSubManager {
     redis: ConnectionManager,
     pubsub_tx: tokio::sync::broadcast::Sender<PushInfo>,
-    cancellation_token: CancellationToken,
 }
 
 impl PubSubManager {
@@ -121,13 +87,8 @@ impl PubSubManager {
     pub fn new(
         redis: ConnectionManager,
         pubsub_tx: tokio::sync::broadcast::Sender<PushInfo>,
-        cancellation_token: CancellationToken,
     ) -> Self {
-        Self {
-            redis,
-            pubsub_tx,
-            cancellation_token,
-        }
+        Self { redis, pubsub_tx }
     }
 
     pub async fn subscribe_to_channel(&mut self, channel: &str) -> Result<ChannelReceiver> {
@@ -139,286 +100,5 @@ impl PubSubManager {
             inner: self.pubsub_tx.subscribe(),
             channel: channel.to_string(),
         })
-    }
-
-    /// Publish an event to a partition channel
-    pub async fn publish_event(
-        &mut self,
-        partition_id: u32,
-        event: &GameEventMessage,
-    ) -> Result<()> {
-        let channel = RedisKeys::partition_events(partition_id);
-        let data = serde_json::to_vec(event).context("Failed to serialize event")?;
-
-        let _: () = self
-            .redis
-            .publish(&channel, data)
-            .await
-            .context("Failed to publish event")?;
-
-        debug!(
-            "Published event to channel {} for game {}: {:?}",
-            channel, event.game_id, event.event
-        );
-
-        Ok(())
-    }
-
-    /// Publish a snapshot to a partition channel and store in Redis.
-    ///
-    /// `stream_seq` is the executor-assigned transport sequence for this
-    /// message (0 for pre-executor publishes, e.g. match creation). Returns
-    /// the constructed snapshot event so callers can trace exactly what was
-    /// published without rebuilding it.
-    pub async fn publish_snapshot(
-        &self,
-        partition_id: u32,
-        game_id: u32,
-        snapshot: &GameState,
-        stream_seq: u64,
-    ) -> Result<GameEventMessage> {
-        // Create a snapshot event
-        let event = GameEventMessage {
-            game_id,
-            tick: snapshot.tick,
-            sequence: snapshot.event_sequence,
-            stream_seq,
-            user_id: None,
-            event: GameEvent::Snapshot {
-                game_state: snapshot.clone(),
-            },
-        };
-
-        // Publish to partition events channel
-        let channel = RedisKeys::partition_events(partition_id);
-        let data = serde_json::to_vec(&event).context("Failed to serialize snapshot event")?;
-
-        let mut redis = self.redis.clone();
-        let _: () = redis
-            .publish(&channel, data)
-            .await
-            .context("Failed to publish snapshot")?;
-
-        self.store_snapshot(game_id, snapshot).await?;
-
-        info!(
-            "Published snapshot for game {} at tick {} to partition {} (stream_seq {})",
-            game_id, snapshot.tick, partition_id, stream_seq
-        );
-
-        Ok(event)
-    }
-
-    /// Store a game snapshot in Redis WITHOUT publishing it to subscribers.
-    ///
-    /// Two callers rely on this: the game loop refreshes it periodically so a
-    /// takeover executor can resume in-flight games from near-current state
-    /// (see game_executor::resume_partition_games), and the completion path
-    /// stores the terminal state as the reload fallback before publishing
-    /// completion events and releasing the in-memory copy. 5-minute TTL: a
-    /// game whose executor stays dead longer than that is not resumable.
-    pub async fn store_snapshot(&self, game_id: u32, snapshot: &GameState) -> Result<()> {
-        let key = RedisKeys::game_snapshot(game_id);
-        let data =
-            serde_json::to_vec(snapshot).context("Failed to serialize snapshot for storage")?;
-        let mut redis = self.redis.clone();
-        let _: () = redis
-            .set_ex(&key, data, 300)
-            .await
-            .context("Failed to store snapshot")?;
-        Ok(())
-    }
-
-    /// Request snapshots for all games in a partition
-    pub async fn request_partition_snapshots(&mut self, partition_id: u32) -> Result<()> {
-        let channel = RedisKeys::snapshot_requests(partition_id);
-        let request = SnapshotRequest {
-            partition_id,
-            requester_id: None,
-        };
-
-        let data = serde_json::to_vec(&request).context("Failed to serialize snapshot request")?;
-
-        let _: () = self
-            .redis
-            .publish(&channel, data)
-            .await
-            .context("Failed to publish snapshot request")?;
-
-        debug!("Requested snapshots for partition {}", partition_id);
-        Ok(())
-    }
-
-    /// Get stored snapshot from Redis
-    pub async fn get_stored_snapshot(&mut self, game_id: u32) -> Result<Option<GameState>> {
-        let data: Option<Vec<u8>> = self
-            .redis
-            .get(RedisKeys::game_snapshot(game_id))
-            .await
-            .context("Failed to get snapshot from Redis")?;
-
-        match data {
-            Some(bytes) => {
-                let snapshot =
-                    serde_json::from_slice(&bytes).context("Failed to deserialize snapshot")?;
-                Ok(Some(snapshot))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Subscribe to a partition's events, commands and snapshot requests
-    pub async fn subscribe_to_partition(
-        &mut self,
-        partition_id: u32,
-    ) -> Result<PartitionSubscription> {
-        // Create channels for receiving messages
-        let (event_tx, event_rx) = mpsc::channel(2000);
-        let (command_tx, command_rx) = mpsc::channel(2000);
-        let (request_tx, request_rx) = mpsc::channel(2000);
-
-        // Establish all Redis subscriptions before reporting readiness. Redis Pub/Sub is
-        // ephemeral, so returning while these SUBSCRIBE commands are still in flight can drop
-        // the first GameCreated command during server startup.
-        let events_handle = self
-            .spawn_channel_handler(
-                RedisKeys::partition_events(partition_id),
-                event_tx,
-                "Events",
-            )
-            .await?;
-        let commands_handle = self
-            .spawn_channel_handler(
-                RedisKeys::partition_commands(partition_id),
-                command_tx,
-                "Commands",
-            )
-            .await?;
-        let requests_handle = self
-            .spawn_channel_handler(
-                RedisKeys::snapshot_requests(partition_id),
-                request_tx,
-                "Requests",
-            )
-            .await?;
-
-        tokio::spawn(async move {
-            let (events_result, commands_result, requests_result) =
-                tokio::join!(events_handle, commands_handle, requests_handle);
-
-            if let Err(e) = events_result {
-                error!("Events task panicked: {}", e);
-            }
-            if let Err(e) = commands_result {
-                error!("Commands task panicked: {}", e);
-            }
-            if let Err(e) = requests_result {
-                error!("Requests task panicked: {}", e);
-            }
-        });
-
-        Ok(PartitionSubscription {
-            partition_id,
-            event_receiver: event_rx,
-            command_receiver: command_rx,
-            snapshot_request_receiver: request_rx,
-        })
-    }
-
-    /// Publish a command to a partition
-    pub async fn publish_command(&self, partition_id: u32, command: &StreamEvent) -> Result<()> {
-        let json = serde_json::to_string(&command).context("Failed to serialize command")?;
-        let channel = RedisKeys::partition_commands(partition_id);
-        let mut redis = self.redis.clone();
-
-        let StreamEvent::GameCreated { game_id, .. } = command else {
-            let _: () = redis
-                .publish(&channel, json)
-                .await
-                .context("Failed to publish command")?;
-            return Ok(());
-        };
-
-        // GameCreated cannot be fire-and-forget: Redis Pub/Sub drops messages published before
-        // the partition executor subscribes. Retry until the responsible executor confirms that
-        // it accepted this game, making startup and failover races visible to the caller.
-        let ack_key = RedisKeys::game_creation_ack(*game_id);
-        let _: usize = redis.del(&ack_key).await?;
-        let deadline = Instant::now() + GAME_CREATION_ACK_TIMEOUT;
-
-        loop {
-            let _: usize = redis
-                .publish(&channel, &json)
-                .await
-                .context("Failed to publish GameCreated command")?;
-
-            let acknowledged: bool = redis.exists(&ack_key).await?;
-            if acknowledged {
-                let _: usize = redis.del(&ack_key).await?;
-                return Ok(());
-            }
-
-            if Instant::now() >= deadline {
-                return Err(anyhow!(
-                    "Partition executor did not acknowledge game {} within {:?}",
-                    game_id,
-                    GAME_CREATION_ACK_TIMEOUT
-                ));
-            }
-
-            sleep(GAME_CREATION_RETRY_INTERVAL).await;
-        }
-    }
-
-    /// Spawn a task to handle messages from a single channel
-    async fn spawn_channel_handler<T>(
-        &mut self,
-        channel_name: String,
-        sender: mpsc::Sender<T>,
-        task_name: &str,
-    ) -> Result<tokio::task::JoinHandle<()>>
-    where
-        T: DeserializeOwned + Send + 'static + Clone,
-    {
-        let mut channel_receiver = self.subscribe_to_channel(&channel_name).await?;
-        let cancellation_token = self.cancellation_token.clone();
-        let task_name = task_name.to_string();
-
-        let handle = tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-
-                    _ = cancellation_token.cancelled() => {
-                        info!("{} subscription task for channel {} received cancellation signal", task_name, channel_name);
-                        break;
-                    }
-
-                    message = channel_receiver.recv::<T>() => {
-                        match message {
-                            Ok(msg) => {
-                                if let Err(e) = sender.try_send(msg.clone()) {
-                                    match e {
-                                        mpsc::error::TrySendError::Full(_) => {
-                                            error!("{} channel full, message dropped", task_name);
-                                        }
-                                        mpsc::error::TrySendError::Closed(_) => {
-                                            warn!("{} receiver dropped, stopping subscription", task_name);
-                                            break;
-                                        }
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                error!("Failed to receive {} from channel {}: {}", task_name, channel_name, e);
-                                break;
-                            }
-                        }
-                    }
-                }
-            }
-        });
-
-        Ok(handle)
     }
 }

--- a/server/src/redis_keys.rs
+++ b/server/src/redis_keys.rs
@@ -131,17 +131,7 @@ impl RedisKeys {
         "lobby-updates".to_string()
     }
 
-    // === PubSub Channels ===
-
-    /// Partition events channel
-    pub fn partition_events(partition_id: u32) -> String {
-        format!("snaketron:events:partition:{}", partition_id)
-    }
-
-    /// Partition commands channel
-    pub fn partition_commands(partition_id: u32) -> String {
-        format!("snaketron:commands:partition:{}", partition_id)
-    }
+    // === PubSub Channels (loss-tolerant fan-out) ===
 
     /// Lobby chat channel
     pub fn lobby_chat_channel(lobby_code: &str) -> String {
@@ -163,22 +153,12 @@ impl RedisKeys {
         format!("game:{}:chat:history", game_id)
     }
 
-    /// Snapshot requests channel
-    pub fn snapshot_requests(partition_id: u32) -> String {
-        format!("snaketron:snapshot-requests:partition:{}", partition_id)
-    }
-
     /// Game snapshot key
     pub fn game_snapshot(game_id: u32) -> String {
         format!("game:snapshot:{}", game_id)
     }
 
-    /// Short-lived acknowledgement that a partition executor accepted GameCreated.
-    pub fn game_creation_ack(game_id: u32) -> String {
-        format!("game:creation-ack:{}", game_id)
-    }
-
-    // === Game Bus Streams Keys (SNAKETRON_BUS=streams) ===
+    // === Game Bus Streams Keys ===
 
     /// Stream carrying game events for a partition
     pub fn stream_events(partition_id: u32) -> String {
@@ -229,11 +209,8 @@ mod tests {
             RedisKeys::matchmaking_user_status(123),
             "matchmaking:user:123"
         );
-        assert_eq!(
-            RedisKeys::partition_events(0),
-            "snaketron:events:partition:0"
-        );
-        assert_eq!(RedisKeys::game_creation_ack(123), "game:creation-ack:123");
+        assert_eq!(RedisKeys::stream_events(0), "snaketron:stream:events:0");
+        assert_eq!(RedisKeys::game_snapshot(123), "game:snapshot:123");
 
         // Test game type hashing
         let game_type = common::GameType::FreeForAll { max_players: 2 };

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -1,6 +1,5 @@
-use crate::game_bus::{BusKind, GameBus};
+use crate::game_bus::{GameBus, PartitionSubscription};
 use crate::game_executor::{PARTITION_COUNT, StreamEvent};
-use crate::pubsub_manager::{PartitionSubscription, PubSubManager};
 use anyhow::{Context, Result};
 use common::{GameEvent, GameEventMessage, GameState, GameStatus};
 use std::collections::{HashMap, HashSet};
@@ -109,7 +108,7 @@ impl FilteredEventReceiver {
     }
 }
 
-/// PartitionReplica subscribes to partition events via PubSub and maintains game states
+/// PartitionReplica subscribes to partition events on the game bus and maintains game states
 pub struct PartitionReplica {
     partition_id: u32,
     bus: Arc<GameBus>,
@@ -134,7 +133,9 @@ impl PartitionReplica {
     ) -> Self {
         let status = Arc::new(RwLock::new(ReplicationStatus {
             partition_id,
-            is_ready: true, // With PubSub, we're immediately ready
+            // Immediately ready: the subscription anchors at the stream tail
+            // and initial state arrives via the snapshot request below.
+            is_ready: true,
         }));
 
         Self {
@@ -181,10 +182,13 @@ impl PartitionReplica {
             game_id, self.partition_id
         );
 
-        // Transport-integrity check. Redis pub/sub is at-most-once: a gap in
+        // Transport-integrity check, kept as defense-in-depth. The Streams
+        // bus itself doesn't drop, but a gap can still appear past it (trim
+        // horizon after a long outage, broadcast-lag downstream): a gap in
         // stream_seq means this replica lost messages and its state can no
         // longer be trusted, so ask the executor for fresh snapshots. Stale
-        // or duplicate messages are dropped instead of double-applied.
+        // or duplicate messages are dropped instead of double-applied. On a
+        // healthy system this path sits idle (see DEBUGGING.md).
         let is_snapshot = matches!(&event_msg.event, GameEvent::Snapshot { .. });
         if event_msg.stream_seq > 0 {
             let last = {
@@ -333,10 +337,11 @@ impl PartitionReplica {
             mut snapshot_request_receiver,
         } = subscription;
 
-        // Mark as ready immediately (no catch-up needed with PubSub)
+        // Mark as ready immediately (initial state arrives via the snapshot
+        // request above; there is no historical catch-up phase)
         self.status.write().await.is_ready = true;
 
-        // Events and commands use separate Redis channels, so the durable completion marker can
+        // Events and commands use separate Redis streams, so the durable completion marker can
         // arrive before the final snapshot even though the executor publishes the snapshot first.
         // Track both sides and evict only after this replica has processed (and broadcast) that
         // terminal snapshot.
@@ -400,7 +405,7 @@ impl PartitionReplica {
                 // Drain snapshot requests (processed by game executor, not used here)
                 Some(_) = snapshot_request_receiver.recv() => {
                     // Snapshot requests are handled by the game executor, we just drain them
-                    // to prevent the channel from filling up and blocking the PubSub handler
+                    // to prevent the channel from filling up and stalling the stream reader
                 }
             }
         }
@@ -449,7 +454,7 @@ impl GameStateReader for ReplicationManager {
     }
 
     async fn is_ready(&self) -> bool {
-        // With PubSub, we're always ready
+        // Replicas are ready from startup; see PartitionReplica::new
         true
     }
 }
@@ -515,7 +520,7 @@ impl ReplicationManager {
         seqs.get(&game_id).copied().unwrap_or(0)
     }
 
-    /// Get a game state, always ready with PubSub
+    /// Get a game state (replicas are always ready; no readiness gate)
     pub async fn get_game_state_when_ready(&self, game_id: u32) -> Option<GameState> {
         self.get_game_state(game_id).await
     }
@@ -569,7 +574,6 @@ impl ReplicationManager {
         partitions: Vec<u32>,
         cancellation_token: CancellationToken,
         redis_url: &str,
-        bus_kind: BusKind,
     ) -> Result<Self> {
         let game_states = Arc::new(RwLock::new(HashMap::new()));
         let game_event_broadcasters = Arc::new(RwLock::new(HashMap::new()));
@@ -577,19 +581,17 @@ impl ReplicationManager {
         let statuses = Arc::new(RwLock::new(HashMap::new()));
         let mut workers = Vec::new();
 
-        // The replication workers get their own Redis connection (and thus
-        // their own push firehose under pubsub), isolated from the main
-        // server's connection.
+        // The replication workers get their own Redis connection, isolated
+        // from the main server's connection. The push channel only satisfies
+        // the shared connection-manager config; nothing here subscribes to
+        // Pub/Sub pushes.
         let redis_client = redis::Client::open(redis_url)?;
         let (pubsub_tx, _pubsub_rx) = tokio::sync::broadcast::channel(5000);
         let redis =
             crate::redis_utils::create_connection_manager(redis_client.clone(), pubsub_tx.clone())
                 .await?;
 
-        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, cancellation_token.clone());
         let bus = Arc::new(GameBus::new(
-            bus_kind,
-            pubsub,
             redis,
             redis_client,
             cancellation_token.clone(),
@@ -632,7 +634,7 @@ impl ReplicationManager {
         self.game_states.clone()
     }
 
-    /// Check if all workers are ready (always true with PubSub)
+    /// Check if all workers are ready (always true; see PartitionReplica::new)
     pub async fn is_ready(&self) -> bool {
         true
     }

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -1169,8 +1169,8 @@ async fn authorize_game_join(
             return Err("This game is unavailable".to_string());
         }
         Ok(Some(cached_game_state)) => {
-            // GameCreated acknowledgement proves that the executor accepted the game, but the
-            // replica can consume its initial snapshot a moment later. A non-terminal Redis
+            // A stored Redis snapshot proves the game was created, but the replica can
+            // consume its initial snapshot a moment later. A non-terminal Redis
             // snapshot identifies that startup window, so wait briefly for the subscribable
             // in-memory state before treating the request as a durable reload.
             match replication_manager.wait_for_game(game_id, 1).await {
@@ -2845,7 +2845,6 @@ async fn process_ws_message(
                 }
                 WSMessage::GameCommand(command_message) => {
                     if let Some(game_id) = game_id {
-                        // Submit command via PubSub
                         let partition_id = game_id % PARTITION_COUNT;
 
                         let event = StreamEvent::GameCommandSubmitted {
@@ -2869,7 +2868,7 @@ async fn process_ws_message(
                                 })
                             }
                             Err(e) => {
-                                error!("Failed to submit command via PubSub: {}", e);
+                                error!("Failed to submit command via the game bus: {}", e);
                                 Ok(ConnectionState::Authenticated {
                                     metadata,
                                     lobby_handle: lobby,

--- a/server/tests/completed_game_snapshot_tests.rs
+++ b/server/tests/completed_game_snapshot_tests.rs
@@ -2,7 +2,7 @@ use anyhow::{Context, Result};
 use common::{GameState, GameStatus, GameType, QueueMode};
 use redis::AsyncCommands;
 use server::{
-    game_executor::PARTITION_COUNT, pubsub_manager::PubSubManager, redis_keys::RedisKeys,
+    game_bus::GameBus, game_executor::PARTITION_COUNT, redis_keys::RedisKeys,
     redis_utils::create_connection_manager,
 };
 use tokio::sync::broadcast;
@@ -20,17 +20,17 @@ fn redis_test_url() -> String {
     }
 }
 
-async fn test_pubsub_manager() -> Result<(PubSubManager, redis::aio::ConnectionManager)> {
+async fn test_game_bus() -> Result<(GameBus, redis::aio::ConnectionManager)> {
     let client = redis::Client::open(redis_test_url())
         .context("Redis is required for this integration test; start it with ./test-deps.sh")?;
     let (push_tx, _) = broadcast::channel(32);
-    let redis = create_connection_manager(client, push_tx.clone())
+    let redis = create_connection_manager(client.clone(), push_tx.clone())
         .await
         .context("Redis is required for this integration test; start it with ./test-deps.sh")?;
     let inspection_connection = redis.clone();
-    let manager = PubSubManager::new(redis, push_tx, CancellationToken::new());
+    let bus = GameBus::new(redis, client, CancellationToken::new());
 
-    Ok((manager, inspection_connection))
+    Ok((bus, inspection_connection))
 }
 
 fn unique_game_id() -> u32 {
@@ -59,16 +59,15 @@ fn completed_game_state() -> GameState {
 
 #[tokio::test]
 async fn completed_game_snapshot_round_trips_through_redis() -> Result<()> {
-    let (mut manager, mut redis) = test_pubsub_manager().await?;
+    let (bus, mut redis) = test_game_bus().await?;
     let game_id = unique_game_id();
     let key = RedisKeys::game_snapshot(game_id);
     let expected = completed_game_state();
 
-    manager
-        .publish_snapshot(game_id % PARTITION_COUNT, game_id, &expected, 0)
+    bus.publish_snapshot(game_id % PARTITION_COUNT, game_id, &expected, 0)
         .await?;
 
-    let actual = manager
+    let actual = bus
         .get_stored_snapshot(game_id)
         .await?
         .context("completed snapshot should be available for reload")?;
@@ -89,15 +88,14 @@ async fn completed_game_snapshot_round_trips_through_redis() -> Result<()> {
 
 #[tokio::test]
 async fn terminal_snapshot_can_be_cached_before_completion_is_broadcast() -> Result<()> {
-    let (manager, mut redis) = test_pubsub_manager().await?;
+    let (bus, mut redis) = test_game_bus().await?;
     let game_id = unique_game_id();
     let key = RedisKeys::game_snapshot(game_id);
     let expected = completed_game_state();
 
-    manager.store_snapshot(game_id, &expected).await?;
+    bus.store_snapshot(game_id, &expected).await?;
 
-    let mut reader = manager.clone();
-    let actual = reader
+    let actual = bus
         .get_stored_snapshot(game_id)
         .await?
         .context("terminal snapshot should be cached before eviction")?;
@@ -110,23 +108,23 @@ async fn terminal_snapshot_can_be_cached_before_completion_is_broadcast() -> Res
 
 #[tokio::test]
 async fn missing_game_snapshot_returns_none() -> Result<()> {
-    let (mut manager, mut redis) = test_pubsub_manager().await?;
+    let (bus, mut redis) = test_game_bus().await?;
     let game_id = unique_game_id();
     let key = RedisKeys::game_snapshot(game_id);
     let _: usize = redis.del(&key).await?;
 
-    assert!(manager.get_stored_snapshot(game_id).await?.is_none());
+    assert!(bus.get_stored_snapshot(game_id).await?.is_none());
     Ok(())
 }
 
 #[tokio::test]
 async fn malformed_game_snapshot_returns_deserialization_error() -> Result<()> {
-    let (mut manager, mut redis) = test_pubsub_manager().await?;
+    let (bus, mut redis) = test_game_bus().await?;
     let game_id = unique_game_id();
     let key = RedisKeys::game_snapshot(game_id);
     let _: () = redis.set_ex(&key, b"not-json".as_slice(), 30).await?;
 
-    let error = manager
+    let error = bus
         .get_stored_snapshot(game_id)
         .await
         .expect_err("corrupt snapshots must not be treated as valid game state");

--- a/server/tests/executor_resume_test.rs
+++ b/server/tests/executor_resume_test.rs
@@ -8,14 +8,14 @@
 //! store/scan path the production code uses.
 //!
 //! Isolation note: this test only writes/reads uniquely numbered
-//! game:snapshot:* keys — it publishes nothing on the shared pub/sub
-//! channels, so it cannot interfere with (or be affected by) a dev server
+//! game:snapshot:* keys — it publishes nothing on the shared partition
+//! streams, so it cannot interfere with (or be affected by) a dev server
 //! running against the same Redis.
 
 use anyhow::Result;
 use common::{GameState, GameStatus, GameType, QueueMode};
+use server::game_bus::GameBus;
 use server::game_executor::PARTITION_COUNT;
-use server::pubsub_manager::PubSubManager;
 use tokio::time::{Duration, timeout};
 use tokio_util::sync::CancellationToken;
 
@@ -52,17 +52,18 @@ async fn stored_snapshot_is_discoverable_for_resume() -> Result<()> {
         let redis_client = redis::Client::open(REDIS_URL)?;
         let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(64);
         let mut redis =
-            server::redis_utils::create_connection_manager(redis_client, pubsub_tx.clone()).await?;
+            server::redis_utils::create_connection_manager(redis_client.clone(), pubsub_tx.clone())
+                .await?;
 
         let token = CancellationToken::new();
-        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
+        let bus = GameBus::new(redis.clone(), redis_client, token.clone());
 
         let partition = 4;
         let game_id = unique_game_id(partition);
         let dead_executor_state = started_state(137);
 
         // The dying executor's last act: the TickHash-cadence snapshot store.
-        pubsub.store_snapshot(game_id, &dead_executor_state).await?;
+        bus.store_snapshot(game_id, &dead_executor_state).await?;
 
         // A takeover executor discovers it through the same scan path
         // run_game_executor uses, with an empty (cold) replica.
@@ -86,7 +87,7 @@ async fn stored_snapshot_is_discoverable_for_resume() -> Result<()> {
         complete_state.status = GameStatus::Complete {
             winning_snake_id: None,
         };
-        pubsub.store_snapshot(complete_id, &complete_state).await?;
+        bus.store_snapshot(complete_id, &complete_state).await?;
 
         let discovered = server::game_executor::load_stored_snapshots(&mut redis).await;
         let resumable =

--- a/server/tests/game_bus_test.rs
+++ b/server/tests/game_bus_test.rs
@@ -1,4 +1,4 @@
-//! Integration tests for the Streams game-bus transport (SNAKETRON_BUS=streams).
+//! Integration tests for the Streams game bus.
 //!
 //! Run against the test-deps Redis (test-deps.sh). Isolation: these tests use
 //! partition ids far outside the live range (game partitions are 0..10) so
@@ -6,14 +6,14 @@
 //! the same Redis.
 //!
 //! The headline test is `paused_consumer_loses_nothing`: the exact scenario —
-//! a subscriber that stops draining for a while — where Pub/Sub drops
-//! messages (broadcast lag / at-most-once) and Streams must not.
+//! a subscriber that stops draining for a while — where the old Pub/Sub
+//! transport dropped messages (broadcast lag / at-most-once) and Streams
+//! must not.
 
 use anyhow::Result;
 use common::{GameEvent, GameEventMessage};
-use server::game_bus::{BusKind, GameBus};
+use server::game_bus::GameBus;
 use server::game_executor::StreamEvent;
-use server::pubsub_manager::PubSubManager;
 use server::redis_keys::RedisKeys;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::time::timeout;
@@ -35,8 +35,7 @@ async fn streams_bus(token: CancellationToken) -> Result<GameBus> {
     let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(64);
     let redis =
         server::redis_utils::create_connection_manager(client.clone(), pubsub_tx.clone()).await?;
-    let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
-    Ok(GameBus::new(BusKind::Streams, pubsub, redis, client, token))
+    Ok(GameBus::new(redis, client, token))
 }
 
 fn event(game_id: u32, stream_seq: u64) -> GameEventMessage {
@@ -77,7 +76,7 @@ async fn paused_consumer_loses_nothing() -> Result<()> {
         let game_id = partition;
 
         let mut sub = bus.subscribe_to_partition(partition).await?;
-        // Give the reader task a moment to issue its first XREAD ("$").
+        // Give the reader task a moment to issue its first XREAD.
         tokio::time::sleep(Duration::from_millis(100)).await;
 
         // Publish MORE messages than the subscriber channel holds (2000)
@@ -163,8 +162,9 @@ async fn subscription_starts_at_now_not_history() -> Result<()> {
         let bus = streams_bus(token.clone()).await?;
         let partition = test_partition(3);
 
-        // History that must NOT be delivered: subscriptions anchor on
-        // snapshots (like the pubsub transport), not on stream history.
+        // History that must NOT be delivered: subscriptions start at the
+        // stream tail and rely on snapshots for initial state, not on
+        // replaying stream history.
         for seq in 1..=50u64 {
             bus.publish_event(partition, &event(partition, seq)).await?;
         }
@@ -348,44 +348,35 @@ async fn reader_reconnect_resumes_without_loss_or_duplicates() -> Result<()> {
     .await?
 }
 
-/// Manual A/B benchmark across both transports; ignored in normal runs.
-/// cargo test -p server --test game_bus_test bench_both -- --ignored --nocapture
+/// Manual latency benchmark; ignored in normal runs.
+/// cargo test -p server --test game_bus_test bench_streams -- --ignored --nocapture
 #[tokio::test]
 #[ignore]
-async fn bench_both_transports() -> Result<()> {
-    for kind in [BusKind::PubSub, BusKind::Streams] {
-        let token = CancellationToken::new();
-        let client = redis::Client::open(REDIS_URL)?;
-        let (pubsub_tx, _rx) = tokio::sync::broadcast::channel(5000);
-        let redis =
-            server::redis_utils::create_connection_manager(client.clone(), pubsub_tx.clone())
-                .await?;
-        let pubsub = PubSubManager::new(redis.clone(), pubsub_tx, token.clone());
-        let bus = GameBus::new(kind, pubsub, redis, client, token.clone());
-        let partition = test_partition(6);
+async fn bench_streams() -> Result<()> {
+    let token = CancellationToken::new();
+    let bus = streams_bus(token.clone()).await?;
+    let partition = test_partition(6);
 
-        let mut sub = bus.subscribe_to_partition(partition).await?;
-        tokio::time::sleep(Duration::from_millis(300)).await;
+    let mut sub = bus.subscribe_to_partition(partition).await?;
+    tokio::time::sleep(Duration::from_millis(300)).await;
 
-        let mut latencies_us: Vec<u128> = Vec::new();
-        for round in 0..200u64 {
-            let sent = Instant::now();
-            bus.publish_event(partition, &event(partition, round + 1))
-                .await?;
-            sub.recv_event().await.expect("stream ended");
-            latencies_us.push(sent.elapsed().as_micros());
-            tokio::time::sleep(Duration::from_millis(25)).await;
-        }
-        latencies_us.sort_unstable();
-        println!(
-            "{:?}: p50={}us p90={}us p99={}us",
-            kind,
-            latencies_us[latencies_us.len() / 2],
-            latencies_us[latencies_us.len() * 90 / 100],
-            latencies_us[latencies_us.len() * 99 / 100],
-        );
-        token.cancel();
-        cleanup(partition).await;
+    let mut latencies_us: Vec<u128> = Vec::new();
+    for round in 0..200u64 {
+        let sent = Instant::now();
+        bus.publish_event(partition, &event(partition, round + 1))
+            .await?;
+        sub.recv_event().await.expect("stream ended");
+        latencies_us.push(sent.elapsed().as_micros());
+        tokio::time::sleep(Duration::from_millis(25)).await;
     }
+    latencies_us.sort_unstable();
+    println!(
+        "streams: p50={}us p90={}us p99={}us",
+        latencies_us[latencies_us.len() / 2],
+        latencies_us[latencies_us.len() * 90 / 100],
+        latencies_us[latencies_us.len() * 99 / 100],
+    );
+    token.cancel();
+    cleanup(partition).await;
     Ok(())
 }

--- a/server/tests/game_load_failure_tests.rs
+++ b/server/tests/game_load_failure_tests.rs
@@ -2,10 +2,9 @@ use ::common::{GameEvent, GameState, GameStatus, GameType, QueueMode};
 use anyhow::{Context, Result};
 use redis::AsyncCommands;
 use server::db::DURABLE_GAME_ID_FLOOR;
-use server::game_bus::{BusKind, GameBus};
+use server::game_bus::GameBus;
 use server::game_executor::{PARTITION_COUNT, StreamEvent, run_game_executor};
 use server::matchmaking_manager::MatchmakingManager;
-use server::pubsub_manager::PubSubManager;
 use server::redis_keys::RedisKeys;
 use server::redis_utils::create_connection_manager;
 use server::replication::ReplicationManager;
@@ -242,23 +241,16 @@ async fn live_game_join_is_authorized_before_enabling_game_chat() -> Result<()> 
     let redis_url = std::env::var("SNAKETRON_REDIS_URL")?;
     let redis_client = redis::Client::open(redis_url)?;
     let (push_tx, _) = broadcast::channel(16);
-    let publisher_connection =
-        create_connection_manager(redis_client.clone(), push_tx.clone()).await?;
-    // Publish on the same transport the test server's replicas subscribe to.
+    let publisher_connection = create_connection_manager(redis_client.clone(), push_tx).await?;
     let publisher = GameBus::new(
-        BusKind::from_env(),
-        PubSubManager::new(
-            publisher_connection.clone(),
-            push_tx,
-            CancellationToken::new(),
-        ),
         publisher_connection,
         redis_client.clone(),
         CancellationToken::new(),
     );
     let partition_id = game_id % PARTITION_COUNT;
 
-    // Pub/Sub startup is asynchronous. Republish until this server's replica proves the live
+    // Replica reader startup is asynchronous (subscriptions anchor at the stream tail, so
+    // earlier entries are invisible). Republish until this server's replica proves the live
     // state is available to the same authorization path used by JoinGame.
     timeout(Duration::from_secs(10), async {
         loop {
@@ -343,16 +335,8 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
         .await?;
 
     let (push_tx, _) = broadcast::channel(16);
-    let publisher_connection =
-        create_connection_manager(redis_client.clone(), push_tx.clone()).await?;
-    // Publish on the same transport the test server's replicas subscribe to.
+    let publisher_connection = create_connection_manager(redis_client.clone(), push_tx).await?;
     let publisher = GameBus::new(
-        BusKind::from_env(),
-        PubSubManager::new(
-            publisher_connection.clone(),
-            push_tx,
-            CancellationToken::new(),
-        ),
         publisher_connection,
         redis_client.clone(),
         CancellationToken::new(),
@@ -365,7 +349,7 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
 
     // The server sees the executor-stored Redis snapshot first and enters its bounded
     // readiness wait. Publishing shortly afterward models the replica consuming the initial
-    // snapshot after GameCreated was already acknowledged.
+    // snapshot a moment after the game was created.
     tokio::time::sleep(Duration::from_millis(200)).await;
     publisher
         .publish_snapshot(game_id % PARTITION_COUNT, game_id, &live_state, 0)
@@ -526,25 +510,15 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
     let redis_client = redis::Client::open(redis_url)?;
     let cancellation_token = CancellationToken::new();
     let (push_tx, _) = broadcast::channel(32);
-    let executor_connection =
-        create_connection_manager(redis_client.clone(), push_tx.clone()).await?;
-    let executor_pubsub = PubSubManager::new(
-        executor_connection.clone(),
-        push_tx.clone(),
-        cancellation_token.clone(),
-    );
-    // This test drives hand-built Pub/Sub publishers, so the executor's bus
-    // is pinned to pubsub independent of the SNAKETRON_BUS test matrix.
+    let executor_connection = create_connection_manager(redis_client.clone(), push_tx).await?;
     let executor_bus = Arc::new(GameBus::new(
-        BusKind::PubSub,
-        executor_pubsub,
         executor_connection.clone(),
         redis_client.clone(),
         cancellation_token.clone(),
     ));
-    let publisher_pubsub = PubSubManager::new(
+    let publisher_bus = GameBus::new(
         executor_connection.clone(),
-        push_tx,
+        redis_client.clone(),
         cancellation_token.clone(),
     );
     let replication_manager = Arc::new(
@@ -552,7 +526,6 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
             vec![partition_id],
             cancellation_token.clone(),
             &std::env::var("SNAKETRON_REDIS_URL")?,
-            BusKind::PubSub,
         )
         .await?,
     );
@@ -571,18 +544,13 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
         .await
     });
 
-    // The acknowledged publisher retries across the executor's subscription startup window.
-    publisher_pubsub
-        .publish_command(
-            partition_id,
-            &StreamEvent::GameCreated {
-                game_id,
-                game_state: final_state.clone(),
-            },
-        )
-        .await
-        .context("executor did not acknowledge GameCreated")?;
-
+    // The executor's command subscription anchors at the stream tail, and that
+    // happens asynchronously after the spawn above — a GameCreated published
+    // before the anchor is never delivered. Re-publishing is idempotent while
+    // the game is running (the executor ignores GameCreated for a game it
+    // already started), so publish until the executor proves acceptance by
+    // persisting the completed game. Persistence is checked before each
+    // publish so the loop stops as soon as the game went through.
     timeout(Duration::from_secs(20), async {
         loop {
             if let Some(game) = env.db().get_game_by_id(game_id as i32).await?
@@ -595,6 +563,15 @@ async fn executor_persists_a_completed_game_for_reload_after_cache_loss() -> Res
                     return Ok::<_, anyhow::Error>(());
                 }
             }
+            publisher_bus
+                .publish_command(
+                    partition_id,
+                    &StreamEvent::GameCreated {
+                        game_id,
+                        game_state: final_state.clone(),
+                    },
+                )
+                .await?;
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
     })

--- a/server/tests/sync_equivalence_test.rs
+++ b/server/tests/sync_equivalence_test.rs
@@ -3,7 +3,7 @@
 //! These tests run a fully in-process simulation of the production topology:
 //! an authoritative server-side `GameEngine` advanced on a virtual clock the
 //! way `game_executor::run_game` does, a deterministic transport with
-//! configurable latency/jitter/loss standing in for Redis pub/sub + WebSocket,
+//! configurable latency/jitter/loss standing in for the server bus + WebSocket,
 //! and a client-side `GameEngine` that sees only what the transport delivers.
 //! No network, no Redis, no sleeps — a 60-virtual-second game runs in
 //! milliseconds and is bit-for-bit reproducible from its seeds.
@@ -145,8 +145,9 @@ impl Transport {
     }
 
     fn send_to_client(&mut self, now_ms: i64, msg: GameEventMessage) {
-        // Snapshots are the reliable join/recovery path; everything else is
-        // at-most-once pub/sub and may be dropped.
+        // Snapshots are the reliable join/recovery path; everything else
+        // rides hops that can drop (broadcast lag, the WebSocket leg), so
+        // the simulation lets it be dropped.
         let droppable = !matches!(msg.event, GameEvent::Snapshot { .. });
         if droppable
             && self.cfg.drop_probability > 0.0


### PR DESCRIPTION
## What changed

The game-critical bus previously had two interchangeable transports behind an enum (`GameBus::PubSub | Streams`), selected per-process by `SNAKETRON_BUS`. Streams has been the default since the migration landed and is strictly better — ordered, replayable, backpressured — so this PR removes the Pub/Sub option entirely, along with every workaround that existed for its at-most-once semantics. Net **-782/+260 lines**.

- **`game_bus.rs`**: `GameBus` is now the streams implementation directly — `BusKind`, the `SNAKETRON_BUS` flag, and the enum dispatch are gone. `PartitionSubscription`/`SnapshotRequest` moved here from `pubsub_manager.rs`. Reader/anchor/trim behavior is unchanged.
- **`pubsub_manager.rs`** (424 → ~100 lines): keeps only `subscribe_to_channel` for loss-tolerant fan-out (chat, lobby updates, user counts), which intentionally stays on plain Pub/Sub. All partition/game methods removed — most notably the **GameCreated ack/retry handshake**, a workaround for Pub/Sub dropping commands published before the executor subscribes.
- **Workaround removals**: executor-side `game:creation-ack` write, the ack Redis key, and the three pubsub partition-channel keys.
- **CI**: the `SNAKETRON_BUS` test matrix is removed (one test job instead of two).
- **Tests**: the one test pinned to `BusKind::PubSub` (executor completed-game persistence) now drives the streams bus with a check-DB-then-publish retry loop — a streams subscription anchors at the tail, so a too-early publish is invisible, and re-publishing GameCreated is idempotent while the game runs. The A/B transport benchmark became a streams-only bench; three other suites construct `GameBus` directly for snapshot storage.
- **Docs**: STREAMS_MIGRATION.md status records the removal (its Phase 5 explicitly planned this cleanup once the flag became dead weight), DEBUGGING.md/CODEX.md no longer describe the game path as pub/sub.

## Why the ack handshake is safe to remove

The ack existed because Pub/Sub loses any command published before the executor subscribes. Under streams the same race is covered structurally: matchmaking stores the game snapshot (`game:snapshot:<id>`) *before* publishing GameCreated, and `run_game_executor`'s resume path (`select_resumable_games`) picks up any non-complete game found in stored snapshots — including `Stopped` games whose GameCreated was never delivered. This was already the recovery path under the streams default; nothing about it changes here.

## Deliberately kept

`stream_seq` gap detection and snapshot resync stay. They are not pubsub-specific: they still guard the hops past the bus (broadcast fan-out lag, the WebSocket leg) and trim-horizon loss after a long outage. Both the code and STREAMS_MIGRATION.md document keeping them as defense-in-depth whose counters should sit at ~0.

## Verification

- Full workspace suite green: `cargo test --all -- --test-threads=1` against test-deps (includes the chaos suite `sync_equivalence_test` 7/7, `game_bus_test` 6/6, and the rewritten `game_load_failure_tests` 8/8).
- `cargo clippy --all-targets --all-features` and `cargo fmt --check` clean.
- A multi-agent adversarial review of the diff (lost-behavior, correctness, test-integrity, and stale-reference lenses, each finding independently verified) confirmed only minor stale comments, all fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)