### PR TITLE
Reduce main-thread load during gameplay: gate backdrop, tick-rate React updates

### DIFF
--- a/client/web/App.tsx
+++ b/client/web/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter, Route } from 'react-router-dom';
+import { BrowserRouter, Route, matchPath, useLocation } from 'react-router-dom';
 import './index.css';
 import Auth from './components/Auth';
 import CustomGameCreator from './components/CustomGameCreator';
@@ -10,7 +10,7 @@ import GameModeSelector from './components/GameModeSelector';
 import AnimatedRoutes from './components/AnimatedRoutes';
 import LobbyInvitePage from './components/LobbyInvitePage';
 import { NewHome } from './components/NewHome';
-import { ArenaBackdrop } from './components/ArenaBackdrop';
+import { ArenaBackdrop, SHOW_BACKDROP_DURING_GAMEPLAY } from './components/ArenaBackdrop';
 import { Leaderboard } from './components/Leaderboard';
 import { MatchmakingBanner } from './components/MatchmakingBanner';
 import { WebSocketProvider } from './contexts/WebSocketContext';
@@ -19,9 +19,13 @@ import { UIProvider } from './contexts/UIContext';
 import { LatencyProvider } from './contexts/LatencyContext';
 
 function AppContent() {
+  const location = useLocation();
+  const isGameArenaActive = matchPath('/play/:gameId', location.pathname) !== null;
+  const showBackdrop = SHOW_BACKDROP_DURING_GAMEPLAY || !isGameArenaActive;
+
   return (
     <div className="min-h-screen flex flex-col">
-      <ArenaBackdrop />
+      {showBackdrop && <ArenaBackdrop />}
       <MatchmakingBanner />
       <AnimatedRoutes>
         <Route path="/" element={<NewHome />} />

--- a/client/web/components/ArenaBackdrop.tsx
+++ b/client/web/components/ArenaBackdrop.tsx
@@ -14,6 +14,10 @@ interface Color {
   blue: number;
 }
 
+// Kill switch for the backdrop during gameplay (/play/*), while investigating
+// rendering freezes and input delay. Flip to true to show it there again.
+export const SHOW_BACKDROP_DURING_GAMEPLAY = false;
+
 const FRAME_INTERVAL_MS = 1000 / 6;
 
 const INK: Color = { red: 71, green: 78, blue: 90 };

--- a/client/web/hooks/useGameEngine.ts
+++ b/client/web/hooks/useGameEngine.ts
@@ -55,6 +55,17 @@ export const useGameEngine = ({
   const watchdogBackoffMsRef = useRef(WATCHDOG_BACKOFF_INITIAL_MS);
   const watchdogNextSendAtRef = useRef(0);
   const prevSyncStatusRef = useRef<any | null>(null);
+  // Byte-identity caches for the engine's per-frame JSON exports. The engine
+  // only changes on tick boundaries and server events, so most animation
+  // frames serialize to the exact same string; skipping parse + setState on
+  // those frames keeps React updates at tick cadence (~10/s) instead of rAF
+  // cadence (~60/s).
+  const lastGameStateJsonRef = useRef<string | null>(null);
+  const lastCommittedStateJsonRef = useRef<string | null>(null);
+  const lastSyncStatusJsonRef = useRef<string | null>(null);
+  // Latest parsed committed state, for per-frame logic (liveness watchdog)
+  // that must not wait for the next JSON change.
+  const parsedCommittedStateRef = useRef<GameState | null>(null);
 
   // console.log('useGameEngine called (initial state:', !!initialState);
 
@@ -98,6 +109,10 @@ export const useGameEngine = ({
     watchdogBackoffMsRef.current = WATCHDOG_BACKOFF_INITIAL_MS;
     watchdogNextSendAtRef.current = 0;
     prevSyncStatusRef.current = null;
+    lastGameStateJsonRef.current = null;
+    lastCommittedStateJsonRef.current = null;
+    lastSyncStatusJsonRef.current = null;
+    parsedCommittedStateRef.current = null;
   }, [gameId]);
 
   const runGameLoop = useCallback(() => {
@@ -116,56 +131,75 @@ export const useGameEngine = ({
       // events into one React commit.
       engineRef.current.rebuildPredictedState(now);
 
-      // Update game state
+      // Update game state. Parse + setState only when the serialization
+      // actually changed: a fresh JSON.parse every frame would hand React a
+      // new object identity at rAF rate and re-render the arena tree (and
+      // re-run every gameState-keyed effect) even though nothing moved.
       const stateJson = engineRef.current.getGameStateJson();
-      const newState = JSON.parse(stateJson);
-      setGameState(newState);
+      if (stateJson !== lastGameStateJsonRef.current) {
+        lastGameStateJsonRef.current = stateJson;
+        setGameState(JSON.parse(stateJson));
+      }
 
       // Check if COMMITTED state is complete (for game over UI)
       const committedStateJson = engineRef.current.getCommittedStateJson();
-      const committedState = JSON.parse(committedStateJson);
-      setCommittedState(committedState);
-      if (typeof committedState.status === 'object' &&
-          committedState.status !== null &&
-          'Complete' in committedState.status) {
-        if (!isGameComplete) {
-          console.log('Committed state is complete, triggering game over UI');
-          setIsGameComplete(true);
+      if (committedStateJson !== lastCommittedStateJsonRef.current) {
+        lastCommittedStateJsonRef.current = committedStateJson;
+        const committedState = JSON.parse(committedStateJson);
+        parsedCommittedStateRef.current = committedState;
+        setCommittedState(committedState);
+        if (typeof committedState.status === 'object' &&
+            committedState.status !== null &&
+            'Complete' in committedState.status) {
+          if (!isGameComplete) {
+            console.log('Committed state is complete, triggering game over UI');
+            setIsGameComplete(true);
+          }
         }
       }
 
       // Sync health: watch the engine's stream/hash accounting for gaps and
       // divergence, and drive the resync + liveness watchdog paths.
       try {
-        const sync = JSON.parse(engineRef.current.getSyncStatusJson());
-        const prevSync = prevSyncStatusRef.current;
         const nowMs = Date.now();
+        // The sync counters only move when a server message is processed, so
+        // parse-on-change is safe for the delta detection below. The resync
+        // debounce and the watchdog are wall-clock driven and must keep
+        // running every frame — the watchdog fires precisely when messages
+        // stop, i.e. when this JSON stops changing.
+        const syncJson = engineRef.current.getSyncStatusJson();
+        if (syncJson !== lastSyncStatusJsonRef.current) {
+          lastSyncStatusJsonRef.current = syncJson;
+          const sync = JSON.parse(syncJson);
+          const prevSync = prevSyncStatusRef.current;
 
-        if (prevSync) {
-          if (sync.stream_gap_count > prevSync.stream_gap_count) {
-            recordTrace({
-              Note: {
-                ts_ms: nowMs,
-                note: `stream gap detected: gaps=${sync.stream_gap_count} missed=${sync.missed_messages} last_seq=${sync.last_stream_seq}`
-              }
-            });
-            autoUploadOnce('stream gap detected');
+          if (prevSync) {
+            if (sync.stream_gap_count > prevSync.stream_gap_count) {
+              recordTrace({
+                Note: {
+                  ts_ms: nowMs,
+                  note: `stream gap detected: gaps=${sync.stream_gap_count} missed=${sync.missed_messages} last_seq=${sync.last_stream_seq}`
+                }
+              });
+              autoUploadOnce('stream gap detected');
+            }
+            if (sync.total_mismatches > prevSync.total_mismatches) {
+              recordTrace({
+                Note: {
+                  ts_ms: nowMs,
+                  note: `hash mismatch at probe tick ${sync.last_probe_tick} (consecutive=${sync.consecutive_hash_mismatches}, total=${sync.total_mismatches})`
+                }
+              });
+            }
+            if (sync.consecutive_hash_mismatches >= 2 && prevSync.consecutive_hash_mismatches < 2) {
+              autoUploadOnce('2+ consecutive hash mismatches');
+            }
           }
-          if (sync.total_mismatches > prevSync.total_mismatches) {
-            recordTrace({
-              Note: {
-                ts_ms: nowMs,
-                note: `hash mismatch at probe tick ${sync.last_probe_tick} (consecutive=${sync.consecutive_hash_mismatches}, total=${sync.total_mismatches})`
-              }
-            });
-          }
-          if (sync.consecutive_hash_mismatches >= 2 && prevSync.consecutive_hash_mismatches < 2) {
-            autoUploadOnce('2+ consecutive hash mismatches');
-          }
+          prevSyncStatusRef.current = sync;
         }
-        prevSyncStatusRef.current = sync;
 
-        if (sync.needs_resync && nowMs - lastResyncSentAtRef.current >= RESYNC_DEBOUNCE_MS) {
+        const latestSync = prevSyncStatusRef.current;
+        if (latestSync?.needs_resync && nowMs - lastResyncSentAtRef.current >= RESYNC_DEBOUNCE_MS) {
           lastResyncSentAtRef.current = nowMs;
           onRequestResyncRef.current?.();
           engineRef.current.clearNeedsResync();
@@ -175,7 +209,7 @@ export const useGameEngine = ({
         // Liveness watchdog: the engine's bounded prediction freezes the
         // simulation when server messages stop; surface that to the UI and
         // nudge the server for a fresh snapshot with exponential backoff.
-        const committedStatus = committedState.status;
+        const committedStatus = parsedCommittedStateRef.current?.status;
         const isStarted =
           typeof committedStatus === 'object' &&
           committedStatus !== null &&
@@ -428,8 +462,15 @@ export const useGameEngine = ({
           // Synchronize React state before the caller dismisses its awaiting-snapshot overlay.
           // This prevents a reconnect or retry from briefly revealing the stale pre-reconnect
           // arena between receipt and the next animation frame.
-          const nextGameState = JSON.parse(engineRef.current.getGameStateJson());
-          const nextCommittedState = JSON.parse(engineRef.current.getCommittedStateJson());
+          const nextGameStateJson = engineRef.current.getGameStateJson();
+          const nextCommittedStateJson = engineRef.current.getCommittedStateJson();
+          const nextGameState = JSON.parse(nextGameStateJson);
+          const nextCommittedState = JSON.parse(nextCommittedStateJson);
+          // Keep the loop's byte-identity caches coherent with the state
+          // pushed here, outside the loop.
+          lastGameStateJsonRef.current = nextGameStateJson;
+          lastCommittedStateJsonRef.current = nextCommittedStateJson;
+          parsedCommittedStateRef.current = nextCommittedState;
           const snapshotIsComplete =
             typeof nextCommittedState.status === 'object' &&
             nextCommittedState.status !== null &&


### PR DESCRIPTION
## What changed

**1. Disable the dotted backdrop during gameplay (easy to flip back)**

The rendering freezes / input delay reports started after the dotted backdrop landed. `ArenaBackdrop` is now unmounted (canvas, ~6fps draw loop of 2-7k arc/fill calls, and pointer listeners all torn down) whenever the `/play/:gameId` route is active. A single exported flag, `SHOW_BACKDROP_DURING_GAMEPLAY` in `ArenaBackdrop.tsx`, restores the old always-on behavior when flipped to `true`.

**2. Stop updating React state 60×/sec in the game loop**

`useGameEngine`'s rAF loop was calling `JSON.parse` + `setState` on the engine's predicted state, committed state, and sync status every animation frame. The engine only mutates on tick boundaries (100ms) and server events, so those serializations are byte-identical between ticks — but a fresh parse gives React a new object identity, so the arena tree re-rendered at ~60fps and every `gameState`-keyed effect in `GameArena` (keydown listener, size calc, countdown interval, canvas render effect) tore down and re-ran every frame.

The loop now caches the last-seen JSON strings and only parses + sets state when the string changed, dropping `gameState` updates to tick cadence (~10/s) and `committedState` to server-event cadence.

## Reviewer notes

- The liveness watchdog deliberately still runs every frame: it fires exactly when server messages stop, which is when the sync JSON *stops* changing, so it can't sit behind the change guard. It reads committed status from a new `parsedCommittedStateRef` instead of a per-frame parse.
- The snapshot/resync path in `processServerEvent` sets React state outside the loop, so it updates the caches too; all caches reset on game-ID change.
- The guard fails safe: if two serializations of unchanged content ever differ byte-wise (e.g. map ordering after an engine rebuild), the cost is one redundant update, never a missed one.
- Verified with `tsc --noEmit`, a clean webpack build, and route-toggle behavior in the browser (backdrop present on `/`, unmounted on `/play/*`, restored on navigating back). The in-game loop itself wasn't exercised — no backend in the dev environment — so a feel-test in a real game is worthwhile before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)