### PR TITLE
Show the dotted backdrop through the header and feather the frosted panels

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "web-client",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-lc", "cd client/web && npx webpack-dev-server --port 3100"],
+      "port": 3100
+    }
+  ]
+}

--- a/client/web/index.css
+++ b/client/web/index.css
@@ -31,14 +31,15 @@ body {
   min-height: 100svh;
   flex-direction: column;
   overflow-x: hidden;
-  isolation: isolate;
 }
 
-/* Site-wide dotted backdrop, mounted once at the app root behind all routes. */
+/* Site-wide dotted backdrop, mounted once at the app root behind all routes.
+   Kept at negative z-index (rather than isolating each page above it) so
+   frosted panels can reach it with backdrop-filter. */
 .home-arena-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 0;
+  z-index: -1;
   width: 100%;
   height: 100%;
   pointer-events: none;
@@ -59,9 +60,10 @@ body {
 
 .home-top-nav {
   display: flex;
-  height: 100%;
+  height: 44px;
   align-items: center;
   gap: 32px;
+  padding: 0 20px;
 }
 
 .home-nav-link,
@@ -97,7 +99,7 @@ body {
 .home-nav-link.is-active::after {
   position: absolute;
   right: 0;
-  bottom: 15px;
+  bottom: 8px;
   left: 0;
   height: 2px;
   border-radius: 1px;
@@ -254,8 +256,10 @@ body {
 
 .home-account {
   display: flex;
+  height: 44px;
   align-items: center;
   gap: 18px;
+  padding: 0 20px;
 }
 
 .home-account-action {
@@ -280,16 +284,6 @@ body {
   padding: 84px 20px 76px;
 }
 
-/* Leaderboards share the home shell while keeping the rankings as the focal surface. */
-.leaderboard-page .home-header,
-.leaderboard-page .home-status-rack {
-  position: fixed;
-}
-
-.leaderboard-page .home-header {
-  background: rgba(255, 255, 255, 0.97);
-}
-
 .leaderboard-main {
   box-sizing: border-box;
   width: 100%;
@@ -301,9 +295,42 @@ body {
   width: min(100%, 60rem);
 }
 
+/* Frosted panels keep foreground content legible over the dotted backdrop.
+   The tint/blur lives on a masked ::before that extends past the box and
+   feathers to transparent, so nearby dots fade out gradually instead of
+   hitting a hard panel edge. A pseudo (not the element itself) carries the
+   mask so child popouts like the social dropdown aren't masked away. */
+.home-top-nav,
+.home-account,
+.leaderboard-summary,
+.home-social-footer {
+  position: relative;
+}
+
+.home-top-nav::before,
+.home-account::before,
+.leaderboard-summary::before,
+.home-social-footer::before {
+  position: absolute;
+  z-index: -1;
+  inset: -14px -28px;
+  pointer-events: none;
+  background: rgba(255, 255, 255, 0.7);
+  -webkit-backdrop-filter: blur(14px);
+  backdrop-filter: blur(14px);
+  -webkit-mask-image:
+    linear-gradient(to right, transparent, #000 40px, #000 calc(100% - 40px), transparent),
+    linear-gradient(to bottom, transparent, #000 20px, #000 calc(100% - 20px), transparent);
+  -webkit-mask-composite: source-in;
+  mask-image:
+    linear-gradient(to right, transparent, #000 40px, #000 calc(100% - 40px), transparent),
+    linear-gradient(to bottom, transparent, #000 20px, #000 calc(100% - 20px), transparent);
+  mask-composite: intersect;
+  content: "";
+}
+
 .leaderboard-summary {
-  padding-bottom: 26px;
-  border-bottom: 2px solid #eef0f3;
+  padding: 20px 22px;
 }
 
 .leaderboard-control-frame {
@@ -337,6 +364,7 @@ body {
   display: grid;
   justify-items: center;
   gap: 9px;
+  padding: 10px 18px 9px;
   transform: translateX(-50%);
 }
 
@@ -772,6 +800,8 @@ a.home-social-icon:hover {
 
   .home-top-nav {
     gap: 14px;
+    height: 40px;
+    padding: 0 12px;
   }
 
   .home-nav-link,
@@ -785,10 +815,12 @@ a.home-social-icon:hover {
 
   .home-account {
     gap: 10px;
+    height: 40px;
+    padding: 0 12px;
   }
 
   .home-nav-link.is-active::after {
-    bottom: 9px;
+    bottom: 7px;
   }
 
   .home-status-rack {
@@ -811,7 +843,7 @@ a.home-social-icon:hover {
   }
 
   .leaderboard-summary {
-    padding-bottom: 22px;
+    padding: 16px 14px;
   }
 
   .leaderboard-table .leaderboard-grid {
@@ -833,8 +865,13 @@ a.home-social-icon:hover {
   }
 
   .home-social-footer {
-    position: static;
+    position: relative;
+    bottom: auto;
+    left: auto;
+    width: fit-content;
     margin-top: 16px;
+    margin-right: auto;
+    margin-left: auto;
     transform: none;
   }
 
@@ -885,8 +922,13 @@ a.home-social-icon:hover {
 
 @media (min-width: 701px) and (max-height: 640px) {
   .home-social-footer {
-    position: static;
+    position: relative;
+    bottom: auto;
+    left: auto;
+    width: fit-content;
     margin-top: 16px;
+    margin-right: auto;
+    margin-left: auto;
     transform: none;
   }
 }


### PR DESCRIPTION
## What changed

- **Leaderboards header now matches home.** Removed the leaderboards-only overrides that made `.home-header` fixed with a `rgba(255,255,255,0.97)` background — that white bar was covering the dotted backdrop. Every page now uses the same transparent, absolutely-positioned header.
- **Frosted panels for foreground chrome.** The nav-link cluster, account cluster, leaderboard summary (rank + region/season/mode filters), and the social footer share one rule: a `::before` pseudo carrying `rgba(255,255,255,0.7)` + `backdrop-filter: blur(14px)`, masked by crossed linear gradients (40px horizontal / 20px vertical fades, `mask-composite: intersect`) and extended `-14px -28px` past the box. Dots right next to the text are barely visible and ramp smoothly to full strength — no hard panel edge. The effect lives on a pseudo rather than the element so child popouts (e.g. the Social dropdown) aren't masked away.
- **Made the blur actually composite.** `isolation: isolate` on `.home-page` made it a backdrop root, so `backdrop-filter` couldn't see the dot canvas mounted at the app root — the "blur" was previously just a white tint. Dropped the isolation and moved the canvas to `z-index: -1`, which keeps it behind all content while remaining visible to backdrop filters.
- **Footer pseudo containment fix.** In the breakpoints where the footer switches from fixed to in-flow, `position: static` let the absolutely-positioned pseudo resolve against the whole page and frost the entire viewport. Those breakpoints now use `position: relative` (with `bottom`/`left` reset) and center the pill with `width: fit-content` + auto margins.
- **Nav geometry.** The header clusters went from full-height (72px) strips to 44px pills (40px on narrow screens) with horizontal padding, and the active-link underline moved up to stay just under the text.
- Added `.claude/launch.json` so preview tooling can start the webpack dev server on port 3100 without running `npm start` (whose `kill-port` step would kill a dev server already occupying 3000).

## Why

On the home page the dotted backdrop showed under the transparent header, but the leaderboards page covered it with a near-opaque white bar, and text/icons elsewhere (footer, leaderboard filters) sat directly on the dots and visually clashed with them.

## Reviewer notes

- CSS-only change plus the untracked launch config; no TS/component changes. `npx tsc --noEmit` passes.
- `mask-composite: intersect` needs Chrome 120+/Safari 15.4+/Firefox 53+; the `-webkit-mask-composite: source-in` fallback is included.
- Verified in-browser on home + leaderboards at desktop, short-viewport (static footer), and mobile widths, including the Social dropdown overlap and scroll-under behavior of the fixed footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)