### PR TITLE
Validate snake ownership before scheduling game commands

### DIFF
--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -6,8 +6,8 @@ use crate::xp_persistence;
 use anyhow::{Context, Result};
 use common::trace::{TRACE_FORMAT_VERSION, TraceRecord, TraceSide};
 use common::{
-    EXECUTOR_POLL_INTERVAL_MS, GameCommandMessage, GameEngine, GameEvent, GameEventMessage,
-    GameState, GameStatus, TICK_HASH_INTERVAL_TICKS,
+    EXECUTOR_POLL_INTERVAL_MS, GameCommand, GameCommandMessage, GameEngine, GameEvent,
+    GameEventMessage, GameState, GameStatus, TICK_HASH_INTERVAL_TICKS,
 };
 use redis::aio::ConnectionManager;
 use serde::{Deserialize, Serialize};
@@ -161,6 +161,47 @@ pub enum StreamEvent {
     },
 }
 
+/// A client-submitted command paired with the authenticated user id of the
+/// WebSocket connection that submitted it (carried by `GameCommandSubmitted`).
+#[derive(Debug)]
+struct SubmittedCommand {
+    user_id: u32,
+    command: GameCommandMessage,
+}
+
+/// Gate between the transport and the engine. Every field of a
+/// `GameCommandMessage` is client-controlled — including the claimed user_id
+/// and the target snake_id — so nothing in it is trusted: a `Turn` must
+/// target the snake the authenticated user owns in `GameState::players`, and
+/// system commands are never accepted from a client connection. The claimed
+/// identity is rewritten to the authenticated one so everything downstream
+/// (command ordering, the spectator check in `schedule_command`, the
+/// broadcast `CommandScheduled` event) operates on the real submitter.
+fn authorize_game_command(
+    state: &GameState,
+    user_id: u32,
+    mut command: GameCommandMessage,
+) -> Result<GameCommandMessage, &'static str> {
+    match command.command {
+        GameCommand::Turn { snake_id, .. } => match state.players.get(&user_id) {
+            None => return Err("user is not a player in this game"),
+            Some(player) if player.snake_id != snake_id => {
+                return Err("snake is not owned by the submitting user");
+            }
+            Some(_) => {}
+        },
+        GameCommand::UpdateStatus { .. } => {
+            return Err("system command submitted over a client connection");
+        }
+    }
+
+    command.command_id_client.user_id = user_id;
+    // The server id is assigned by the engine in process_command; a
+    // client-supplied one is discarded rather than trusted.
+    command.command_id_server = None;
+    Ok(command)
+}
+
 /// Decides when to emit a TickHash heartbeat: every `interval_ticks` committed
 /// ticks, or the equivalent span of wall time when the committed tick is not
 /// advancing (pre-start, completion pending) so it doubles as a liveness
