### PR TITLE
Disable ANSI log colors when stdout is not a terminal

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -23,9 +23,13 @@ async fn main() -> Result<()> {
     let filter = tracing_subscriber::EnvFilter::try_from_default_env()
         .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("debug"));
 
+    // Only emit ANSI color codes when stdout is a terminal; log collectors
+    // like CloudWatch render them as literal escape sequences.
+    let use_ansi = std::io::IsTerminal::is_terminal(&std::io::stdout());
+
     tracing_subscriber::registry()
         .with(filter)
-        .with(tracing_subscriber::fmt::layer())
+        .with(tracing_subscriber::fmt::layer().with_ansi(use_ansi))
         .init();
 
     // Database setup - now using DynamoDB


### PR DESCRIPTION
## Summary
ECS logs in CloudWatch were full of literal ANSI escape sequences (`[2m`, `[32m`, `[0m`) because the tracing subscriber in `server/src/main.rs` emits color codes unconditionally.

This enables ANSI output only when stdout is a TTY (`std::io::IsTerminal`), so:
- **ECS / CloudWatch** (stdout is a pipe): plain, readable log lines
- **Local `cargo run`** (stdout is a terminal): colored output unchanged

## Verification
Ran the built server binary both ways and inspected raw bytes:
- Piped stdout: `2026-07-21T01:10:51.758517Z  WARN aws_config::imds::region: ...` — no escape codes
- Under a pseudo-TTY (`script`): `^[[2m2026-07-21T01:11:20.557559Z^[[0m ^[[33m WARN^[[0m ...` — colors preserved

Also ran `cargo fmt --check` and `cargo clippy --bin server` clean.

After merge, the snaketron-io deploy repo needs a submodule bump to ship this to ECS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)