### PR TITLE
Harden server heartbeats and region cache against silent stalls

### DIFF
--- a/server/src/db/dynamodb.rs
+++ b/server/src/db/dynamodb.rs
@@ -16,7 +16,9 @@ use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
 use super::models::*;
-use super::{DURABLE_GAME_ID_FLOOR, Database};
+use super::{
+    DURABLE_GAME_ID_FLOOR, Database, SERVER_HEARTBEAT_FRESHNESS_SECONDS, ServerRegistration,
+};
 use crate::season::Season;
 
 pub struct DynamoDatabase {
@@ -30,10 +32,30 @@ const SECONDS_PER_DAY: i64 = 24 * 60 * 60;
 const DYNAMODB_CONTROL_PLANE_MAX_ATTEMPTS: usize = 30;
 const DYNAMODB_CONTROL_PLANE_RETRY_DELAY: Duration = Duration::from_secs(1);
 
+/// How long a SERVER registration item lives past its last heartbeat before
+/// DynamoDB TTL reaps it. Deliberately generous: staleness is already handled
+/// by heartbeat-freshness cutoffs at read time, so TTL is pure registry
+/// hygiene, and the wide margin ensures expiry can never race a live server
+/// whose heartbeats are temporarily failing.
+const SERVER_REGISTRATION_TTL_SECONDS: i64 = 3600;
+
+/// Build a DynamoDB client with explicit timeouts. The SDK ships with no
+/// response timeout, so a hung request would otherwise stall its caller
+/// indefinitely without ever erroring. Every DynamoDB client in the server
+/// must be built through this function.
+pub async fn dynamodb_client() -> Client {
+    let timeouts = aws_config::timeout::TimeoutConfig::builder()
+        .connect_timeout(Duration::from_secs(2))
+        .operation_attempt_timeout(Duration::from_secs(5))
+        .operation_timeout(Duration::from_secs(15))
+        .build();
+    let config = aws_config::from_env().timeout_config(timeouts).load().await;
+    Client::new(&config)
+}
+
 impl DynamoDatabase {
     pub async fn new() -> Result<Self> {
-        let config = aws_config::load_from_env().await;
-        let client = Client::new(&config);
+        let client = dynamodb_client().await;
 
         let table_prefix =
             std::env::var("DYNAMODB_TABLE_PREFIX").unwrap_or_else(|_| "snaketron".to_string());
@@ -798,6 +820,10 @@ impl Database for DynamoDatabase {
         item.insert("status".to_string(), Self::av_s("active"));
         item.insert("currentGameCount".to_string(), Self::av_n(0));
         item.insert("maxGameCapacity".to_string(), Self::av_n(100));
+        item.insert(
+            "ttl".to_string(),
+            Self::av_n(now.timestamp() + SERVER_REGISTRATION_TTL_SECONDS),
+        );
 
         self.client
             .put_item()
@@ -811,21 +837,54 @@ impl Database for DynamoDatabase {
         Ok(server_id)
     }
 
-    async fn update_server_heartbeat(&self, server_id: i32) -> Result<()> {
+    async fn update_server_heartbeat(
+        &self,
+        server_id: i32,
+        registration: &ServerRegistration,
+    ) -> Result<()> {
         let now = Utc::now();
 
+        // A full upsert rather than a bare timestamp bump: if the registration
+        // item was deleted out from under a live server (TTL reaper, manual
+        // cleanup), this recreates it whole instead of leaving a partial item
+        // or failing forever. if_not_exists preserves mutable counters.
         self.client
             .update_item()
             .table_name(self.main_table())
             .key("pk", Self::av_s(format!("SERVER#{}", server_id)))
             .key("sk", Self::av_s("META"))
-            .update_expression("SET lastHeartbeat = :now, gsi1sk = :gsi1sk, gsi2sk = :gsi2sk")
+            .update_expression(
+                "SET lastHeartbeat = :now, gsi1sk = :gsi1sk, gsi2sk = :gsi2sk, #ttl = :ttl, \
+                 gsi1pk = :gsi1pk, gsi2pk = :gsi2pk, id = :id, grpcAddress = :grpc, \
+                 #region = :region, origin = :origin, wsUrl = :ws_url, \
+                 createdAt = if_not_exists(createdAt, :now), \
+                 #status = if_not_exists(#status, :active), \
+                 currentGameCount = if_not_exists(currentGameCount, :zero), \
+                 maxGameCapacity = if_not_exists(maxGameCapacity, :max_capacity)",
+            )
+            .expression_attribute_names("#ttl", "ttl")
+            .expression_attribute_names("#region", "region")
+            .expression_attribute_names("#status", "status")
             .expression_attribute_values(":now", Self::av_s(now.to_rfc3339()))
             .expression_attribute_values(":gsi1sk", Self::av_s(now.to_rfc3339()))
             .expression_attribute_values(
                 ":gsi2sk",
                 Self::av_s(format!("{}#SERVER#{}", now.to_rfc3339(), server_id)),
             )
+            .expression_attribute_values(
+                ":ttl",
+                Self::av_n(now.timestamp() + SERVER_REGISTRATION_TTL_SECONDS),
+            )
+            .expression_attribute_values(":gsi1pk", Self::av_s("SERVER"))
+            .expression_attribute_values(":gsi2pk", Self::av_s(&registration.region))
+            .expression_attribute_values(":id", Self::av_n(server_id))
+            .expression_attribute_values(":grpc", Self::av_s(&registration.grpc_address))
+            .expression_attribute_values(":region", Self::av_s(&registration.region))
+            .expression_attribute_values(":origin", Self::av_s(&registration.origin))
+            .expression_attribute_values(":ws_url", Self::av_s(&registration.ws_url))
+            .expression_attribute_values(":active", Self::av_s("active"))
+            .expression_attribute_values(":zero", Self::av_n(0))
+            .expression_attribute_values(":max_capacity", Self::av_n(100))
             .send()
             .await
             .context("Failed to update server heartbeat")?;
@@ -835,14 +894,21 @@ impl Database for DynamoDatabase {
     }
 
     async fn update_server_status(&self, server_id: i32, status: &str) -> Result<()> {
+        // Also stamp ttl so an item this upsert might create (e.g. status write
+        // racing a TTL reap) is itself reaped instead of lingering forever.
         self.client
             .update_item()
             .table_name(self.main_table())
             .key("pk", Self::av_s(format!("SERVER#{}", server_id)))
             .key("sk", Self::av_s("META"))
-            .update_expression("SET #status = :status")
+            .update_expression("SET #status = :status, #ttl = :ttl")
             .expression_attribute_names("#status", "status")
+            .expression_attribute_names("#ttl", "ttl")
             .expression_attribute_values(":status", Self::av_s(status))
+            .expression_attribute_values(
+                ":ttl",
+                Self::av_n(Utc::now().timestamp() + SERVER_REGISTRATION_TTL_SECONDS),
+            )
             .send()
             .await
             .context("Failed to update server status")?;
@@ -852,7 +918,7 @@ impl Database for DynamoDatabase {
     }
 
     async fn get_server_for_load_balancing(&self, region: &str) -> Result<i32> {
-        let thirty_seconds_ago = Utc::now() - chrono::Duration::seconds(30);
+        let cutoff = Utc::now() - chrono::Duration::seconds(SERVER_HEARTBEAT_FRESHNESS_SECONDS);
 
         let response = self
             .client
@@ -861,7 +927,7 @@ impl Database for DynamoDatabase {
             .index_name("GSI2")
             .key_condition_expression("gsi2pk = :region AND gsi2sk > :cutoff")
             .expression_attribute_values(":region", Self::av_s(region))
-            .expression_attribute_values(":cutoff", Self::av_s(thirty_seconds_ago.to_rfc3339()))
+            .expression_attribute_values(":cutoff", Self::av_s(cutoff.to_rfc3339()))
             .projection_expression("id, currentGameCount")
             .send()
             .await
@@ -884,7 +950,7 @@ impl Database for DynamoDatabase {
     }
 
     async fn get_active_servers(&self, region: &str) -> Result<Vec<(i32, String)>> {
-        let thirty_seconds_ago = Utc::now() - chrono::Duration::seconds(30);
+        let cutoff = Utc::now() - chrono::Duration::seconds(SERVER_HEARTBEAT_FRESHNESS_SECONDS);
 
         let response = self
             .client
@@ -893,7 +959,7 @@ impl Database for DynamoDatabase {
             .index_name("GSI2")
             .key_condition_expression("gsi2pk = :region AND gsi2sk > :cutoff")
             .expression_attribute_values(":region", Self::av_s(region))
-            .expression_attribute_values(":cutoff", Self::av_s(thirty_seconds_ago.to_rfc3339()))
+            .expression_attribute_values(":cutoff", Self::av_s(cutoff.to_rfc3339()))
             .projection_expression("id, grpcAddress")
             .send()
             .await
@@ -914,7 +980,7 @@ impl Database for DynamoDatabase {
     }
 
     async fn get_region_ws_url(&self, region: &str) -> Result<Option<String>> {
-        let thirty_seconds_ago = Utc::now() - chrono::Duration::seconds(30);
+        let cutoff = Utc::now() - chrono::Duration::seconds(SERVER_HEARTBEAT_FRESHNESS_SECONDS);
 
         let response = self
             .client
@@ -923,7 +989,7 @@ impl Database for DynamoDatabase {
             .index_name("GSI2")
             .key_condition_expression("gsi2pk = :region AND gsi2sk > :cutoff")
             .expression_attribute_values(":region", Self::av_s(region))
-            .expression_attribute_values(":cutoff", Self::av_s(thirty_seconds_ago.to_rfc3339()))
+            .expression_attribute_values(":cutoff", Self::av_s(cutoff.to_rfc3339()))
             .projection_expression("wsUrl")
             .limit(1) // We only need one server's WS URL
             .send()

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -16,6 +16,23 @@ use models::*;
 /// Redis loss safe while old nodes are still present.
 pub const DURABLE_GAME_ID_FLOOR: i32 = 1_000_000_000;
 
+/// How old a server heartbeat may be before that server no longer counts as
+/// alive. Shared by every consumer (region cache, load balancing, ws-url
+/// lookup) so a region is never advertised while its servers are considered
+/// ineligible, or vice versa.
+pub const SERVER_HEARTBEAT_FRESHNESS_SECONDS: i64 = 60;
+
+/// The metadata a server registers under; heartbeats re-assert it so a
+/// registration deleted out from under a live server (TTL reaper, manual
+/// cleanup) is transparently recreated on the next heartbeat.
+#[derive(Debug, Clone)]
+pub struct ServerRegistration {
+    pub grpc_address: String,
+    pub region: String,
+    pub origin: String,
+    pub ws_url: String,
+}
+
 // Several DB methods take a full column set as separate parameters by design.
 #[allow(clippy::too_many_arguments)]
 #[async_trait]
@@ -28,7 +45,11 @@ pub trait Database: Send + Sync {
         origin: &str,
         ws_url: &str,
     ) -> Result<i32>;
-    async fn update_server_heartbeat(&self, server_id: i32) -> Result<()>;
+    async fn update_server_heartbeat(
+        &self,
+        server_id: i32,
+        registration: &ServerRegistration,
+    ) -> Result<()>;
     async fn update_server_status(&self, server_id: i32, status: &str) -> Result<()>;
     async fn get_server_for_load_balancing(&self, region: &str) -> Result<i32>;
     async fn get_active_servers(&self, region: &str) -> Result<Vec<(i32, String)>>;

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -17,8 +17,12 @@ use crate::pubsub_manager::PubSubManager;
 use crate::redis_utils::create_connection_manager;
 use crate::region_cache::RegionCache;
 use crate::{
-    cluster_singleton::ClusterSingleton, db::Database, game_executor::run_game_executor,
-    matchmaking::run_matchmaking_loop, redis_keys::RedisKeys, replication::ReplicationManager,
+    cluster_singleton::ClusterSingleton,
+    db::{Database, ServerRegistration},
+    game_executor::run_game_executor,
+    matchmaking::run_matchmaking_loop,
+    redis_keys::RedisKeys,
+    replication::ReplicationManager,
     ws_server::JwtVerifier,
 };
 use redis::Client;
@@ -117,8 +121,20 @@ impl GameServer {
         // Start heartbeat loop to keep server registration alive
         let heartbeat_db = db.clone();
         let heartbeat_token = cancellation_token.clone();
+        let heartbeat_registration = ServerRegistration {
+            grpc_address: grpc_addr.clone(),
+            region: region.clone(),
+            origin: origin.clone(),
+            ws_url: ws_url.clone(),
+        };
         handles.push(tokio::spawn(async move {
-            run_heartbeat_loop(heartbeat_db, server_id, heartbeat_token).await;
+            run_heartbeat_loop(
+                heartbeat_db,
+                server_id,
+                heartbeat_registration,
+                heartbeat_token,
+            )
+            .await;
         }));
 
         // Create the broadcast channel for Redis Pub/Sub
@@ -169,8 +185,7 @@ impl GameServer {
         ));
 
         // Create RegionCache for dynamic region discovery
-        let aws_config = aws_config::load_from_env().await;
-        let dynamodb_client = aws_sdk_dynamodb::Client::new(&aws_config);
+        let dynamodb_client = crate::db::dynamodb::dynamodb_client().await;
         let table_prefix =
             env::var("DYNAMODB_TABLE_PREFIX").unwrap_or_else(|_| "snaketron".to_string());
         let region_cache = Arc::new(RegionCache::new(dynamodb_client, table_prefix));
@@ -499,10 +514,16 @@ pub fn get_available_port() -> u16 {
     port
 }
 
+/// Each heartbeat write must be bounded: a single hung request would otherwise
+/// silently block every later heartbeat until the region drops out of the
+/// region cache. Kept below the 5s interval so a stall never delays the next tick.
+const HEARTBEAT_WRITE_TIMEOUT: Duration = Duration::from_secs(4);
+
 /// Run a loop to update last_heartbeat in the database
 pub async fn run_heartbeat_loop(
     db: Arc<dyn Database>,
     server_id: u64,
+    registration: ServerRegistration,
     cancellation_token: CancellationToken,
 ) {
     let mut interval = tokio::time::interval(Duration::from_secs(5));
@@ -517,12 +538,24 @@ pub async fn run_heartbeat_loop(
             }
 
             _ = interval.tick() => {
-                match db.update_server_heartbeat(server_id as i32).await {
-                    Ok(()) => {
+                match tokio::time::timeout(
+                    HEARTBEAT_WRITE_TIMEOUT,
+                    db.update_server_heartbeat(server_id as i32, &registration),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
                         trace!(?server_id, "Heartbeat sent successfully.");
                     }
-                    Err(e) => {
+                    Ok(Err(e)) => {
                         error!(?server_id, error = %e, "Failed to send heartbeat");
+                    }
+                    Err(_) => {
+                        error!(
+                            ?server_id,
+                            timeout_secs = HEARTBEAT_WRITE_TIMEOUT.as_secs(),
+                            "Heartbeat write timed out"
+                        );
                     }
                 }
             }

--- a/server/src/region_cache.rs
+++ b/server/src/region_cache.rs
@@ -3,22 +3,38 @@ use aws_sdk_dynamodb::Client;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, error, info};
+use tracing::{debug, error, info, warn};
 
 use crate::api::regions::RegionMetadata;
+use crate::db::SERVER_HEARTBEAT_FRESHNESS_SECONDS;
+
+/// A cached region is only dropped after it has been absent from this many
+/// consecutive refreshes, so a single stale query result can't flap the list.
+const MAX_CONSECUTIVE_MISSES: u32 = 2;
+
+/// Upper bound on a single refresh, kept below the 30s refresh interval so a
+/// hung DynamoDB query can never wedge the refresh loop.
+const REFRESH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
 
 /// Cache for region metadata scanned from DynamoDB
 pub struct RegionCache {
-    cache: Arc<RwLock<HashMap<String, RegionMetadata>>>,
+    state: Arc<RwLock<CacheState>>,
     dynamodb_client: Client,
     table_prefix: String,
+}
+
+#[derive(Default)]
+struct CacheState {
+    regions: HashMap<String, RegionMetadata>,
+    /// Consecutive refreshes each cached region has been missing from query results.
+    miss_counts: HashMap<String, u32>,
 }
 
 impl RegionCache {
     /// Create a new region cache
     pub fn new(dynamodb_client: Client, table_prefix: String) -> Self {
         Self {
-            cache: Arc::new(RwLock::new(HashMap::new())),
+            state: Arc::new(RwLock::new(CacheState::default())),
             dynamodb_client,
             table_prefix,
         }
@@ -33,8 +49,8 @@ impl RegionCache {
     pub async fn refresh(&self) -> Result<()> {
         debug!("Refreshing region cache from DynamoDB");
 
-        // Calculate cutoff time (30 seconds ago)
-        let thirty_seconds_ago = chrono::Utc::now() - chrono::Duration::seconds(30);
+        let cutoff =
+            chrono::Utc::now() - chrono::Duration::seconds(SERVER_HEARTBEAT_FRESHNESS_SECONDS);
 
         // Query GSI1 for all servers
         // Note: "region" is a DynamoDB reserved keyword, so we use expression attribute names
@@ -50,7 +66,7 @@ impl RegionCache {
             )
             .expression_attribute_values(
                 ":cutoff",
-                aws_sdk_dynamodb::types::AttributeValue::S(thirty_seconds_ago.to_rfc3339()),
+                aws_sdk_dynamodb::types::AttributeValue::S(cutoff.to_rfc3339()),
             )
             .projection_expression("id, #region, origin, wsUrl")
             .expression_attribute_names("#region", "region")
@@ -61,7 +77,7 @@ impl RegionCache {
         let items = response.items.unwrap_or_default();
 
         // Group servers by region
-        let mut regions: HashMap<String, RegionMetadata> = HashMap::new();
+        let mut fresh: HashMap<String, RegionMetadata> = HashMap::new();
 
         for item in items {
             // Extract fields
@@ -81,8 +97,8 @@ impl RegionCache {
             };
 
             // If we haven't seen this region yet, add it
-            if !regions.contains_key(&region_id) {
-                regions.insert(
+            if !fresh.contains_key(&region_id) {
+                fresh.insert(
                     region_id.clone(),
                     RegionMetadata {
                         id: region_id.clone(),
@@ -95,13 +111,16 @@ impl RegionCache {
         }
 
         // Update cache
-        let mut cache = self.cache.write().await;
-        *cache = regions.clone();
+        let mut state = self.state.write().await;
+        merge_refresh(&mut state, fresh);
 
-        info!("Region cache refreshed: {} regions found", regions.len());
+        info!(
+            "Region cache refreshed: {} regions found",
+            state.regions.len()
+        );
         debug!(
             "Available regions: {:?}",
-            regions.keys().collect::<Vec<_>>()
+            state.regions.keys().collect::<Vec<_>>()
         );
 
         Ok(())
@@ -109,8 +128,8 @@ impl RegionCache {
 
     /// Get all cached regions
     pub async fn get_regions(&self) -> Vec<RegionMetadata> {
-        let cache = self.cache.read().await;
-        cache.values().cloned().collect()
+        let state = self.state.read().await;
+        state.regions.values().cloned().collect()
     }
 
     /// Start background refresh task that runs every 30 seconds
@@ -122,8 +141,10 @@ impl RegionCache {
             let mut interval = tokio::time::interval(std::time::Duration::from_secs(30));
 
             // Do initial refresh
-            if let Err(e) = self.refresh().await {
-                error!("Failed initial region cache refresh: {}", e);
+            match tokio::time::timeout(REFRESH_TIMEOUT, self.refresh()).await {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => error!("Failed initial region cache refresh: {}", e),
+                Err(_) => error!("Initial region cache refresh timed out"),
             }
 
             loop {
@@ -133,13 +154,50 @@ impl RegionCache {
                         break;
                     }
                     _ = interval.tick() => {
-                        if let Err(e) = self.refresh().await {
-                            error!("Failed to refresh region cache: {}", e);
+                        match tokio::time::timeout(REFRESH_TIMEOUT, self.refresh()).await {
+                            Ok(Ok(())) => {}
+                            Ok(Err(e)) => error!("Failed to refresh region cache: {}", e),
+                            Err(_) => error!("Region cache refresh timed out"),
                         }
                     }
                 }
             }
         });
+    }
+}
+
+/// Fold a refresh result into the cache. Regions present in `fresh` are updated
+/// and their miss counters reset; cached regions absent from `fresh` are kept
+/// until they have been missing for MAX_CONSECUTIVE_MISSES refreshes.
+fn merge_refresh(state: &mut CacheState, fresh: HashMap<String, RegionMetadata>) {
+    let missing: Vec<String> = state
+        .regions
+        .keys()
+        .filter(|id| !fresh.contains_key(*id))
+        .cloned()
+        .collect();
+
+    for id in missing {
+        let misses = state.miss_counts.entry(id.clone()).or_insert(0);
+        *misses += 1;
+        if *misses >= MAX_CONSECUTIVE_MISSES {
+            state.regions.remove(&id);
+            state.miss_counts.remove(&id);
+            info!(
+                "Region {} dropped from cache after {} consecutive missing refreshes",
+                id, MAX_CONSECUTIVE_MISSES
+            );
+        } else {
+            warn!(
+                "Region {} missing from refresh ({} consecutive); keeping cached entry",
+                id, misses
+            );
+        }
+    }
+
+    for (id, meta) in fresh {
+        state.miss_counts.remove(&id);
+        state.regions.insert(id, meta);
     }
 }
 
@@ -150,5 +208,88 @@ fn format_region_name(region_id: &str) -> String {
         "europe" => "Europe".to_string(),
         "asia" => "Asia".to_string(),
         _ => region_id.to_uppercase(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn meta(id: &str) -> RegionMetadata {
+        RegionMetadata {
+            id: id.to_string(),
+            name: format_region_name(id),
+            origin: format!("https://{}.example.com", id),
+            ws_url: format!("wss://{}.example.com/ws", id),
+        }
+    }
+
+    fn fresh(ids: &[&str]) -> HashMap<String, RegionMetadata> {
+        ids.iter().map(|id| (id.to_string(), meta(id))).collect()
+    }
+
+    fn cached_ids(state: &CacheState) -> Vec<String> {
+        let mut ids: Vec<String> = state.regions.keys().cloned().collect();
+        ids.sort();
+        ids
+    }
+
+    #[test]
+    fn adds_new_regions_and_updates_existing() {
+        let mut state = CacheState::default();
+        merge_refresh(&mut state, fresh(&["use1"]));
+        assert_eq!(cached_ids(&state), vec!["use1"]);
+
+        merge_refresh(&mut state, fresh(&["use1", "euw1"]));
+        assert_eq!(cached_ids(&state), vec!["euw1", "use1"]);
+    }
+
+    #[test]
+    fn keeps_region_through_a_single_missing_refresh() {
+        let mut state = CacheState::default();
+        merge_refresh(&mut state, fresh(&["use1", "euw1"]));
+
+        // use1 missing once: kept, miss counter at 1
+        merge_refresh(&mut state, fresh(&["euw1"]));
+        assert_eq!(cached_ids(&state), vec!["euw1", "use1"]);
+        assert_eq!(state.miss_counts.get("use1"), Some(&1));
+    }
+
+    #[test]
+    fn drops_region_after_consecutive_misses() {
+        let mut state = CacheState::default();
+        merge_refresh(&mut state, fresh(&["use1", "euw1"]));
+
+        merge_refresh(&mut state, fresh(&["euw1"]));
+        merge_refresh(&mut state, fresh(&["euw1"]));
+        assert_eq!(cached_ids(&state), vec!["euw1"]);
+        assert!(!state.miss_counts.contains_key("use1"));
+    }
+
+    #[test]
+    fn reappearing_region_resets_miss_counter() {
+        let mut state = CacheState::default();
+        merge_refresh(&mut state, fresh(&["use1", "euw1"]));
+
+        merge_refresh(&mut state, fresh(&["euw1"]));
+        merge_refresh(&mut state, fresh(&["use1", "euw1"]));
+        assert!(!state.miss_counts.contains_key("use1"));
+
+        // A later single miss starts counting from zero again
+        merge_refresh(&mut state, fresh(&["euw1"]));
+        assert_eq!(cached_ids(&state), vec!["euw1", "use1"]);
+        assert_eq!(state.miss_counts.get("use1"), Some(&1));
+    }
+
+    #[test]
+    fn empty_refresh_eventually_empties_cache() {
+        let mut state = CacheState::default();
+        merge_refresh(&mut state, fresh(&["use1"]));
+
+        merge_refresh(&mut state, HashMap::new());
+        assert_eq!(cached_ids(&state), vec!["use1"]);
+        merge_refresh(&mut state, HashMap::new());
+        assert!(state.regions.is_empty());
+        assert!(state.miss_counts.is_empty());
     }
 }


### PR DESCRIPTION
## What

Fixes the production incident (2026-07-21 00:31–00:55 UTC) where the USE1 region intermittently vanished from the public region list while the server was healthy.

- Build every DynamoDB client through a shared constructor with explicit connect/attempt/operation timeouts. The SDK ships with none, so a hung request stalled its caller silently — the region cache previously built its own un-timeoutted client, so a hung GSI query could freeze the region list permanently.
- Bound each heartbeat write at 4s and each region-cache refresh at 25s so a single hung call can never block either loop.
- Server-freshness cutoff widened to a shared 60s constant used by the region cache, load balancing, and ws-url lookup, so "region advertised" and "servers eligible" always agree; a region is dropped from the list only after 2 consecutive refreshes without a fresh heartbeat (hysteresis). Unit tests cover the merge logic.
- Heartbeats are now a full registration upsert stamping a `ttl` attribute: DynamoDB TTL reaps dead-server registrations (91 tombstones had accumulated since 2025-10-31), and a registration deleted out from under a live server (TTL race, manual cleanup) is transparently recreated on the next heartbeat. Status updates stamp ttl too so no partial item can outlive the reaper.

## Why

Root cause of the incident: the 5s heartbeat loop awaited an un-timeoutted DynamoDB write inline; one silently hung request blocked all subsequent heartbeats past the region cache's 30s freshness cutoff, so the region dropped out for a refresh cycle, in both regions' caches, several times in one evening.

## Reviewer notes

- Behavior tradeoff: a genuinely dead region now leaves the list in ~90–120s instead of ~30–60s (freshness window + hysteresis). Flap resistance was chosen deliberately after the incident.
- `update_server_heartbeat` gained a `ServerRegistration` parameter (trait + only impl + only caller updated).
- Rolling deploy is safe: old and new heartbeat formats are mutually readable; `ttl` only appears on items written by new code.
- `cargo test -p server`: 95 passed, 0 failed (LocalStack). Clippy and fmt clean.
- Companion infra PR in snaketron-io adds GSI autoscaling and a one-time tombstone cleanup script, and pins this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)