@@ -204,7 +245,7 @@ async fn run_game(
     game_id: u32,
     game_state: GameState,
     bus: Arc<GameBus>,
-    mut command_receiver: mpsc::Receiver<GameCommandMessage>,
+    mut command_receiver: mpsc::Receiver<SubmittedCommand>,
     mut snapshot_request_receiver: mpsc::Receiver<SnapshotRequest>,
     db: Arc<dyn Database>,
     cancellation_token: CancellationToken,
@@ -346,9 +387,28 @@ async fn run_game(
             }
 
             // Process commands from the channel
-            Some(command) = command_receiver.recv() => {
-                debug!("Processing command for game {}. Command: {:?}",
-                    game_id, command);
+            Some(SubmittedCommand { user_id, command }) = command_receiver.recv() => {
+                debug!("Processing command for game {} from user {}. Command: {:?}",
+                    game_id, user_id, command);
+
+                // Rejected commands never reach the engine, so they are
+                // deliberately not recorded as CmdIn: the trace's command
+                // timeline must contain exactly what the engine executed for
+                // deterministic replay.
+                let command = match authorize_game_command(engine.get_committed_state(), user_id, command) {
+                    Ok(command) => command,
+                    Err(reason) => {
+                        warn!(
+                            "Dropping unauthorized command for game {} from user {}: {}",
+                            game_id, user_id, reason
+                        );
+                        recorder.note(format!(
+                            "dropped unauthorized command from user {}: {}",
+                            user_id, reason
+                        ));
+                        continue;
+                    }
+                };
 
                 let now_ms = chrono::Utc::now().timestamp_millis();
                 recorder.record(&TraceRecord::CmdIn {
@@ -747,7 +807,7 @@ pub async fn run_game_executor(
     let mut game_channels: HashMap<
         u32,
         (
-            mpsc::Sender<GameCommandMessage>,
+            mpsc::Sender<SubmittedCommand>,
             mpsc::Sender<SnapshotRequest>,
         ),
     > = HashMap::new();
@@ -760,7 +820,7 @@ pub async fn run_game_executor(
                           game_channels: &mut HashMap<
         u32,
         (
-            mpsc::Sender<GameCommandMessage>,
+            mpsc::Sender<SubmittedCommand>,
             mpsc::Sender<SnapshotRequest>,
         ),
     >| {
@@ -913,10 +973,12 @@ pub async fn run_game_executor(
                             info!("Game {} completed", game_id);
                         }
                     }
-                    StreamEvent::GameCommandSubmitted { game_id, user_id: _, command } => {
-                        // Route command to the appropriate game
+                    StreamEvent::GameCommandSubmitted { game_id, user_id, command } => {
+                        // Route command to the appropriate game, keeping the
+                        // authenticated user_id attached so the game loop can
+                        // validate ownership before scheduling.
                         if let Some((cmd_tx, _)) = game_channels.get(&game_id) {
-                            if let Err(e) = cmd_tx.send(command).await {
+                            if let Err(e) = cmd_tx.send(SubmittedCommand { user_id, command }).await {
                                 warn!("Failed to send command to game {}: {}", game_id, e);
                                 // The game might have ended, remove from channels
                                 game_channels.remove(&game_id);
@@ -935,8 +997,11 @@ pub async fn run_game_executor(
 
 #[cfg(test)]
 mod tests {
-    use super::{PARTITION_COUNT, TickHashCadence, select_resumable_games};
-    use common::{GameState, GameStatus, GameType, QueueMode};
+    use super::{PARTITION_COUNT, TickHashCadence, authorize_game_command, select_resumable_games};
+    use common::{
+        CommandId, Direction, GameCommand, GameCommandMessage, GameState, GameStatus, GameType,
+        QueueMode,
+    };
 
     fn state(status: GameStatus, tick: u32) -> GameState {
         let mut s = GameState::new(
@@ -1044,5 +1109,114 @@ mod tests {
         assert!(!cadence.due(19, 1499));
         assert!(cadence.due(20, 600));
         assert!(cadence.due(19, 1500));
+    }
+
+    const USER_A: u32 = 11;
+    const USER_B: u32 = 22;
+
+    /// Two-player state; returns (state, snake_of_user_a, snake_of_user_b).
+    fn two_player_state() -> (GameState, u32, u32) {
+        let mut s = GameState::new(
+            30,
+            30,
+            GameType::FreeForAll { max_players: 4 },
+            QueueMode::Quickmatch,
+            Some(1),
+            0,
+        );
+        let snake_a = s.add_player(USER_A, None).unwrap().snake_id;
+        let snake_b = s.add_player(USER_B, None).unwrap().snake_id;
+        (s, snake_a, snake_b)
+    }
+
+    fn turn_command(claimed_user_id: u32, snake_id: u32) -> GameCommandMessage {
+        GameCommandMessage {
+            command_id_client: CommandId {
+                tick: 5,
+                user_id: claimed_user_id,
+                sequence_number: 0,
+            },
+            command_id_server: None,
+            command: GameCommand::Turn {
+                snake_id,
+                direction: Direction::Up,
+            },
+        }
+    }
+
+    #[test]
+    fn turn_for_unowned_snake_is_rejected() {
+        let (state, _snake_a, snake_b) = two_player_state();
+        // USER_A's connection targets USER_B's snake.
+        let result = authorize_game_command(&state, USER_A, turn_command(USER_A, snake_b));
+        assert!(result.is_err(), "turning another player's snake must fail");
+    }
+
+    #[test]
+    fn spoofed_user_id_cannot_drive_another_players_snake() {
+        let (state, _snake_a, snake_b) = two_player_state();
+        // USER_A's connection claims to be USER_B and targets USER_B's snake:
+        // the claimed identity is client-controlled, so ownership must be
+        // checked against the authenticated identity.
+        let result = authorize_game_command(&state, USER_A, turn_command(USER_B, snake_b));
+        assert!(result.is_err(), "identity spoofing must not grant control");
+    }
+
+    #[test]
+    fn turn_for_own_snake_is_authorized_with_authenticated_identity() {
+        let (state, snake_a, _snake_b) = two_player_state();
+        // Claimed identity (USER_B) differs from the authenticated one; the
+        // authorized command must carry the authenticated identity.
+        let mut command = turn_command(USER_B, snake_a);
+        command.command_id_server = Some(CommandId {
+            tick: 9999,
+            user_id: USER_B,
+            sequence_number: 7,
+        });
+
+        let authorized = authorize_game_command(&state, USER_A, command).unwrap();
+        assert_eq!(authorized.command_id_client.user_id, USER_A);
+        assert_eq!(
+            authorized.command_id_server, None,
+            "a client-supplied server command id must be discarded"
+        );
+        assert_eq!(
+            authorized.command,
+            GameCommand::Turn {
+                snake_id: snake_a,
+                direction: Direction::Up,
+            }
+        );
+    }
+
+    #[test]
+    fn turn_from_non_player_is_rejected() {
+        let (state, snake_a, _snake_b) = two_player_state();
+        let spectator = 99;
+        let result = authorize_game_command(&state, spectator, turn_command(spectator, snake_a));
+        assert!(result.is_err(), "spectators must not drive snakes");
+    }
+
+    #[test]
+    fn update_status_from_client_is_rejected() {
+        let (state, _snake_a, _snake_b) = two_player_state();
+        let command = GameCommandMessage {
+            command_id_client: CommandId {
+                tick: 0,
+                user_id: USER_A,
+                sequence_number: 0,
+            },
+            command_id_server: None,
+            command: GameCommand::UpdateStatus {
+                status: GameStatus::Complete {
+                    winning_snake_id: None,
+                },
+            },
+        };
+        let result = authorize_game_command(&state, USER_A, command);
+        assert!(
+            result.is_err(),
+            "system commands must never be accepted from clients"
+        );
     }
 }

--- a/server/tests/duel_game_test.rs
+++ b/server/tests/duel_game_test.rs
@@ -1,10 +1,16 @@
 mod common;
 
 use crate::common::{TestClient, TestEnvironment};
-use ::common::{GameEvent, GameStatus, GameType, TeamId};
+use ::common::{
+    CommandId, Direction, GameCommand, GameCommandMessage, GameEvent, GameStatus, GameType, TeamId,
+};
 use anyhow::Result;
 use server::ws_server::WSMessage;
 use tokio::time::{Duration, timeout};
+
+// TestEnvironment sets process-global env vars, so tests in this binary must
+// not run concurrently.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Wait for a JoinGame message, skipping unrelated messages (e.g. UserCountUpdate).
 async fn wait_for_join_game(client: &mut TestClient, label: &str) -> Result<u32> {
@@ -45,6 +51,8 @@ async fn wait_for_snapshot(client: &mut TestClient, label: &str) -> Result<WSMes
 
 #[tokio::test]
 async fn test_duel_game() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+
     // Initialize tracing
     let _ = tracing_subscriber::fmt::try_init();
 
@@ -325,6 +333,193 @@ async fn test_duel_game() -> Result<()> {
         }
         _ => panic!("Expected GameEvent messages, got {:?} and {:?}", msg1, msg2),
     };
+
+    env.shutdown().await?;
+    Ok(())
+}
+
+/// A Turn command targeting another player's snake must be ignored by the
+/// executor, even when the attacker also spoofs the victim's user_id in the
+/// client command id. The victim's own command (sent second, in the opposite
+/// direction) is the positive control proving the command pipeline is live.
+#[tokio::test]
+async fn test_turn_for_unowned_snake_is_ignored() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+
+    let _ = tracing_subscriber::fmt::try_init();
+
+    let redis_client = redis::Client::open("redis://localhost:6379/1")?;
+    let mut redis_conn = redis_client.get_multiplexed_async_connection().await?;
+    let _: () = redis::cmd("FLUSHDB").query_async(&mut redis_conn).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut env = TestEnvironment::new("test_turn_for_unowned_snake_is_ignored").await?;
+    let (_, _server_id) = env.add_server().await?;
+    env.create_user().await?;
+    env.create_user().await?;
+
+    let server_addr = env.ws_addr(0).expect("Server should exist");
+
+    let mut attacker = TestClient::connect(&server_addr).await?;
+    let mut victim = TestClient::connect(&server_addr).await?;
+
+    let attacker_user_id = env.user_ids()[0] as u32;
+    let victim_user_id = env.user_ids()[1] as u32;
+
+    attacker.authenticate(env.user_ids()[0]).await?;
+    victim.authenticate(env.user_ids()[1]).await?;
+
+    attacker
+        .send_message(WSMessage::QueueForMatch {
+            game_type: GameType::TeamMatch { per_team: 1 },
+            queue_mode: ::common::QueueMode::Quickmatch,
+        })
+        .await?;
+    victim
+        .send_message(WSMessage::QueueForMatch {
+            game_type: GameType::TeamMatch { per_team: 1 },
+            queue_mode: ::common::QueueMode::Quickmatch,
+        })
+        .await?;
+
+    let join_id1 = wait_for_join_game(&mut attacker, "Attacker").await?;
+    let join_id2 = wait_for_join_game(&mut victim, "Victim").await?;
+    assert_eq!(join_id1, join_id2, "Both clients should join the same game");
+    let game_id = join_id1;
+
+    attacker.join_game(game_id).await?;
+    victim.join_game(game_id).await?;
+
+    let snapshot_msg = wait_for_snapshot(&mut attacker, "Attacker").await?;
+    wait_for_snapshot(&mut victim, "Victim").await?;
+
+    let victim_snake_id = match &snapshot_msg {
+        WSMessage::GameEvent(event) => match &event.event {
+            GameEvent::Snapshot { game_state } => {
+                game_state
+                    .players
+                    .get(&victim_user_id)
+                    .expect("Victim should have a snake")
+                    .snake_id
+            }
+            other => panic!("Expected Snapshot event, got {:?}", other),
+        },
+        other => panic!("Expected GameEvent message, got {:?}", other),
+    };
+
+    // Wait until the countdown is over and the game is actually ticking, so
+    // both commands below execute promptly (and long before either snake can
+    // reach a wall — duel snakes spawn facing the length of the arena).
+    timeout(Duration::from_secs(10), async {
+        loop {
+            if let WSMessage::GameEvent(event) = attacker.receive_message().await?
+                && event.tick >= 1
+            {
+                break Ok::<(), anyhow::Error>(());
+            }
+        }
+    })
+    .await??;
+
+    // The attack: sent from the attacker's connection, targeting the victim's
+    // snake AND claiming the victim's user_id. Duel snakes face Left/Right,
+    // so Up and Down are both legal turns.
+    attacker
+        .send_message(WSMessage::GameCommand(GameCommandMessage {
+            command_id_client: CommandId {
+                tick: 0,
+                user_id: victim_user_id,
+                sequence_number: 0,
+            },
+            command_id_server: None,
+            command: GameCommand::Turn {
+                snake_id: victim_snake_id,
+                direction: Direction::Up,
+            },
+        }))
+        .await?;
+
+    // Positive control, sent after the attack: the victim legitimately turns
+    // its own snake the other way.
+    victim
+        .send_message(WSMessage::GameCommand(GameCommandMessage {
+            command_id_client: CommandId {
+                tick: 0,
+                user_id: victim_user_id,
+                sequence_number: 0,
+            },
+            command_id_server: None,
+            command: GameCommand::Turn {
+                snake_id: victim_snake_id,
+                direction: Direction::Down,
+            },
+        }))
+        .await?;
+
+    // The forged command was submitted first, so if the executor accepted it,
+    // its CommandScheduled { ..Up } would be published before the legitimate
+    // command's. Scan until the legitimate turn is executed, then keep
+    // scanning briefly for stragglers.
+    let mut legit_turn_executed = false;
+    let forbidden = |event: &GameEvent| match event {
+        GameEvent::SnakeTurned {
+            snake_id,
+            direction,
+        } => *snake_id == victim_snake_id && *direction == Direction::Up,
+        GameEvent::CommandScheduled { command_message } => {
+            command_message.command
+                == GameCommand::Turn {
+                    snake_id: victim_snake_id,
+                    direction: Direction::Up,
+                }
+        }
+        _ => false,
+    };
+
+    timeout(Duration::from_secs(10), async {
+        while !legit_turn_executed {
+            if let WSMessage::GameEvent(event) = attacker.receive_message().await? {
+                assert!(
+                    !forbidden(&event.event),
+                    "forged turn for another player's snake reached the engine: {:?}",
+                    event.event
+                );
+                if let GameEvent::SnakeTurned {
+                    snake_id,
+                    direction,
+                } = &event.event
+                    && *snake_id == victim_snake_id
+                    && *direction == Direction::Down
+                {
+                    legit_turn_executed = true;
+                }
+            }
+        }
+        Ok::<(), anyhow::Error>(())
+    })
+    .await??;
+
+    // Tail scan: nothing stemming from the forged command may show up late.
+    let tail_deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    while tokio::time::Instant::now() < tail_deadline {
+        match timeout(Duration::from_millis(100), attacker.receive_message()).await {
+            Ok(Ok(WSMessage::GameEvent(event))) => {
+                assert!(
+                    !forbidden(&event.event),
+                    "forged turn surfaced after the legitimate one: {:?}",
+                    event.event
+                );
+            }
+            Ok(Ok(_)) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {} // no message within 100ms; keep scanning until the deadline
+        }
+    }
+
+    println!(
+        "✅ Forged turn (attacker user {} -> snake {}) was ignored; legitimate turn executed",
+        attacker_user_id, victim_snake_id
+    );
 
     env.shutdown().await?;
     Ok(())


### PR DESCRIPTION
## What

The game executor discarded the authenticated `user_id` that the WebSocket server attaches to `GameCommandSubmitted` and routed the raw client-supplied `GameCommandMessage` straight into `GameEngine::process_command`. Since `GameCommand::Turn` carries a client-controlled `snake_id` and `command_id_client.user_id` is also client-controlled (`schedule_command` only checks that the *claimed* user is *some* player), a modified client could turn any other player's snake, spoof another player's identity, or inject the system-only `UpdateStatus` command to force a game's status.

This PR threads the authenticated `user_id` through the per-game command channel (`SubmittedCommand`) and adds an authorization gate (`authorize_game_command`) between the transport and the engine:

- A `Turn` must target the snake the authenticated user owns per `GameState.players`; anything else is dropped with a warn log and a flight-recorder note.
- The claimed `user_id` is rewritten to the authenticated one, so command ordering, the spectator check in `schedule_command`, and the broadcast `CommandScheduled` event all operate on the real submitter (no-op for honest clients).
- A client-supplied `command_id_server` is discarded rather than trusted.
- `UpdateStatus` (failover/system command) is rejected outright from client connections.

## Reviewer notes

- **Trace determinism**: rejected commands are deliberately *not* recorded as `CmdIn` — the flight recorder's command timeline must contain exactly what the engine executed, or `trace_rca` replays would diverge from the live run. Rejections appear as recorder notes instead.
- **Honest clients are unaffected**: the web client (`process_local_command`) and bots always send their own `snake_id`/`user_id`, and every existing integration test turns the authenticated user's own snake.
- **Test proof**: the new end-to-end duel test (`test_turn_for_unowned_snake_is_ignored`) has an attacker forge the victim's identity and target the victim's snake over the real WS → game bus → executor pipeline, with the victim's own turn (opposite direction) as the positive control. Verified it fails on the unpatched executor — it catches the forged `CommandScheduled` — and passes with the fix.
- `duel_game_test.rs` now holds two tests, so it gained the per-binary `TEST_LOCK` required by `TestEnvironment`'s process-global env vars (same pattern as the other multi-test binaries).

## Testing

- New unit tests on the authorization gate: unowned snake, spoofed identity, non-player/spectator, client-supplied `UpdateStatus`, identity rewrite on the happy path.
- New integration test as above; three consecutive green runs, and confirmed red on the unpatched code.
- Chaos suite `sync_equivalence_test` green (7/7), `cargo test -p common` green, server unit tests green, clippy clean, `cargo fmt` applied.
- Known unrelated: the two MMR-widening matchmaking tests (`test_extreme_mmr_difference_max_30_seconds`, `test_silver_diamond_matches_in_30_seconds`) fail on this machine on unmodified master as well; suite-level runs here are additionally noisy because concurrent test runs share un-namespaced Redis keys and cluster with each other (separate fix tracked outside this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)