### PR TITLE
Add coordinated Snaketron autoscaling load tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ replays/
 
 # Sync flight-recorder traces (see DEBUGGING.md)
 traces/
+loadtest-reports/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1936,6 +1936,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23fb14cb19457329c82206317a5663005a4d404783dc74f4252769b0d5f42856"
 
 [[package]]
+name = "loadtest"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "clap",
+ "common",
+ "futures-util",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "server",
+ "tokio",
+ "tokio-tungstenite 0.24.0",
+ "tokio-util",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,7 +2600,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3348,8 +3369,12 @@ checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
 dependencies = [
  "futures-util",
  "log",
+ "rustls 0.23.31",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls 0.26.2",
  "tungstenite 0.24.0",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -3588,6 +3613,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
+ "rustls 0.23.31",
+ "rustls-pki-types",
  "sha1",
  "thiserror 1.0.69",
  "utf-8",
@@ -3862,6 +3889,24 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,6 @@ members = [
     "server",
     "client",
     "terminal",
-    "bot"
+    "bot",
+    "loadtest"
 ]

--- a/README.md
+++ b/README.md
@@ -72,10 +72,17 @@ RUST_LOG=info cargo test -p server -- --nocapture
 ```
 
 
-### Run load test
+### Run a coordinated autoscaling load test
 ```bash
-cargo run -p bot -- --url http://localhost:8080 --mode duel --bots 40 --games 10 --queue-mode quickmatch
+cargo run --release -p loadtest -- \
+  --target https://snaketron.io \
+  --confirm-production \
+  --require-scale-out \
+  --mode duel \
+  --queue-mode competitive
 ```
+
+The load runner supports Solo, Duel, 2v2, and FFA; creates deterministic full-party multiplayer lobbies; plays with the shared Rust/WASM game engine and AI; ramps to 256 maintained sessions by default; and writes an HTML/JSON report with per-failure details. See [loadtest/README.md](loadtest/README.md) for profiles, safety controls, and report semantics.
 
 ### Project Structure
 
@@ -83,6 +90,7 @@ cargo run -p bot -- --url http://localhost:8080 --mode duel --bots 40 --games 10
 - `server/` - Game server with WebSocket and gRPC support
 - `client/` - WebAssembly client module
 - `terminal/` - Terminal-based game viewer and replay player
+- `loadtest/` - Coordinated AI load generator and aggregate reporting
 - `specs/` - TLA+ specifications for distributed systems design
 
 ## Production Deployment

--- a/loadtest/Cargo.toml
+++ b/loadtest/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "loadtest"
+version = "0.1.0"
+edition = "2024"
+publish = false
+
+[[bin]]
+name = "snaketron-loadtest"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = "1"
+chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
+common = { path = "../common" }
+futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
+reqwest = { version = "0.11", features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+server = { path = "../server" }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time", "net", "sync", "signal"] }
+tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+tokio-util = "0.7"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
+url = "2"

--- a/loadtest/README.md
+++ b/loadtest/README.md
@@ -1,0 +1,90 @@
+# Snaketron coordinated load test
+
+`snaketron-loadtest` creates real guest sessions, connects them to one Snaketron region, puts each intended match into a complete lobby, queues synchronized waves, and plays every snake with the repository's existing AI.
+
+The runner deliberately does not use one browser per virtual user. The React hooks require a DOM, router, storage, and animation frames, making the load generator the bottleneck at autoscaling volumes. It instead reuses the same `common::GameEngine` compiled to WebAssembly for the React client, the same `common::calculate_ai_move` AI, and the server's canonical WebSocket message types.
+
+## Production autoscaling run
+
+Build in release mode and run from a machine outside the Snaketron cluster:
+
+Deploy the accompanying server changes first; `--require-scale-out` preflights
+the new `/api/regions/server-counts` observer endpoint before creating users.
+
+```bash
+cargo run --release -p loadtest -- \
+  --target https://snaketron.io \
+  --confirm-production \
+  --require-scale-out \
+  --mode duel \
+  --queue-mode competitive \
+  --run-id autoscale-20260721
+```
+
+The default staircase targets 4, 16, 64, 128, then 256 concurrent sessions for progressively longer bounded ramp-and-hold windows. Whole match groups are started at no more than four sessions per second, and completed groups are replaced through that same limiter. Override the plan and rate with, for example:
+
+```bash
+--stages 4@30s,32@1m,128@3m,512@5m
+--spawn-rate 8
+```
+
+Supported modes are `solo`, `duel`, `2v2`, and `ffa`. Every target must be a multiple of the match size: 1 for solo, 2 for duel, and 4 for 2v2/FFA. Solo uses one player per lobby; duel, 2v2, and FFA put the complete 2- or 4-player party in one lobby, deliberately covering multi-user lobby create/join/update behavior. The FFA matchmaker prefers a complete party over older partial public lobbies so test membership remains deterministic.
+
+Duel and 2v2 use the authoritative server game limit. Solo and FFA have no server time limit, so they play with the AI for two minutes by default, send `LeaveGame`, and confirm that the server processed it with an ordered ping. Natural completion before that window remains authoritative. Override the window with `--untimed-play-duration 5m`; when increasing it, also leave enough `--drain-timeout` for authentication, lobby setup, matchmaking, and the complete play window.
+
+`--max-total-sessions 4096` is a hard default safety ceiling across replacements. Production targets require `--confirm-production`; the check is repeated against the region origin and effective WebSocket URL returned by discovery. TLS certificate and hostname checks are never disabled.
+
+For a small invariant check, four duel sessions are released together as two complete lobbies and therefore create exactly two initial games:
+
+```bash
+cargo run --release -p loadtest -- \
+  --target https://snaketron.io \
+  --confirm-production \
+  --mode duel \
+  --queue-mode competitive \
+  --stages 4@30s \
+  --run-id four-session-check
+```
+
+## Session behavior
+
+Each virtual user performs the production lifecycle:
+
+1. `POST /api/auth/guest` with a deterministic `lt...` nickname.
+2. Discover regions through `/api/regions`; all sessions use the same healthy region.
+3. Connect by WebSocket and authenticate with the guest token.
+4. Create or join the match group's lobby and wait until every expected user ID appears in `LobbyUpdate`.
+5. Wait at a wave barrier, then have the lobby host queue the complete party.
+6. Receive `JoinGame`, join the assigned game, and initialize the shared `GameEngine` from its snapshot.
+7. Verify that the snapshot contains exactly the intended lobby members.
+8. Reconcile authoritative events, calculate AI moves once per predicted tick, and send normal game commands until authoritative completion. For an untimed Solo/FFA game, play until `--untimed-play-duration`, then leave successfully.
+9. Send application pings, measure RTT/clock offset, and reconnect up to twice using the browser client's two-second delay.
+
+A complete duel/2v2 lobby is split across the opposing teams by the existing matchmaker; a complete FFA lobby is selected intact. These choices isolate intended games from unrelated public queue participants. Snapshot membership validation turns any unexpected pairing into an explicit session failure.
+
+`--command-profile realistic` sends only actual direction changes, like UI input. `--command-profile every-tick` intentionally saturates the command path.
+
+## Reports
+
+Artifacts are written to `loadtest-reports/<run-id>/` by default:
+
+- `index.html` — aggregate session, authoritative/timeboxed game, latency, traffic, ramp, and infrastructure overview.
+- `summary.json` — the machine-readable aggregate plus compact status and completion kind for every session.
+- `failures/*.json` — complete lifecycle, metrics, failure context, and recent protocol events for every failed, cancelled, or incomplete session; the HTML report links to these files.
+
+The command exits unsuccessfully if fewer than 98% of launched sessions complete, the configured peak is never observed as concurrent logical sessions that have sent their authentication tokens, a session is lost from coordinator accounting, a stage misses that token-sent session target, a launched game is never observed, or deterministic pairing validation fails. Logical session concurrency continues across short reconnect gaps and does not claim every transport socket remains continuously open. Coordinator panics and force-aborted groups are synthesized as individual failed-session artifacts instead of disappearing from the denominator.
+
+Autoscaling evidence is reported separately. The harness samples regional user counts and active regional server counts throughout the run. Backend-cookie aliases, when present, remain a secondary in-band routing hint.
+
+Press Ctrl-C to stop adding load and drain active games. After `--drain-timeout` (five minutes by default), remaining sessions are cancelled and still included in the report. A drain cancellation is never reported as a successful timebox.
+
+## Production data note
+
+The current guest endpoint persists users, and completed matches can affect game/ranking records. Synthetic names are deterministic and prefixed `lt`; normally each created user ID is retained in its session diagnostics. A process/task panic after guest creation can lose that server-assigned ID, though the deterministic name and a synthetic failure record remain. If production load tests become routine, add a server-side synthetic-user marker with TTL and ranking exclusion.
+
+## Validation
+
+```bash
+cargo test -p loadtest
+cargo check -p loadtest
+```

--- a/loadtest/src/config.rs
+++ b/loadtest/src/config.rs
@@ -1,0 +1,1034 @@
+//! Command-line configuration and safety validation for the load-test runner.
+//!
+//! Parsing and validation are intentionally separate. [`Args`] describes the
+//! CLI, while [`Config`] is the validated input consumed by the coordinator.
+
+use clap::{Parser, ValueEnum};
+use std::error::Error;
+use std::fmt;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use url::Url;
+
+const DEFAULT_TARGET: &str = "http://localhost:8080";
+const DEFAULT_STAGES: &str = "4@30s,16@30s,64@1m,128@2m,256@5m";
+const DEFAULT_SPAWN_RATE: usize = 4;
+const DEFAULT_MAX_TOTAL_SESSIONS: usize = 4_096;
+const MAX_RUN_ID_LEN: usize = 64;
+
+/// CLI arguments for the Snaketron load test.
+///
+/// Production is deliberately not the default. Any target on `snaketron.io`
+/// also requires `--confirm-production` before [`Config`] can be created.
+#[derive(Debug, Clone, Parser)]
+#[command(
+    name = "snaketron-loadtest",
+    about = "Run coordinated, AI-driven Snaketron load-test sessions"
+)]
+pub struct Args {
+    /// Base HTTP(S) URL used for guest authentication and target identification.
+    #[arg(long, default_value = DEFAULT_TARGET, value_name = "URL")]
+    pub target: String,
+
+    /// Region identifier to request or record (for example, `use1`).
+    #[arg(long, value_name = "REGION")]
+    pub region: Option<String>,
+
+    /// Connect directly to this WebSocket endpoint instead of deriving one.
+    #[arg(long, value_name = "WS_URL")]
+    pub ws_url: Option<String>,
+
+    /// Match type exercised by each coordinated group.
+    #[arg(long, value_enum, default_value_t = GameMode::Duel)]
+    pub mode: GameMode,
+
+    /// Matchmaking queue to exercise.
+    #[arg(long, value_enum, default_value_t = QueueMode::Quickmatch)]
+    pub queue_mode: QueueMode,
+
+    /// Comma-separated target concurrency and ramp duration stages.
+    ///
+    /// Example: `4@30s,8@1m` gives the 4-session ramp/hold 30 seconds, then
+    /// gives the 8-session ramp/hold one minute. Once reached, a target is
+    /// maintained by replacing completed groups through the spawn limiter.
+    #[arg(long, default_value = DEFAULT_STAGES, value_name = "N@DURATION,...")]
+    pub stages: StagePlan,
+
+    /// Maximum virtual-user sessions started per second.
+    ///
+    /// Launches are rounded down to whole deterministic match groups. This
+    /// rate also limits replacement sessions when games finish or fail.
+    #[arg(long, default_value_t = DEFAULT_SPAWN_RATE, value_name = "SESSIONS")]
+    pub spawn_rate: usize,
+
+    /// Hard safety cap on virtual-user sessions created during the entire run.
+    #[arg(
+        long,
+        default_value_t = DEFAULT_MAX_TOTAL_SESSIONS,
+        value_name = "SESSIONS"
+    )]
+    pub max_total_sessions: usize,
+
+    /// Maximum time allowed to establish a WebSocket connection.
+    #[arg(
+        long,
+        default_value = "10s",
+        value_parser = parse_duration,
+        value_name = "DURATION"
+    )]
+    pub connect_timeout: Duration,
+
+    /// Maximum time allowed to create and observe a ready lobby.
+    #[arg(
+        long,
+        default_value = "10s",
+        value_parser = parse_duration,
+        value_name = "DURATION"
+    )]
+    pub lobby_timeout: Duration,
+
+    /// Maximum time a coordinated group may wait in matchmaking.
+    #[arg(
+        long,
+        default_value = "1m",
+        value_parser = parse_duration,
+        value_name = "DURATION"
+    )]
+    pub queue_timeout: Duration,
+
+    /// Maximum time to wait for active sessions after the final stage.
+    #[arg(
+        long,
+        default_value = "5m",
+        value_parser = parse_duration,
+        value_name = "DURATION"
+    )]
+    pub drain_timeout: Duration,
+
+    /// How long a healthy Solo/FFA session plays before leaving successfully.
+    ///
+    /// Those modes have no authoritative server time limit. A timeboxed leave
+    /// is reported separately from an authoritatively completed game.
+    #[arg(
+        long,
+        default_value = "2m",
+        value_parser = parse_duration,
+        value_name = "DURATION"
+    )]
+    pub untimed_play_duration: Duration,
+
+    /// Directory under which the run's aggregate and failure reports are written.
+    #[arg(long, default_value = "loadtest-reports", value_name = "PATH")]
+    pub report_dir: PathBuf,
+
+    /// Stable identifier used in reports and deterministic session names.
+    ///
+    /// If omitted, a process-local identifier is generated.
+    #[arg(long, value_name = "ID")]
+    pub run_id: Option<String>,
+
+    /// How frequently the AI emits turn commands.
+    #[arg(long, value_enum, default_value_t = CommandProfile::Realistic)]
+    pub command_profile: CommandProfile,
+
+    /// Acknowledge that this run intentionally sends load to snaketron.io.
+    #[arg(long)]
+    pub confirm_production: bool,
+
+    /// Fail the run unless the selected region's active server count rises
+    /// above its preflight baseline.
+    #[arg(long)]
+    pub require_scale_out: bool,
+}
+
+impl Args {
+    /// Validate parsed CLI arguments and convert them into coordinator input.
+    pub fn into_config(self) -> Result<Config, ConfigError> {
+        Config::try_from(self)
+    }
+}
+
+/// Supported multiplayer game modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum GameMode {
+    #[value(name = "solo")]
+    Solo,
+    #[value(name = "duel")]
+    Duel,
+    #[value(name = "2v2", alias = "two-v-two")]
+    TwoVTwo,
+    #[value(name = "ffa", alias = "free-for-all")]
+    FreeForAll,
+}
+
+impl GameMode {
+    pub const fn players_per_game(self) -> usize {
+        match self {
+            Self::Solo => 1,
+            Self::Duel => 2,
+            Self::TwoVTwo | Self::FreeForAll => 4,
+        }
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Solo => "solo",
+            Self::Duel => "duel",
+            Self::TwoVTwo => "2v2",
+            Self::FreeForAll => "ffa",
+        }
+    }
+}
+
+impl fmt::Display for GameMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Matchmaking queue selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum QueueMode {
+    #[value(name = "quickmatch")]
+    Quickmatch,
+    #[value(name = "competitive")]
+    Competitive,
+}
+
+impl QueueMode {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Quickmatch => "quickmatch",
+            Self::Competitive => "competitive",
+        }
+    }
+}
+
+impl fmt::Display for QueueMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Command emission policy for AI-driven sessions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CommandProfile {
+    /// Emit a turn only when the AI changes direction, matching normal UI input.
+    #[value(name = "realistic", alias = "changed-only")]
+    Realistic,
+    /// Emit the AI decision every game tick, including unchanged directions.
+    #[value(name = "every-tick", alias = "saturating")]
+    EveryTick,
+}
+
+impl CommandProfile {
+    pub const fn sends_unchanged_turns(self) -> bool {
+        matches!(self, Self::EveryTick)
+    }
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Realistic => "realistic",
+            Self::EveryTick => "every-tick",
+        }
+    }
+}
+
+impl fmt::Display for CommandProfile {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One bounded ramp-and-hold stage. `duration` includes the time spent rising
+/// to `target_concurrency`; after reaching it, the coordinator maintains it for
+/// the remainder of the stage.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoadStage {
+    pub target_concurrency: usize,
+    pub duration: Duration,
+}
+
+impl LoadStage {
+    pub const fn new(target_concurrency: usize, duration: Duration) -> Self {
+        Self {
+            target_concurrency,
+            duration,
+        }
+    }
+}
+
+/// Parsed sequence of concurrency targets.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StagePlan(Vec<LoadStage>);
+
+impl StagePlan {
+    pub fn new(stages: Vec<LoadStage>) -> Result<Self, ConfigError> {
+        if stages.is_empty() {
+            return Err(ConfigError::EmptyStages);
+        }
+        Ok(Self(stages))
+    }
+
+    pub fn as_slice(&self) -> &[LoadStage] {
+        &self.0
+    }
+
+    pub fn iter(&self) -> impl ExactSizeIterator<Item = &LoadStage> {
+        self.0.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn max_concurrency(&self) -> usize {
+        self.0
+            .iter()
+            .map(|stage| stage.target_concurrency)
+            .max()
+            .unwrap_or(0)
+    }
+}
+
+impl AsRef<[LoadStage]> for StagePlan {
+    fn as_ref(&self) -> &[LoadStage] {
+        self.as_slice()
+    }
+}
+
+impl IntoIterator for StagePlan {
+    type Item = LoadStage;
+    type IntoIter = std::vec::IntoIter<LoadStage>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a StagePlan {
+    type Item = &'a LoadStage;
+    type IntoIter = std::slice::Iter<'a, LoadStage>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl FromStr for StagePlan {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let value = value.trim();
+        if value.is_empty() {
+            return Err("stage plan must contain at least one stage".to_string());
+        }
+
+        let mut stages = Vec::new();
+        for (index, raw_stage) in value.split(',').enumerate() {
+            let raw_stage = raw_stage.trim();
+            let display_index = index + 1;
+            if raw_stage.is_empty() {
+                return Err(format!("stage {display_index} is empty"));
+            }
+
+            let (concurrency, duration) = raw_stage.split_once('@').ok_or_else(|| {
+                format!("stage {display_index} must use N@DURATION syntax (received '{raw_stage}')")
+            })?;
+
+            if duration.contains('@') {
+                return Err(format!("stage {display_index} contains more than one '@'"));
+            }
+
+            let target_concurrency = concurrency.trim().parse::<usize>().map_err(|_| {
+                format!(
+                    "stage {display_index} has invalid concurrency '{}'",
+                    concurrency.trim()
+                )
+            })?;
+            if target_concurrency == 0 {
+                return Err(format!(
+                    "stage {display_index} target concurrency must be greater than zero"
+                ));
+            }
+
+            let duration = parse_duration(duration.trim())
+                .map_err(|error| format!("stage {display_index}: {error}"))?;
+            stages.push(LoadStage::new(target_concurrency, duration));
+        }
+
+        Ok(Self(stages))
+    }
+}
+
+/// Validated configuration consumed by the load-test coordinator.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    pub target_url: Url,
+    pub region: Option<String>,
+    pub ws_url: Option<Url>,
+    pub mode: GameMode,
+    pub queue_mode: QueueMode,
+    pub stages: StagePlan,
+    pub spawn_rate: usize,
+    pub max_total_sessions: usize,
+    pub connect_timeout: Duration,
+    pub lobby_timeout: Duration,
+    pub queue_timeout: Duration,
+    pub drain_timeout: Duration,
+    pub untimed_play_duration: Duration,
+    pub report_dir: PathBuf,
+    pub run_id: String,
+    pub command_profile: CommandProfile,
+    pub production_confirmed: bool,
+    pub require_scale_out: bool,
+}
+
+impl Config {
+    pub const fn players_per_game(&self) -> usize {
+        self.mode.players_per_game()
+    }
+
+    pub fn max_concurrency(&self) -> usize {
+        self.stages.max_concurrency()
+    }
+
+    pub fn is_production(&self) -> bool {
+        is_snaketron_production_url(&self.target_url)
+            || self
+                .ws_url
+                .as_ref()
+                .is_some_and(is_snaketron_production_url)
+    }
+}
+
+impl TryFrom<Args> for Config {
+    type Error = ConfigError;
+
+    fn try_from(args: Args) -> Result<Self, Self::Error> {
+        let target_url = parse_target_url(&args.target)?;
+        let ws_url = args
+            .ws_url
+            .as_deref()
+            .map(parse_websocket_url)
+            .transpose()?;
+
+        let region = args.region.map(validate_region).transpose()?;
+
+        validate_stages(&args.stages, args.mode)?;
+        if args.spawn_rate < args.mode.players_per_game() {
+            return Err(ConfigError::SpawnRateBelowMatchSize {
+                spawn_rate: args.spawn_rate,
+                players_per_game: args.mode.players_per_game(),
+            });
+        }
+        if args.max_total_sessions < args.stages.max_concurrency() {
+            return Err(ConfigError::SessionLimitBelowConcurrency {
+                max_total_sessions: args.max_total_sessions,
+                max_concurrency: args.stages.max_concurrency(),
+            });
+        }
+        validate_timeout("connect timeout", args.connect_timeout)?;
+        validate_timeout("lobby timeout", args.lobby_timeout)?;
+        validate_timeout("queue timeout", args.queue_timeout)?;
+        validate_timeout("drain timeout", args.drain_timeout)?;
+        validate_timeout("untimed play duration", args.untimed_play_duration)?;
+
+        if args.report_dir.as_os_str().is_empty() {
+            return Err(ConfigError::InvalidReportDirectory);
+        }
+
+        let run_id = args.run_id.unwrap_or_else(generate_run_id);
+        validate_run_id(&run_id)?;
+
+        let production_target = is_snaketron_production_url(&target_url)
+            || ws_url.as_ref().is_some_and(is_snaketron_production_url);
+        if production_target && !args.confirm_production {
+            return Err(ConfigError::ProductionConfirmationRequired);
+        }
+
+        Ok(Self {
+            target_url,
+            region,
+            ws_url,
+            mode: args.mode,
+            queue_mode: args.queue_mode,
+            stages: args.stages,
+            spawn_rate: args.spawn_rate,
+            max_total_sessions: args.max_total_sessions,
+            connect_timeout: args.connect_timeout,
+            lobby_timeout: args.lobby_timeout,
+            queue_timeout: args.queue_timeout,
+            drain_timeout: args.drain_timeout,
+            untimed_play_duration: args.untimed_play_duration,
+            report_dir: args.report_dir,
+            run_id,
+            command_profile: args.command_profile,
+            production_confirmed: args.confirm_production,
+            require_scale_out: args.require_scale_out,
+        })
+    }
+}
+
+/// Configuration errors that are discovered after clap has parsed the CLI.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    InvalidTargetUrl(String),
+    InvalidWebSocketUrl(String),
+    InvalidRegion(String),
+    EmptyStages,
+    InvalidStage {
+        stage_index: usize,
+        reason: String,
+    },
+    StageConcurrencyMisaligned {
+        stage_index: usize,
+        target_concurrency: usize,
+        players_per_game: usize,
+    },
+    StagesNotIncreasing {
+        stage_index: usize,
+        previous_target: usize,
+        target_concurrency: usize,
+    },
+    SpawnRateBelowMatchSize {
+        spawn_rate: usize,
+        players_per_game: usize,
+    },
+    SessionLimitBelowConcurrency {
+        max_total_sessions: usize,
+        max_concurrency: usize,
+    },
+    InvalidTimeout {
+        name: &'static str,
+    },
+    InvalidReportDirectory,
+    InvalidRunId(String),
+    ProductionConfirmationRequired,
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTargetUrl(reason) => write!(formatter, "invalid target URL: {reason}"),
+            Self::InvalidWebSocketUrl(reason) => {
+                write!(formatter, "invalid WebSocket URL: {reason}")
+            }
+            Self::InvalidRegion(reason) => write!(formatter, "invalid region: {reason}"),
+            Self::EmptyStages => formatter.write_str("at least one load stage is required"),
+            Self::InvalidStage {
+                stage_index,
+                reason,
+            } => write!(formatter, "invalid stage {}: {reason}", stage_index + 1),
+            Self::StageConcurrencyMisaligned {
+                stage_index,
+                target_concurrency,
+                players_per_game,
+            } => write!(
+                formatter,
+                "stage {} target concurrency {} must be a multiple of {} players per game",
+                stage_index + 1,
+                target_concurrency,
+                players_per_game
+            ),
+            Self::StagesNotIncreasing {
+                stage_index,
+                previous_target,
+                target_concurrency,
+            } => write!(
+                formatter,
+                "stage {} target concurrency {} must be greater than the previous target {}",
+                stage_index + 1,
+                target_concurrency,
+                previous_target
+            ),
+            Self::SpawnRateBelowMatchSize {
+                spawn_rate,
+                players_per_game,
+            } => write!(
+                formatter,
+                "spawn rate {spawn_rate} must be at least one complete {players_per_game}-player match group per second"
+            ),
+            Self::SessionLimitBelowConcurrency {
+                max_total_sessions,
+                max_concurrency,
+            } => write!(
+                formatter,
+                "maximum total sessions {max_total_sessions} must be at least the configured peak concurrency {max_concurrency}"
+            ),
+            Self::InvalidTimeout { name } => {
+                write!(formatter, "{name} must be greater than zero")
+            }
+            Self::InvalidReportDirectory => {
+                formatter.write_str("report directory must not be empty")
+            }
+            Self::InvalidRunId(reason) => write!(formatter, "invalid run ID: {reason}"),
+            Self::ProductionConfirmationRequired => formatter.write_str(
+                "snaketron.io is a production target; pass --confirm-production to acknowledge the load",
+            ),
+        }
+    }
+}
+
+impl Error for ConfigError {}
+
+/// Parse a positive duration with integer `ms`, `s`, `m`, or `h` components.
+/// Compound values such as `1m30s` are supported.
+pub fn parse_duration(value: &str) -> Result<Duration, String> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Err("duration must not be empty".to_string());
+    }
+
+    let bytes = value.as_bytes();
+    let mut cursor = 0;
+    let mut total_millis = 0_u64;
+
+    while cursor < bytes.len() {
+        let number_start = cursor;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if number_start == cursor {
+            return Err(format!(
+                "duration '{value}' must contain an integer before each unit"
+            ));
+        }
+
+        let amount = value[number_start..cursor]
+            .parse::<u64>()
+            .map_err(|_| format!("duration component in '{value}' is too large"))?;
+
+        let (unit_millis, unit_len) = if value[cursor..].starts_with("ms") {
+            (1_u64, 2)
+        } else if value[cursor..].starts_with('s') {
+            (1_000, 1)
+        } else if value[cursor..].starts_with('m') {
+            (60_000, 1)
+        } else if value[cursor..].starts_with('h') {
+            (3_600_000, 1)
+        } else {
+            return Err(format!("duration '{value}' must use ms, s, m, or h units"));
+        };
+        cursor += unit_len;
+
+        let component_millis = amount
+            .checked_mul(unit_millis)
+            .ok_or_else(|| format!("duration '{value}' is too large"))?;
+        total_millis = total_millis
+            .checked_add(component_millis)
+            .ok_or_else(|| format!("duration '{value}' is too large"))?;
+    }
+
+    if total_millis == 0 {
+        return Err("duration must be greater than zero".to_string());
+    }
+
+    Ok(Duration::from_millis(total_millis))
+}
+
+fn parse_target_url(value: &str) -> Result<Url, ConfigError> {
+    let url =
+        Url::parse(value).map_err(|error| ConfigError::InvalidTargetUrl(error.to_string()))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(ConfigError::InvalidTargetUrl(
+            "scheme must be http or https".to_string(),
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(ConfigError::InvalidTargetUrl(
+            "URL must include a host".to_string(),
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(ConfigError::InvalidTargetUrl(
+            "embedded credentials are not allowed".to_string(),
+        ));
+    }
+    Ok(url)
+}
+
+fn parse_websocket_url(value: &str) -> Result<Url, ConfigError> {
+    let url =
+        Url::parse(value).map_err(|error| ConfigError::InvalidWebSocketUrl(error.to_string()))?;
+    if !matches!(url.scheme(), "ws" | "wss") {
+        return Err(ConfigError::InvalidWebSocketUrl(
+            "scheme must be ws or wss".to_string(),
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(ConfigError::InvalidWebSocketUrl(
+            "URL must include a host".to_string(),
+        ));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(ConfigError::InvalidWebSocketUrl(
+            "embedded credentials are not allowed".to_string(),
+        ));
+    }
+    Ok(url)
+}
+
+fn validate_region(region: String) -> Result<String, ConfigError> {
+    if region.is_empty() {
+        return Err(ConfigError::InvalidRegion(
+            "region identifier must not be empty".to_string(),
+        ));
+    }
+    if !region
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(ConfigError::InvalidRegion(
+            "use only ASCII letters, numbers, '-' or '_'".to_string(),
+        ));
+    }
+    Ok(region)
+}
+
+fn validate_stages(stages: &StagePlan, mode: GameMode) -> Result<(), ConfigError> {
+    if stages.is_empty() {
+        return Err(ConfigError::EmptyStages);
+    }
+
+    let players_per_game = mode.players_per_game();
+    let mut previous_target = 0;
+    for (stage_index, stage) in stages.iter().enumerate() {
+        if stage.target_concurrency == 0 {
+            return Err(ConfigError::InvalidStage {
+                stage_index,
+                reason: "target concurrency must be greater than zero".to_string(),
+            });
+        }
+        if stage.duration.is_zero() {
+            return Err(ConfigError::InvalidStage {
+                stage_index,
+                reason: "duration must be greater than zero".to_string(),
+            });
+        }
+        if stage.target_concurrency % players_per_game != 0 {
+            return Err(ConfigError::StageConcurrencyMisaligned {
+                stage_index,
+                target_concurrency: stage.target_concurrency,
+                players_per_game,
+            });
+        }
+        if stage_index > 0 && stage.target_concurrency <= previous_target {
+            return Err(ConfigError::StagesNotIncreasing {
+                stage_index,
+                previous_target,
+                target_concurrency: stage.target_concurrency,
+            });
+        }
+        previous_target = stage.target_concurrency;
+    }
+
+    Ok(())
+}
+
+fn validate_timeout(name: &'static str, timeout: Duration) -> Result<(), ConfigError> {
+    if timeout.is_zero() {
+        return Err(ConfigError::InvalidTimeout { name });
+    }
+    Ok(())
+}
+
+fn validate_run_id(run_id: &str) -> Result<(), ConfigError> {
+    if run_id.is_empty() {
+        return Err(ConfigError::InvalidRunId(
+            "run ID must not be empty".to_string(),
+        ));
+    }
+    if run_id.len() > MAX_RUN_ID_LEN {
+        return Err(ConfigError::InvalidRunId(format!(
+            "run ID must be no more than {MAX_RUN_ID_LEN} characters"
+        )));
+    }
+    if !run_id
+        .bytes()
+        .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(ConfigError::InvalidRunId(
+            "use only ASCII letters, numbers, '-' or '_'".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+fn generate_run_id() -> String {
+    let timestamp_ms = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis();
+    format!("load-{timestamp_ms}-{}", std::process::id())
+}
+
+/// Return whether a resolved HTTP or WebSocket URL targets Snaketron's public
+/// production domain. The coordinator calls this again after region discovery
+/// so a custom discovery endpoint cannot bypass the production confirmation.
+pub fn is_snaketron_production_url(url: &Url) -> bool {
+    url.host_str().is_some_and(|host| {
+        // A trailing DNS root label is equivalent to the same public host and
+        // must not bypass the explicit production acknowledgement.
+        let host = host.trim_end_matches('.').to_ascii_lowercase();
+        host == "snaketron.io" || host.ends_with(".snaketron.io")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_args() -> Args {
+        Args {
+            target: DEFAULT_TARGET.to_string(),
+            region: None,
+            ws_url: None,
+            mode: GameMode::Duel,
+            queue_mode: QueueMode::Quickmatch,
+            stages: DEFAULT_STAGES.parse().unwrap(),
+            spawn_rate: DEFAULT_SPAWN_RATE,
+            max_total_sessions: DEFAULT_MAX_TOTAL_SESSIONS,
+            connect_timeout: Duration::from_secs(10),
+            lobby_timeout: Duration::from_secs(10),
+            queue_timeout: Duration::from_secs(60),
+            drain_timeout: Duration::from_secs(5 * 60),
+            untimed_play_duration: Duration::from_secs(2 * 60),
+            report_dir: PathBuf::from("reports"),
+            run_id: Some("test-run".to_string()),
+            command_profile: CommandProfile::Realistic,
+            confirm_production: false,
+            require_scale_out: false,
+        }
+    }
+
+    #[test]
+    fn parses_example_stage_plan() {
+        let plan: StagePlan = "4@30s,8@1m".parse().unwrap();
+
+        assert_eq!(
+            plan.as_slice(),
+            &[
+                LoadStage::new(4, Duration::from_secs(30)),
+                LoadStage::new(8, Duration::from_secs(60)),
+            ]
+        );
+        assert_eq!(plan.max_concurrency(), 8);
+    }
+
+    #[test]
+    fn parses_compound_and_millisecond_durations() {
+        assert_eq!(parse_duration("1m30s").unwrap(), Duration::from_secs(90));
+        assert_eq!(
+            parse_duration("1500ms").unwrap(),
+            Duration::from_millis(1_500)
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_or_zero_durations() {
+        assert!(parse_duration("").is_err());
+        assert!(parse_duration("30").is_err());
+        assert!(parse_duration("1.5s").is_err());
+        assert!(parse_duration("0s").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_stage_plan() {
+        assert!("".parse::<StagePlan>().is_err());
+        assert!("4".parse::<StagePlan>().is_err());
+        assert!("0@1m".parse::<StagePlan>().is_err());
+        assert!("4@1m,".parse::<StagePlan>().is_err());
+        assert!("four@1m".parse::<StagePlan>().is_err());
+    }
+
+    #[test]
+    fn exposes_players_per_game() {
+        assert_eq!(GameMode::Solo.players_per_game(), 1);
+        assert_eq!(GameMode::Duel.players_per_game(), 2);
+        assert_eq!(GameMode::TwoVTwo.players_per_game(), 4);
+        assert_eq!(GameMode::FreeForAll.players_per_game(), 4);
+    }
+
+    #[test]
+    fn parses_every_supported_game_mode() {
+        for value in ["solo", "duel", "2v2", "ffa"] {
+            let args = Args::try_parse_from(["loadtest", "--mode", value]).unwrap();
+            assert_eq!(args.mode.as_str(), value);
+        }
+    }
+
+    #[test]
+    fn accepts_aligned_increasing_duel_stages() {
+        let config = test_args().into_config().unwrap();
+
+        assert_eq!(config.players_per_game(), 2);
+        assert_eq!(config.max_concurrency(), 256);
+        assert!(!config.is_production());
+    }
+
+    #[test]
+    fn rejects_concurrency_not_aligned_to_game_size() {
+        let mut args = test_args();
+        args.mode = GameMode::TwoVTwo;
+        args.stages = "4@10s,6@10s".parse().unwrap();
+
+        assert_eq!(
+            args.into_config().unwrap_err(),
+            ConfigError::StageConcurrencyMisaligned {
+                stage_index: 1,
+                target_concurrency: 6,
+                players_per_game: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn rejects_non_increasing_stage_targets() {
+        let mut args = test_args();
+        args.stages = "4@10s,4@10s".parse().unwrap();
+
+        assert_eq!(
+            args.into_config().unwrap_err(),
+            ConfigError::StagesNotIncreasing {
+                stage_index: 1,
+                previous_target: 4,
+                target_concurrency: 4,
+            }
+        );
+    }
+
+    #[test]
+    fn production_target_requires_confirmation() {
+        let mut args = test_args();
+        args.target = "https://snaketron.io".to_string();
+
+        assert_eq!(
+            args.into_config().unwrap_err(),
+            ConfigError::ProductionConfirmationRequired
+        );
+    }
+
+    #[test]
+    fn production_subdomain_requires_confirmation() {
+        let mut args = test_args();
+        args.ws_url = Some("wss://use1.snaketron.io/ws".to_string());
+
+        assert_eq!(
+            args.into_config().unwrap_err(),
+            ConfigError::ProductionConfirmationRequired
+        );
+    }
+
+    #[test]
+    fn explicit_confirmation_allows_production_target() {
+        let mut args = test_args();
+        args.target = "https://api.snaketron.io".to_string();
+        args.confirm_production = true;
+
+        let config = args.into_config().unwrap();
+        assert!(config.is_production());
+        assert!(config.production_confirmed);
+    }
+
+    #[test]
+    fn similarly_named_non_production_host_does_not_require_confirmation() {
+        let mut args = test_args();
+        args.target = "https://snaketron.io.example.com".to_string();
+
+        assert!(!args.into_config().unwrap().is_production());
+    }
+
+    #[test]
+    fn fully_qualified_production_host_requires_confirmation() {
+        let mut args = test_args();
+        args.target = "https://snaketron.io.".to_string();
+
+        assert_eq!(
+            args.into_config().unwrap_err(),
+            ConfigError::ProductionConfirmationRequired
+        );
+    }
+
+    #[test]
+    fn validates_target_and_websocket_schemes() {
+        let mut args = test_args();
+        args.target = "wss://example.test/ws".to_string();
+        assert!(matches!(
+            args.into_config(),
+            Err(ConfigError::InvalidTargetUrl(_))
+        ));
+
+        let mut args = test_args();
+        args.ws_url = Some("https://example.test/ws".to_string());
+        assert!(matches!(
+            args.into_config(),
+            Err(ConfigError::InvalidWebSocketUrl(_))
+        ));
+    }
+
+    #[test]
+    fn validates_run_id_for_safe_report_paths() {
+        let mut args = test_args();
+        args.run_id = Some("../unsafe".to_string());
+
+        assert!(matches!(
+            args.into_config(),
+            Err(ConfigError::InvalidRunId(_))
+        ));
+    }
+
+    #[test]
+    fn rejects_spawn_rate_smaller_than_one_match_group() {
+        let mut args = test_args();
+        args.mode = GameMode::FreeForAll;
+        args.spawn_rate = 3;
+
+        assert!(matches!(
+            args.into_config(),
+            Err(ConfigError::SpawnRateBelowMatchSize { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_total_session_limit_below_peak_concurrency() {
+        let mut args = test_args();
+        args.max_total_sessions = 128;
+
+        assert!(matches!(
+            args.into_config(),
+            Err(ConfigError::SessionLimitBelowConcurrency { .. })
+        ));
+    }
+
+    #[test]
+    fn clap_accepts_2v2_and_command_profile() {
+        let args = Args::try_parse_from([
+            "snaketron-loadtest",
+            "--mode",
+            "2v2",
+            "--command-profile",
+            "every-tick",
+        ])
+        .unwrap();
+
+        assert_eq!(args.mode, GameMode::TwoVTwo);
+        assert_eq!(args.command_profile, CommandProfile::EveryTick);
+    }
+
+    #[test]
+    fn clap_accepts_the_untimed_play_window_and_rejects_zero() {
+        let args = Args::try_parse_from(["snaketron-loadtest", "--untimed-play-duration", "3m30s"])
+            .unwrap();
+        assert_eq!(args.untimed_play_duration, Duration::from_secs(210));
+
+        assert!(
+            Args::try_parse_from(["snaketron-loadtest", "--untimed-play-duration", "0s",]).is_err()
+        );
+    }
+}

--- a/loadtest/src/lib.rs
+++ b/loadtest/src/lib.rs
@@ -1,0 +1,6 @@
+//! Reusable components for Snaketron's coordinated load-test runner.
+
+pub mod config;
+pub mod report;
+pub mod session;
+pub mod target;

--- a/loadtest/src/main.rs
+++ b/loadtest/src/main.rs
@@ -1,0 +1,1315 @@
+use anyhow::{Context, Result, anyhow};
+use clap::Parser;
+use common::{GameType, QueueMode};
+use loadtest::config::{self, Args, Config, GameMode};
+use loadtest::report::{
+    InfrastructureSample, LoadTestRun, RampStageRecord, SessionFailureRecord, SessionOutcome,
+    SessionPhase, SessionRecord, aggregate_report, unix_time_ms, write_report,
+};
+use loadtest::session::{
+    MatchGroupResult, MatchGroupSpec, SessionActivityEvent, SessionSettings,
+    deterministic_username, run_match_group,
+};
+use loadtest::target::{TargetOptions, TargetResolver};
+use std::collections::{BTreeSet, HashMap};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{Barrier, mpsc};
+use tokio::task::{Id, JoinError, JoinSet};
+use tokio::time::{Instant, MissedTickBehavior, interval, interval_at};
+use tokio_util::sync::CancellationToken;
+use tracing::{error, info, warn};
+use url::Url;
+
+const OBSERVATION_INTERVAL: Duration = Duration::from_secs(5);
+const SPAWN_INTERVAL: Duration = Duration::from_secs(1);
+const CANCEL_GRACE: Duration = Duration::from_secs(10);
+const FAILURE_CIRCUIT_BREAKER_MIN_SESSIONS: usize = 4;
+const FAILURE_CIRCUIT_BREAKER_RATE: f64 = 0.20;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionConcurrencyState {
+    Pending,
+    Connected,
+    Terminal,
+}
+
+/// Tracks virtual users individually while match-group tasks remain the unit
+/// of deterministic launch and result collection.
+#[derive(Debug, Default)]
+struct SessionConcurrencyTracker {
+    states: HashMap<u64, SessionConcurrencyState>,
+    pending: usize,
+    connected: usize,
+    peak_connected: usize,
+}
+
+impl SessionConcurrencyTracker {
+    fn reserve(&mut self, session_indices: &[u64]) {
+        for session_index in session_indices {
+            if self.states.contains_key(session_index) {
+                // Session indices are monotonic and must never be reused. Keep
+                // release builds safe from double-counting if that invariant
+                // is accidentally violated.
+                warn!(session_index, "duplicate virtual-user reservation ignored");
+            } else {
+                self.states
+                    .insert(*session_index, SessionConcurrencyState::Pending);
+                self.pending = self.pending.saturating_add(1);
+            }
+        }
+    }
+
+    fn observe(&mut self, event: SessionActivityEvent) {
+        let (session_index, next_state) = match event {
+            SessionActivityEvent::Connected { session_index } => {
+                (session_index, SessionConcurrencyState::Connected)
+            }
+            SessionActivityEvent::Terminal { session_index } => {
+                (session_index, SessionConcurrencyState::Terminal)
+            }
+        };
+        let Some(current_state) = self.states.get_mut(&session_index) else {
+            warn!(
+                session_index,
+                "activity received for an unplanned virtual user"
+            );
+            return;
+        };
+
+        match (*current_state, next_state) {
+            (SessionConcurrencyState::Pending, SessionConcurrencyState::Connected) => {
+                self.pending = self.pending.saturating_sub(1);
+                self.connected = self.connected.saturating_add(1);
+                self.peak_connected = self.peak_connected.max(self.connected);
+                *current_state = SessionConcurrencyState::Connected;
+            }
+            (SessionConcurrencyState::Pending, SessionConcurrencyState::Terminal) => {
+                self.pending = self.pending.saturating_sub(1);
+                *current_state = SessionConcurrencyState::Terminal;
+            }
+            (SessionConcurrencyState::Connected, SessionConcurrencyState::Terminal) => {
+                self.connected = self.connected.saturating_sub(1);
+                *current_state = SessionConcurrencyState::Terminal;
+            }
+            // Duplicate messages and a late Connected message drained after a
+            // task result reconciled the VU are deliberately idempotent.
+            _ => {}
+        }
+    }
+
+    fn mark_terminal(&mut self, session_indices: &[u64]) {
+        for session_index in session_indices {
+            self.observe(SessionActivityEvent::Terminal {
+                session_index: *session_index,
+            });
+        }
+    }
+
+    const fn pending(&self) -> usize {
+        self.pending
+    }
+
+    const fn connected(&self) -> usize {
+        self.connected
+    }
+
+    const fn peak_connected(&self) -> usize {
+        self.peak_connected
+    }
+
+    fn reserved(&self) -> usize {
+        self.pending.saturating_add(self.connected)
+    }
+}
+
+fn observe_stage_activity(
+    event: SessionActivityEvent,
+    activity_rx: &mut mpsc::UnboundedReceiver<SessionActivityEvent>,
+    concurrency: &mut SessionConcurrencyTracker,
+    target: usize,
+    target_reached: &mut bool,
+    target_reached_at: &mut Option<u64>,
+) {
+    apply_stage_activity(
+        event,
+        concurrency,
+        target,
+        target_reached,
+        target_reached_at,
+    );
+    drain_stage_activity_events(
+        activity_rx,
+        concurrency,
+        target,
+        target_reached,
+        target_reached_at,
+    );
+}
+
+fn drain_stage_activity_events(
+    activity_rx: &mut mpsc::UnboundedReceiver<SessionActivityEvent>,
+    concurrency: &mut SessionConcurrencyTracker,
+    target: usize,
+    target_reached: &mut bool,
+    target_reached_at: &mut Option<u64>,
+) {
+    while let Ok(event) = activity_rx.try_recv() {
+        apply_stage_activity(
+            event,
+            concurrency,
+            target,
+            target_reached,
+            target_reached_at,
+        );
+    }
+}
+
+fn apply_stage_activity(
+    event: SessionActivityEvent,
+    concurrency: &mut SessionConcurrencyTracker,
+    target: usize,
+    target_reached: &mut bool,
+    target_reached_at: &mut Option<u64>,
+) {
+    concurrency.observe(event);
+    if !*target_reached && concurrency.connected() >= target {
+        *target_reached = true;
+        *target_reached_at = Some(unix_time_ms());
+    }
+}
+
+fn drain_activity_events(
+    activity_rx: &mut mpsc::UnboundedReceiver<SessionActivityEvent>,
+    concurrency: &mut SessionConcurrencyTracker,
+) {
+    while let Ok(event) = activity_rx.try_recv() {
+        concurrency.observe(event);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"));
+    tracing_subscriber::fmt()
+        .with_env_filter(env_filter)
+        .with_target(false)
+        .init();
+
+    let config = Args::parse().into_config()?;
+    run(config).await
+}
+
+async fn run(config: Config) -> Result<()> {
+    if config.is_production() {
+        warn!(
+            "production load test confirmed; synthetic guest users and completed matches may be persisted by the current server"
+        );
+    }
+    let resolver = TargetResolver::new(config.connect_timeout)?;
+    info!(target = %config.target_url, "preflighting load-test target with strict TLS");
+    let preflight = resolver
+        .preflight(&TargetOptions {
+            target: config.target_url.to_string(),
+            region: config.region.clone(),
+        })
+        .await
+        .context("target preflight failed before any sessions were launched")?;
+
+    let websocket_url = match &config.ws_url {
+        Some(url) => url.clone(),
+        None => Url::parse(&preflight.websocket_url)
+            .context("preflight returned an invalid WebSocket URL")?,
+    };
+    let api_origin =
+        Url::parse(&preflight.api_origin).context("preflight returned an invalid API origin")?;
+    let selected_origin = Url::parse(&preflight.selected_origin)
+        .context("preflight returned an invalid selected-region origin")?;
+    ensure_effective_endpoints_confirmed(
+        config.production_confirmed,
+        &[&api_origin, &selected_origin, &websocket_url],
+    )?;
+    let settings = SessionSettings {
+        api_origin,
+        websocket_url,
+        origin: preflight.selected_origin.clone(),
+        game_type: game_type(config.mode),
+        queue_mode: queue_mode(config.queue_mode),
+        selected_mode: config.mode.as_str().to_owned(),
+        competitive: matches!(config.queue_mode, config::QueueMode::Competitive),
+        connect_timeout: config.connect_timeout,
+        lobby_timeout: config.lobby_timeout,
+        queue_timeout: config.queue_timeout,
+        untimed_play_duration: config.untimed_play_duration,
+        command_profile: config.command_profile,
+        backend_hints: resolver.backend_hints(),
+    };
+
+    info!(
+        run_id = %config.run_id,
+        region = %preflight.selected_region.id,
+        websocket = %settings.websocket_url,
+        max_sessions = config.max_concurrency(),
+        mode = %config.mode,
+        queue = %config.queue_mode,
+        "starting coordinated load test"
+    );
+
+    let started_at = unix_time_ms();
+    let mut run = LoadTestRun::new(
+        config.run_id.clone(),
+        config.target_url.to_string(),
+        started_at,
+        config.max_concurrency(),
+    );
+    run.metadata
+        .insert("region".to_owned(), preflight.selected_region.id.clone());
+    run.metadata.insert(
+        "region_name".to_owned(),
+        preflight.selected_region.name.clone(),
+    );
+    run.metadata.insert(
+        "websocket_url".to_owned(),
+        settings.websocket_url.to_string(),
+    );
+    run.metadata
+        .insert("mode".to_owned(), config.mode.to_string());
+    run.metadata
+        .insert("queue_mode".to_owned(), config.queue_mode.to_string());
+    run.metadata.insert(
+        "command_profile".to_owned(),
+        config.command_profile.to_string(),
+    );
+    run.metadata.insert(
+        "spawn_rate_per_second".to_owned(),
+        config.spawn_rate.to_string(),
+    );
+    run.metadata.insert(
+        "max_total_sessions".to_owned(),
+        config.max_total_sessions.to_string(),
+    );
+    run.metadata.insert(
+        "untimed_play_duration_ms".to_owned(),
+        config.untimed_play_duration.as_millis().to_string(),
+    );
+    run.metadata.insert(
+        "lobby_topology".to_owned(),
+        if config.players_per_game() > 1 {
+            format!(
+                "one_full_party_lobby_per_game_{}_members",
+                config.players_per_game()
+            )
+        } else {
+            "one_player_lobby_per_game".to_owned()
+        },
+    );
+    run.metadata.insert(
+        "production_confirmation".to_owned(),
+        config.production_confirmed.to_string(),
+    );
+    run.infrastructure_samples.push(InfrastructureSample {
+        observed_at_unix_ms: preflight
+            .initial_user_counts
+            .endpoint
+            .observed_at_unix_ms
+            .max(preflight.initial_server_counts.endpoint.observed_at_unix_ms),
+        regional_user_counts: preflight.initial_user_counts.counts.clone(),
+        regional_server_counts: preflight.initial_server_counts.counts.clone(),
+        observed_backend_hints: resolver.backend_hints().observed_backend_count(),
+        error: None,
+    });
+
+    let cancellation = CancellationToken::new();
+    let mut tasks = JoinSet::new();
+    let mut planned_groups = HashMap::new();
+    let (activity_tx, mut activity_rx) = mpsc::unbounded_channel();
+    let mut concurrency = SessionConcurrencyTracker::default();
+    let mut total_sessions_launched = 0usize;
+    let mut next_session_index = 1u64;
+    let mut next_group_index = 1u64;
+    let mut next_wave_index = 0u32;
+    let mut interrupted = false;
+    let mut signal = Box::pin(tokio::signal::ctrl_c());
+    let mut observation_interval = interval(OBSERVATION_INTERVAL);
+    observation_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    let mut spawn_interval = interval_at(Instant::now() + SPAWN_INTERVAL, SPAWN_INTERVAL);
+    spawn_interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+    let baseline_backend_hints = resolver.backend_hints().observed_backend_count();
+    let baseline_server_count = preflight
+        .initial_server_counts
+        .counts
+        .get(&preflight.selected_region.id)
+        .copied()
+        .unwrap_or(0);
+
+    for (stage_index, stage) in config.stages.iter().enumerate() {
+        if interrupted {
+            break;
+        }
+        let stage_started_at = unix_time_ms();
+        drain_activity_events(&mut activity_rx, &mut concurrency);
+        let connected_at_start = concurrency.connected();
+        let mut sessions_launched = 0usize;
+        info!(
+            stage = stage_index + 1,
+            target = stage.target_concurrency,
+            hold_seconds = stage.duration.as_secs_f64(),
+            connected = concurrency.connected(),
+            pending = concurrency.pending(),
+            "entering ramp stage"
+        );
+
+        // Seed only the first stage immediately. Every later ramp step uses
+        // the single global one-second ticker below, so a stage boundary can
+        // never grant an extra wave outside the configured spawn rate.
+        let launched = if stage_index == 0 {
+            spawn_deficit_wave(
+                stage.target_concurrency,
+                launch_budget(&config, total_sessions_launched),
+                &mut concurrency,
+                &mut next_session_index,
+                &mut next_group_index,
+                &mut next_wave_index,
+                &mut tasks,
+                &mut planned_groups,
+                &config,
+                &settings,
+                resolver.http_client(),
+                &activity_tx,
+                cancellation.clone(),
+            )
+        } else {
+            0
+        };
+        sessions_launched += launched;
+        total_sessions_launched = total_sessions_launched.saturating_add(launched);
+        run.games.expected = run
+            .games
+            .expected
+            .saturating_add(launched / config.players_per_game());
+        let mut target_reached = concurrency.connected() >= stage.target_concurrency;
+        let mut target_reached_at = target_reached.then(unix_time_ms);
+
+        let stage_deadline = Instant::now() + stage.duration;
+        while Instant::now() < stage_deadline {
+            tokio::select! {
+                signal_result = &mut signal => {
+                    match signal_result {
+                        Ok(()) => warn!("interrupt received; stopping ramp and draining sessions"),
+                        Err(error) => warn!(%error, "failed to install interrupt handler; stopping ramp"),
+                    }
+                    interrupted = true;
+                    break;
+                }
+                event = activity_rx.recv() => {
+                    if let Some(event) = event {
+                        observe_stage_activity(
+                            event,
+                            &mut activity_rx,
+                            &mut concurrency,
+                            stage.target_concurrency,
+                            &mut target_reached,
+                            &mut target_reached_at,
+                        );
+                    }
+                }
+                joined = tasks.join_next_with_id(), if !tasks.is_empty() => {
+                    if let Some(joined) = joined {
+                        drain_stage_activity_events(
+                            &mut activity_rx,
+                            &mut concurrency,
+                            stage.target_concurrency,
+                            &mut target_reached,
+                            &mut target_reached_at,
+                        );
+                        collect_group_result(joined, &mut planned_groups, &mut run, &mut concurrency);
+                    }
+                    if let Some(reason) = failure_circuit_breaker(&run) {
+                        error!(%reason, "failure circuit breaker stopped further load generation");
+                        run.metadata.insert("circuit_breaker".to_owned(), reason);
+                        interrupted = true;
+                        break;
+                    }
+                }
+                _ = spawn_interval.tick() => {
+                    if concurrency.reserved() < stage.target_concurrency
+                        && Instant::now() < stage_deadline
+                    {
+                        let budget = launch_budget(&config, total_sessions_launched);
+                        if budget < config.players_per_game() {
+                            let reason = format!(
+                                "maximum total session limit {} reached before concurrency target {} could be maintained",
+                                config.max_total_sessions,
+                                stage.target_concurrency,
+                            );
+                            error!(%reason, "session safety limit stopped further load generation");
+                            run.metadata.insert("session_limit".to_owned(), reason);
+                            interrupted = true;
+                            break;
+                        }
+                        let launched = spawn_deficit_wave(
+                            stage.target_concurrency,
+                            budget,
+                            &mut concurrency,
+                            &mut next_session_index,
+                            &mut next_group_index,
+                            &mut next_wave_index,
+                            &mut tasks,
+                            &mut planned_groups,
+                            &config,
+                            &settings,
+                            resolver.http_client(),
+                            &activity_tx,
+                            cancellation.clone(),
+                        );
+                        sessions_launched += launched;
+                        total_sessions_launched = total_sessions_launched.saturating_add(launched);
+                        run.games.expected = run
+                            .games
+                            .expected
+                            .saturating_add(launched / config.players_per_game());
+                    }
+                }
+                _ = observation_interval.tick() => {
+                    sample_infrastructure(&resolver, &preflight.api_origin, &mut run).await;
+                }
+                _ = tokio::time::sleep_until(stage_deadline) => break,
+            }
+        }
+
+        drain_stage_activity_events(
+            &mut activity_rx,
+            &mut concurrency,
+            stage.target_concurrency,
+            &mut target_reached,
+            &mut target_reached_at,
+        );
+
+        run.ramp_stages.push(RampStageRecord {
+            stage_index: stage_index as u32,
+            target_concurrency: stage.target_concurrency,
+            started_at_unix_ms: stage_started_at,
+            finished_at_unix_ms: unix_time_ms(),
+            sessions_launched,
+            active_sessions_at_start: connected_at_start,
+            active_sessions_at_end: concurrency.connected(),
+            target_reached,
+            target_reached_at_unix_ms: target_reached_at,
+        });
+    }
+
+    info!(
+        connected = concurrency.connected(),
+        pending = concurrency.pending(),
+        "ramp complete; draining token-sent sessions"
+    );
+    let drain_deadline = Instant::now() + config.drain_timeout;
+    while !tasks.is_empty() && Instant::now() < drain_deadline {
+        tokio::select! {
+            event = activity_rx.recv() => {
+                if let Some(event) = event {
+                    concurrency.observe(event);
+                    drain_activity_events(&mut activity_rx, &mut concurrency);
+                }
+            }
+            joined = tasks.join_next_with_id() => {
+                if let Some(joined) = joined {
+                    drain_activity_events(&mut activity_rx, &mut concurrency);
+                    collect_group_result(joined, &mut planned_groups, &mut run, &mut concurrency);
+                }
+            }
+            _ = observation_interval.tick() => {
+                sample_infrastructure(&resolver, &preflight.api_origin, &mut run).await;
+            }
+            _ = tokio::time::sleep_until(drain_deadline) => break,
+        }
+    }
+
+    if !tasks.is_empty() {
+        warn!(
+            remaining_groups = tasks.len(),
+            "drain timeout reached; cancelling remaining sessions"
+        );
+        cancellation.cancel();
+        let grace_deadline = Instant::now() + CANCEL_GRACE;
+        while !tasks.is_empty() && Instant::now() < grace_deadline {
+            if let Ok(Some(joined)) =
+                tokio::time::timeout_at(grace_deadline, tasks.join_next_with_id()).await
+            {
+                drain_activity_events(&mut activity_rx, &mut concurrency);
+                collect_group_result(joined, &mut planned_groups, &mut run, &mut concurrency);
+            } else {
+                break;
+            }
+        }
+        if !tasks.is_empty() {
+            error!(
+                remaining_groups = tasks.len(),
+                "session tasks did not honor cancellation; aborting them"
+            );
+            tasks.abort_all();
+            while let Some(joined) = tasks.join_next_with_id().await {
+                drain_activity_events(&mut activity_rx, &mut concurrency);
+                collect_group_result(joined, &mut planned_groups, &mut run, &mut concurrency);
+            }
+        }
+    }
+
+    drain_activity_events(&mut activity_rx, &mut concurrency);
+
+    sample_infrastructure(&resolver, &preflight.api_origin, &mut run).await;
+    run.finished_at_unix_ms = unix_time_ms();
+    let observed_backend_hints = resolver.backend_hints().observed_backend_count();
+    let peak_server_count = run
+        .infrastructure_samples
+        .iter()
+        .filter_map(|sample| {
+            sample
+                .regional_server_counts
+                .get(&preflight.selected_region.id)
+                .copied()
+        })
+        .max()
+        .unwrap_or(baseline_server_count);
+    let scale_out_observed = baseline_server_count > 0 && peak_server_count > baseline_server_count;
+    run.metadata.insert(
+        "baseline_selected_region_servers".to_owned(),
+        baseline_server_count.to_string(),
+    );
+    run.metadata.insert(
+        "peak_selected_region_servers".to_owned(),
+        peak_server_count.to_string(),
+    );
+    run.metadata.insert(
+        "require_scale_out".to_owned(),
+        config.require_scale_out.to_string(),
+    );
+    run.metadata.insert(
+        "observed_backend_hints".to_owned(),
+        observed_backend_hints.to_string(),
+    );
+    run.metadata.insert(
+        "autoscaling_signal".to_owned(),
+        if scale_out_observed {
+            "active_server_count_increased"
+        } else if observed_backend_hints > baseline_backend_hints {
+            "backend_hint_increased_without_server_count_increase"
+        } else {
+            "no_scale_out_observed"
+        }
+        .to_owned(),
+    );
+    if interrupted {
+        run.metadata
+            .insert("interrupted".to_owned(), "true".to_owned());
+    }
+    run.metadata.insert(
+        "sessions_launched".to_owned(),
+        total_sessions_launched.to_string(),
+    );
+    run.metadata.insert(
+        "coordinator_peak_token_sent_concurrency".to_owned(),
+        concurrency.peak_connected().to_string(),
+    );
+    if !planned_groups.is_empty() {
+        // This should be unreachable because every JoinSet result is drained,
+        // but keep the report denominator complete if Tokio ever returns an
+        // unexpected coordinator state.
+        for (_, spec) in planned_groups.drain() {
+            concurrency.mark_terminal(&spec.session_indices);
+            run.sessions.extend(synthetic_group_failures(
+                &spec,
+                "coordinator lost task bookkeeping before a terminal result was produced",
+            ));
+            increment_metadata_counter(&mut run, "coordinator_task_failures");
+        }
+    }
+
+    let report_dir = report_directory(&config.report_dir, &config.run_id);
+    let aggregate = aggregate_report(&run);
+    let completed_rate = if aggregate.session_counts.total == 0 {
+        0.0
+    } else {
+        aggregate.session_counts.completed as f64 / aggregate.session_counts.total as f64
+    };
+    let coordinator_failures = metadata_counter(&run, "coordinator_task_failures");
+    let all_sessions_accounted = aggregate.session_counts.total == total_sessions_launched;
+    let all_games_observed = run.games.observed == run.games.expected;
+    let peak_token_sent_target_reached =
+        aggregate.session_counts.peak_token_sent_concurrency >= config.max_concurrency();
+    let all_stages_completed = !interrupted && run.ramp_stages.len() == config.stages.len();
+    let all_targets_reached =
+        all_stages_completed && run.ramp_stages.iter().all(|stage| stage.target_reached);
+    let mut threshold_failures = Vec::new();
+    if aggregate.session_counts.total == 0 {
+        threshold_failures.push("no sessions were reported".to_owned());
+    } else if completed_rate < 0.98 {
+        threshold_failures.push(format!(
+            "session completion rate {:.2}% was below 98%",
+            completed_rate * 100.0
+        ));
+    }
+    if !peak_token_sent_target_reached {
+        threshold_failures.push(format!(
+            "peak token-sent logical sessions {} never reached configured maximum {}",
+            aggregate.session_counts.peak_token_sent_concurrency,
+            config.max_concurrency()
+        ));
+    }
+    if !all_sessions_accounted {
+        threshold_failures.push(format!(
+            "reported {} of {} launched sessions",
+            aggregate.session_counts.total, total_sessions_launched
+        ));
+    }
+    if coordinator_failures > 0 {
+        threshold_failures.push(format!(
+            "{coordinator_failures} coordinator task failures occurred"
+        ));
+    }
+    if !all_games_observed {
+        threshold_failures.push(format!(
+            "observed {} of {} launched games",
+            run.games.observed, run.games.expected
+        ));
+    }
+    if run.games.pairing_violations > 0 {
+        threshold_failures.push(format!(
+            "{} deterministic pairing violations occurred",
+            run.games.pairing_violations
+        ));
+    }
+    if !all_stages_completed {
+        threshold_failures.push("the configured stage plan did not complete".to_owned());
+    } else if !all_targets_reached {
+        threshold_failures
+            .push("one or more token-sent session concurrency targets were not reached".to_owned());
+    }
+    if config.require_scale_out && !scale_out_observed {
+        threshold_failures.push(format!(
+            "active selected-region servers did not rise above baseline {baseline_server_count}"
+        ));
+    }
+    let passed = threshold_failures.is_empty();
+    run.metadata.insert(
+        "sessions_accounted".to_owned(),
+        aggregate.session_counts.total.to_string(),
+    );
+    run.metadata.insert(
+        "all_games_observed".to_owned(),
+        all_games_observed.to_string(),
+    );
+    run.metadata.insert(
+        "peak_token_sent_target_reached".to_owned(),
+        peak_token_sent_target_reached.to_string(),
+    );
+    run.metadata.insert(
+        "all_stages_completed".to_owned(),
+        all_stages_completed.to_string(),
+    );
+    run.metadata.insert(
+        "all_stage_targets_reached".to_owned(),
+        all_targets_reached.to_string(),
+    );
+    run.metadata.insert(
+        "threshold_result".to_owned(),
+        if passed { "passed" } else { "failed" }.to_owned(),
+    );
+    if !threshold_failures.is_empty() {
+        run.metadata.insert(
+            "threshold_failures".to_owned(),
+            threshold_failures.join("; "),
+        );
+    }
+    // Rebuild after threshold metadata is present and write all artifacts.
+    let written = write_report(&report_dir, &run)?;
+    let aggregate = aggregate_report(&run);
+
+    info!(
+        sessions = aggregate.session_counts.total,
+        completed = aggregate.session_counts.completed,
+        failed = aggregate.session_counts.failed,
+        peak_token_sent = aggregate.session_counts.peak_token_sent_concurrency,
+        games_completed = aggregate.games.completed,
+        games_timeboxed = aggregate.games.timeboxed,
+        games_expected = aggregate.games.expected,
+        pairing_violations = aggregate.games.pairing_violations,
+        queue_p95_ms = ?aggregate.metrics.matchmaking_wait_ms.p95_ms,
+        report = %written.index_html.display(),
+        "load test finished"
+    );
+
+    if !passed {
+        return Err(anyhow!(
+            "load-test thresholds failed: {}; report: {}",
+            threshold_failures.join("; "),
+            written.index_html.display()
+        ));
+    }
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_deficit_wave(
+    target: usize,
+    launch_budget: usize,
+    concurrency: &mut SessionConcurrencyTracker,
+    next_session_index: &mut u64,
+    next_group_index: &mut u64,
+    next_wave_index: &mut u32,
+    tasks: &mut JoinSet<MatchGroupResult>,
+    planned_groups: &mut HashMap<Id, MatchGroupSpec>,
+    config: &Config,
+    settings: &SessionSettings,
+    http_client: reqwest::Client,
+    activity_tx: &mpsc::UnboundedSender<SessionActivityEvent>,
+    cancellation: CancellationToken,
+) -> usize {
+    let players_per_game = config.players_per_game();
+    let group_count = groups_to_launch(
+        target,
+        concurrency.reserved(),
+        launch_budget,
+        players_per_game,
+    );
+    if group_count == 0 {
+        return 0;
+    }
+    let barrier = Arc::new(Barrier::new(group_count));
+    let wave_index = *next_wave_index;
+    *next_wave_index = next_wave_index.saturating_add(1);
+
+    let session_groups = plan_session_groups(*next_session_index, group_count, players_per_game);
+    for session_indices in session_groups {
+        let group_index = *next_group_index;
+        *next_group_index = next_group_index.saturating_add(1);
+        let spec = MatchGroupSpec {
+            run_id: config.run_id.clone(),
+            wave_index,
+            group_index,
+            session_indices,
+        };
+        // Reserve before spawning so a very fast prepare failure cannot race
+        // its terminal notification ahead of coordinator bookkeeping.
+        concurrency.reserve(&spec.session_indices);
+        let handle = tasks.spawn(run_match_group(
+            spec.clone(),
+            settings.clone(),
+            http_client.clone(),
+            activity_tx.clone(),
+            barrier.clone(),
+            cancellation.clone(),
+        ));
+        planned_groups.insert(handle.id(), spec);
+    }
+    let launched = group_count * players_per_game;
+    *next_session_index = next_session_index.saturating_add(launched as u64);
+    info!(
+        wave = wave_index,
+        groups = group_count,
+        sessions = launched,
+        connected = concurrency.connected(),
+        pending = concurrency.pending(),
+        reserved = concurrency.reserved(),
+        "launched coordinated wave"
+    );
+    launched
+}
+
+fn groups_to_launch(
+    target: usize,
+    reserved: usize,
+    launch_budget: usize,
+    players_per_game: usize,
+) -> usize {
+    if reserved >= target || players_per_game == 0 {
+        return 0;
+    }
+    // Replacements remain full match groups. If a single VU from a group
+    // exits early, the bounded overshoot is therefore less than one group.
+    (target - reserved)
+        .div_ceil(players_per_game)
+        .min(launch_budget / players_per_game)
+}
+
+fn record_successful_game_outcome(
+    run: &mut LoadTestRun,
+    result: &MatchGroupResult,
+    planned_count: usize,
+) {
+    if result.observed_game_ids.len() != result.expected_game_count
+        || result.sessions.len() != planned_count
+        || !result
+            .sessions
+            .iter()
+            .all(|session| session.outcome == SessionOutcome::Completed)
+    {
+        return;
+    }
+
+    let timeboxed = result.sessions.iter().any(|session| {
+        session
+            .diagnostics
+            .get("completion_kind")
+            .is_some_and(|kind| kind == "timeboxed")
+    });
+    if timeboxed {
+        run.games.timeboxed = run
+            .games
+            .timeboxed
+            .saturating_add(result.expected_game_count);
+    } else {
+        run.games.completed = run
+            .games
+            .completed
+            .saturating_add(result.expected_game_count);
+    }
+}
+
+fn collect_group_result(
+    joined: std::result::Result<(Id, MatchGroupResult), JoinError>,
+    planned_groups: &mut HashMap<Id, MatchGroupSpec>,
+    run: &mut LoadTestRun,
+    concurrency: &mut SessionConcurrencyTracker,
+) {
+    match joined {
+        Ok((task_id, mut result)) => {
+            let spec = planned_groups.remove(&task_id);
+            let planned_count = spec
+                .as_ref()
+                .map_or(result.sessions.len(), |spec| spec.session_indices.len());
+
+            if let Some(spec) = &spec {
+                // Usually idempotent with per-VU terminal events. This also
+                // closes reservations if a task panics before creating leases.
+                concurrency.mark_terminal(&spec.session_indices);
+                let returned: BTreeSet<&str> = result
+                    .sessions
+                    .iter()
+                    .map(|session| session.session_id.as_str())
+                    .collect();
+                let missing: Vec<u64> = spec
+                    .session_indices
+                    .iter()
+                    .copied()
+                    .filter(|index| !returned.contains(format!("session-{index:08}").as_str()))
+                    .collect();
+                if !missing.is_empty() || result.sessions.len() != planned_count {
+                    increment_metadata_counter(run, "coordinator_task_failures");
+                    for session_index in missing {
+                        result.sessions.push(synthetic_session_failure(
+                            spec,
+                            session_index,
+                            "match-group task returned without this planned session record",
+                        ));
+                    }
+                }
+            } else {
+                increment_metadata_counter(run, "coordinator_task_failures");
+                error!(
+                    ?task_id,
+                    "completed match-group task had no coordinator plan"
+                );
+            }
+
+            run.games.observed = run
+                .games
+                .observed
+                .saturating_add(result.observed_game_ids.len());
+            record_successful_game_outcome(run, &result, planned_count);
+            if let Some(violation) = result.pairing_violation {
+                run.games.pairing_violations = run.games.pairing_violations.saturating_add(1);
+                run.pairing_violation_details.push(violation);
+            }
+            run.sessions.extend(result.sessions);
+        }
+        Err(error) => {
+            let task_id = error.id();
+            let spec = planned_groups.remove(&task_id);
+            increment_metadata_counter(run, "coordinator_task_failures");
+            if let Some(spec) = spec {
+                concurrency.mark_terminal(&spec.session_indices);
+                run.sessions.extend(synthetic_group_failures(
+                    &spec,
+                    &format!("match-group coordinator task failed: {error}"),
+                ));
+            }
+            error!(%error, "match-group task failed before producing session records");
+        }
+    }
+}
+
+fn synthetic_group_failures(spec: &MatchGroupSpec, message: &str) -> Vec<SessionRecord> {
+    spec.session_indices
+        .iter()
+        .map(|session_index| synthetic_session_failure(spec, *session_index, message))
+        .collect()
+}
+
+fn synthetic_session_failure(
+    spec: &MatchGroupSpec,
+    session_index: u64,
+    message: &str,
+) -> SessionRecord {
+    let now = unix_time_ms();
+    let mut record = SessionRecord::new(
+        format!("session-{session_index:08}"),
+        deterministic_username(&spec.run_id, session_index),
+        spec.wave_index,
+        spec.group_id(),
+        now,
+    );
+    record.fail(
+        SessionFailureRecord::new(SessionPhase::Cleanup, now, message)
+            .with_context("coordinator_failure", "true")
+            .with_context("session_index", session_index.to_string()),
+    );
+    record
+}
+
+fn increment_metadata_counter(run: &mut LoadTestRun, key: &str) {
+    run.metadata
+        .entry(key.to_owned())
+        .and_modify(|value| {
+            let count = value.parse::<u64>().unwrap_or(0).saturating_add(1);
+            *value = count.to_string();
+        })
+        .or_insert_with(|| "1".to_owned());
+}
+
+fn metadata_counter(run: &LoadTestRun, key: &str) -> u64 {
+    run.metadata
+        .get(key)
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(0)
+}
+
+fn launch_budget(config: &Config, total_sessions_launched: usize) -> usize {
+    config.spawn_rate.min(
+        config
+            .max_total_sessions
+            .saturating_sub(total_sessions_launched),
+    )
+}
+
+async fn sample_infrastructure(resolver: &TargetResolver, api_origin: &str, run: &mut LoadTestRun) {
+    let (users, servers) = tokio::join!(
+        resolver.sample_user_counts_from_origin(api_origin),
+        resolver.sample_server_counts_from_origin(api_origin),
+    );
+    let mut errors = Vec::new();
+    let regional_user_counts = match users {
+        Ok(sample) => sample.counts,
+        Err(error) => {
+            errors.push(format!("user counts: {error}"));
+            Default::default()
+        }
+    };
+    let regional_server_counts = match servers {
+        Ok(sample) => sample.counts,
+        Err(error) => {
+            errors.push(format!("server counts: {error}"));
+            Default::default()
+        }
+    };
+    run.infrastructure_samples.push(InfrastructureSample {
+        observed_at_unix_ms: unix_time_ms(),
+        regional_user_counts,
+        regional_server_counts,
+        observed_backend_hints: resolver.backend_hints().observed_backend_count(),
+        error: (!errors.is_empty()).then(|| errors.join("; ")),
+    });
+}
+
+fn game_type(mode: GameMode) -> GameType {
+    match mode {
+        GameMode::Solo => GameType::Solo,
+        GameMode::Duel => GameType::TeamMatch { per_team: 1 },
+        GameMode::TwoVTwo => GameType::TeamMatch { per_team: 2 },
+        GameMode::FreeForAll => GameType::FreeForAll { max_players: 4 },
+    }
+}
+
+fn queue_mode(mode: config::QueueMode) -> QueueMode {
+    match mode {
+        config::QueueMode::Quickmatch => QueueMode::Quickmatch,
+        config::QueueMode::Competitive => QueueMode::Competitive,
+    }
+}
+
+fn ensure_effective_endpoints_confirmed(
+    production_confirmed: bool,
+    endpoints: &[&Url],
+) -> Result<()> {
+    if !production_confirmed
+        && endpoints
+            .iter()
+            .any(|endpoint| config::is_snaketron_production_url(endpoint))
+    {
+        return Err(anyhow!(
+            "target discovery resolved to snaketron.io production; pass --confirm-production to acknowledge the load"
+        ));
+    }
+    Ok(())
+}
+
+fn report_directory(root: &Path, run_id: &str) -> PathBuf {
+    root.join(run_id)
+}
+
+fn failure_circuit_breaker(run: &LoadTestRun) -> Option<String> {
+    let terminal = run.sessions.len();
+    if terminal < FAILURE_CIRCUIT_BREAKER_MIN_SESSIONS {
+        return None;
+    }
+    let failures = run
+        .sessions
+        .iter()
+        .filter(|session| session.outcome == SessionOutcome::Failed)
+        .count();
+    let rate = failures as f64 / terminal as f64;
+    (rate > FAILURE_CIRCUIT_BREAKER_RATE).then(|| {
+        format!(
+            "{failures}/{terminal} terminal sessions failed ({:.1}%, limit {:.1}%)",
+            rate * 100.0,
+            FAILURE_CIRCUIT_BREAKER_RATE * 100.0
+        )
+    })
+}
+
+fn plan_session_groups(
+    first_session_index: u64,
+    group_count: usize,
+    players_per_game: usize,
+) -> Vec<Vec<u64>> {
+    (0..group_count)
+        .map(|group_offset| {
+            let first = first_session_index + (group_offset * players_per_game) as u64;
+            (0..players_per_game)
+                .map(|player_offset| first + player_offset as u64)
+                .collect()
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn four_duel_sessions_are_planned_as_two_deterministic_games() {
+        assert_eq!(plan_session_groups(1, 2, 2), vec![vec![1, 2], vec![3, 4]]);
+    }
+
+    #[test]
+    fn pending_sessions_reserve_capacity_without_counting_as_connected() {
+        let mut concurrency = SessionConcurrencyTracker::default();
+        concurrency.reserve(&[1, 2]);
+
+        assert_eq!(concurrency.pending(), 2);
+        assert_eq!(concurrency.connected(), 0);
+        assert_eq!(concurrency.reserved(), 2);
+        assert_eq!(groups_to_launch(2, concurrency.reserved(), 2, 2), 0);
+    }
+
+    #[test]
+    fn individual_terminal_session_releases_capacity_before_its_group_finishes() {
+        let mut concurrency = SessionConcurrencyTracker::default();
+        concurrency.reserve(&[1, 2]);
+        concurrency.observe(SessionActivityEvent::Connected { session_index: 1 });
+        concurrency.observe(SessionActivityEvent::Connected { session_index: 2 });
+
+        concurrency.observe(SessionActivityEvent::Terminal { session_index: 1 });
+
+        assert_eq!(concurrency.connected(), 1);
+        assert_eq!(concurrency.reserved(), 1);
+        assert_eq!(groups_to_launch(2, concurrency.reserved(), 2, 2), 1);
+    }
+
+    #[test]
+    fn replacement_launches_stay_match_group_aligned_and_bounded() {
+        // One missing member of a four-player group requires one complete
+        // replacement group, producing at most a three-session overshoot.
+        assert_eq!(groups_to_launch(4, 3, 8, 4), 1);
+        assert_eq!(3 + groups_to_launch(4, 3, 8, 4) * 4, 7);
+        assert_eq!(groups_to_launch(4, 4, 8, 4), 0);
+    }
+
+    #[test]
+    fn late_connected_event_cannot_resurrect_a_terminal_session() {
+        let mut concurrency = SessionConcurrencyTracker::default();
+        concurrency.reserve(&[1]);
+        concurrency.mark_terminal(&[1]);
+        concurrency.observe(SessionActivityEvent::Connected { session_index: 1 });
+
+        assert_eq!(concurrency.connected(), 0);
+        assert_eq!(concurrency.reserved(), 0);
+        assert_eq!(concurrency.peak_connected(), 0);
+    }
+
+    #[test]
+    fn stage_drain_records_a_transient_token_sent_target_before_terminal() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        let mut concurrency = SessionConcurrencyTracker::default();
+        concurrency.reserve(&[1]);
+        sender
+            .send(SessionActivityEvent::Connected { session_index: 1 })
+            .unwrap();
+        sender
+            .send(SessionActivityEvent::Terminal { session_index: 1 })
+            .unwrap();
+        let mut target_reached = false;
+        let mut target_reached_at = None;
+
+        drain_stage_activity_events(
+            &mut receiver,
+            &mut concurrency,
+            1,
+            &mut target_reached,
+            &mut target_reached_at,
+        );
+
+        assert!(target_reached);
+        assert!(target_reached_at.is_some());
+        assert_eq!(concurrency.connected(), 0);
+        assert_eq!(concurrency.peak_connected(), 1);
+    }
+
+    #[test]
+    fn solo_and_four_player_modes_use_the_expected_lobby_topology() {
+        assert_eq!(
+            plan_session_groups(1, 4, GameMode::Solo.players_per_game()),
+            vec![vec![1], vec![2], vec![3], vec![4]]
+        );
+        assert_eq!(
+            plan_session_groups(1, 1, GameMode::FreeForAll.players_per_game()),
+            vec![vec![1, 2, 3, 4]]
+        );
+        assert_eq!(
+            plan_session_groups(1, 1, GameMode::TwoVTwo.players_per_game()),
+            vec![vec![1, 2, 3, 4]]
+        );
+    }
+
+    #[test]
+    fn successful_games_are_split_between_authoritative_and_timeboxed_counts() {
+        fn result(timebox_first: bool) -> MatchGroupResult {
+            let mut first = SessionRecord::new("s1", "u1", 0, "g1", 0);
+            if timebox_first {
+                first
+                    .diagnostics
+                    .insert("completion_kind".to_owned(), "timeboxed".to_owned());
+            }
+            first.complete(1);
+            let mut second = SessionRecord::new("s2", "u2", 0, "g1", 0);
+            second.complete(1);
+            MatchGroupResult {
+                sessions: vec![first, second],
+                expected_game_count: 1,
+                observed_game_ids: BTreeSet::from([42]),
+                pairing_violation: None,
+            }
+        }
+
+        let mut run = LoadTestRun::new("run", "target", 0, 2);
+        record_successful_game_outcome(&mut run, &result(false), 2);
+        record_successful_game_outcome(&mut run, &result(true), 2);
+
+        assert_eq!(run.games.completed, 1);
+        assert_eq!(run.games.timeboxed, 1);
+    }
+
+    #[test]
+    fn unsuccessful_group_is_not_counted_as_a_completed_game() {
+        let mut completed = SessionRecord::new("s1", "u1", 0, "g1", 0);
+        completed.complete(1);
+        let failed = SessionRecord::new("s2", "u2", 0, "g1", 0);
+        let result = MatchGroupResult {
+            sessions: vec![completed, failed],
+            expected_game_count: 1,
+            observed_game_ids: BTreeSet::from([42]),
+            pairing_violation: None,
+        };
+        let mut run = LoadTestRun::new("run", "target", 0, 2);
+
+        record_successful_game_outcome(&mut run, &result, 2);
+
+        assert_eq!(run.games.completed, 0);
+        assert_eq!(run.games.timeboxed, 0);
+    }
+
+    #[test]
+    fn systemic_failures_trip_the_load_circuit_breaker() {
+        let mut run = LoadTestRun::new("run", "target", 0, 4);
+        for index in 0..4 {
+            let mut session = loadtest::report::SessionRecord::new(
+                format!("s{index}"),
+                format!("u{index}"),
+                0,
+                "g",
+                0,
+            );
+            session.fail(loadtest::report::SessionFailureRecord::new(
+                loadtest::report::SessionPhase::WebSocketConnect,
+                1,
+                "down",
+            ));
+            run.sessions.push(session);
+        }
+        assert!(failure_circuit_breaker(&run).is_some());
+    }
+
+    #[test]
+    fn discovered_production_endpoint_requires_confirmation() {
+        let custom_api = Url::parse("https://staging.example.test").unwrap();
+        let production_region = Url::parse("https://use1.snaketron.io").unwrap();
+        let production_websocket = Url::parse("wss://use1.snaketron.io/ws").unwrap();
+
+        assert!(
+            ensure_effective_endpoints_confirmed(
+                false,
+                &[&custom_api, &production_region, &production_websocket],
+            )
+            .is_err()
+        );
+        assert!(
+            ensure_effective_endpoints_confirmed(
+                true,
+                &[&custom_api, &production_region, &production_websocket],
+            )
+            .is_ok()
+        );
+        assert!(ensure_effective_endpoints_confirmed(false, &[&custom_api]).is_ok());
+    }
+
+    #[tokio::test]
+    async fn panicked_group_is_synthesized_into_session_failures() {
+        async fn panic_group() -> MatchGroupResult {
+            panic!("coordinator test panic")
+        }
+
+        let spec = MatchGroupSpec {
+            run_id: "run".to_owned(),
+            wave_index: 3,
+            group_index: 7,
+            session_indices: vec![41, 42],
+        };
+        let mut tasks = JoinSet::new();
+        let handle = tasks.spawn(panic_group());
+        let mut planned = HashMap::from([(handle.id(), spec)]);
+        let joined = tasks.join_next_with_id().await.unwrap();
+        let mut run = LoadTestRun::new("run", "target", 0, 2);
+        let mut concurrency = SessionConcurrencyTracker::default();
+        concurrency.reserve(&[41, 42]);
+
+        collect_group_result(joined, &mut planned, &mut run, &mut concurrency);
+
+        assert_eq!(concurrency.reserved(), 0);
+        assert!(planned.is_empty());
+        assert_eq!(run.sessions.len(), 2);
+        assert!(run.sessions.iter().all(SessionRecord::is_failed));
+        assert_eq!(metadata_counter(&run, "coordinator_task_failures"), 1);
+    }
+}

--- a/loadtest/src/report.rs
+++ b/loadtest/src/report.rs
@@ -1,0 +1,1337 @@
+//! Load-test reporting primitives.
+//!
+//! The coordinator records one [`SessionRecord`] per virtual user and hands the
+//! completed [`LoadTestRun`] to [`write_report`]. The writer produces:
+//!
+//! - `summary.json` with aggregate metrics and compact per-session summaries;
+//! - `index.html`, a self-contained human-readable report; and
+//! - one JSON file under `failures/` for every non-completed session.
+
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::error::Error;
+use std::fmt::{self, Write as _};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const REPORT_SCHEMA_VERSION: u32 = 2;
+
+/// Milliseconds since the Unix epoch, suitable for report timestamps.
+pub fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+/// A lifecycle phase shared by progress events and failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionPhase {
+    Created,
+    GuestAuthentication,
+    WebSocketConnect,
+    WebSocketAuthentication,
+    LobbyCreate,
+    LobbyJoin,
+    LobbyReady,
+    Matchmaking,
+    GameJoin,
+    GameSnapshot,
+    Playing,
+    Cleanup,
+    Complete,
+}
+
+impl SessionPhase {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Created => "created",
+            Self::GuestAuthentication => "guest_authentication",
+            Self::WebSocketConnect => "websocket_connect",
+            Self::WebSocketAuthentication => "websocket_authentication",
+            Self::LobbyCreate => "lobby_create",
+            Self::LobbyJoin => "lobby_join",
+            Self::LobbyReady => "lobby_ready",
+            Self::Matchmaking => "matchmaking",
+            Self::GameJoin => "game_join",
+            Self::GameSnapshot => "game_snapshot",
+            Self::Playing => "playing",
+            Self::Cleanup => "cleanup",
+            Self::Complete => "complete",
+        }
+    }
+}
+
+impl fmt::Display for SessionPhase {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// Terminal state of a virtual-user session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionOutcome {
+    Completed,
+    Failed,
+    Cancelled,
+    Incomplete,
+}
+
+impl SessionOutcome {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Failed => "failed",
+            Self::Cancelled => "cancelled",
+            Self::Incomplete => "incomplete",
+        }
+    }
+}
+
+impl fmt::Display for SessionOutcome {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+/// One timestamped event in a session's lifecycle.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionLifecycleRecord {
+    pub phase: SessionPhase,
+    pub at_unix_ms: u64,
+    /// Duration of the operation that produced this event, when applicable.
+    pub elapsed_ms: Option<u64>,
+    pub message: Option<String>,
+}
+
+impl SessionLifecycleRecord {
+    pub fn new(phase: SessionPhase, at_unix_ms: u64) -> Self {
+        Self {
+            phase,
+            at_unix_ms,
+            elapsed_ms: None,
+            message: None,
+        }
+    }
+
+    pub fn with_elapsed_ms(mut self, elapsed_ms: u64) -> Self {
+        self.elapsed_ms = Some(elapsed_ms);
+        self
+    }
+
+    pub fn with_message(mut self, message: impl Into<String>) -> Self {
+        self.message = Some(message.into());
+        self
+    }
+}
+
+/// Structured information retained for a failed session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionFailureRecord {
+    pub phase: SessionPhase,
+    pub at_unix_ms: u64,
+    pub message: String,
+    pub retryable: bool,
+    /// Small diagnostic values such as close code, last message type, or game ID.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub context: BTreeMap<String, String>,
+}
+
+impl SessionFailureRecord {
+    pub fn new(phase: SessionPhase, at_unix_ms: u64, message: impl Into<String>) -> Self {
+        Self {
+            phase,
+            at_unix_ms,
+            message: message.into(),
+            retryable: false,
+            context: BTreeMap::new(),
+        }
+    }
+
+    pub fn with_retryable(mut self, retryable: bool) -> Self {
+        self.retryable = retryable;
+        self
+    }
+
+    pub fn with_context(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.context.insert(key.into(), value.into());
+        self
+    }
+}
+
+/// Timing and traffic measurements collected by one virtual user.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SessionMetrics {
+    pub guest_auth_ms: Option<u64>,
+    pub websocket_connect_ms: Option<u64>,
+    pub lobby_ready_ms: Option<u64>,
+    pub matchmaking_wait_ms: Option<u64>,
+    pub game_join_ms: Option<u64>,
+    pub game_duration_ms: Option<u64>,
+    #[serde(default)]
+    pub websocket_rtt_ms: Vec<u64>,
+    pub messages_sent: u64,
+    pub messages_received: u64,
+    pub game_events_received: u64,
+    pub commands_sent: u64,
+    pub disconnects: u64,
+    pub reconnects: u64,
+}
+
+/// What happened while the coordinator held one configured concurrency stage.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RampStageRecord {
+    pub stage_index: u32,
+    pub target_concurrency: usize,
+    pub started_at_unix_ms: u64,
+    pub finished_at_unix_ms: u64,
+    pub sessions_launched: usize,
+    pub active_sessions_at_start: usize,
+    pub active_sessions_at_end: usize,
+    /// Whether the coordinator ever observed the requested number of logical
+    /// sessions whose initial WebSocket had sent an authentication token during
+    /// this bounded ramp-and-hold window.
+    pub target_reached: bool,
+    pub target_reached_at_unix_ms: Option<u64>,
+}
+
+/// In-band infrastructure sample. Backend count is a load-balancer hint, not
+/// a claim about the cloud provider's task count.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct InfrastructureSample {
+    pub observed_at_unix_ms: u64,
+    pub regional_user_counts: BTreeMap<String, u32>,
+    pub regional_server_counts: BTreeMap<String, u32>,
+    pub observed_backend_hints: usize,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct GameRunCounts {
+    pub expected: usize,
+    pub observed: usize,
+    /// Games that reached an authoritative server completion event.
+    pub completed: usize,
+    /// Untimed games deliberately left after the configured active-play window.
+    #[serde(default)]
+    pub timeboxed: usize,
+    pub pairing_violations: usize,
+}
+
+/// Full record for one virtual-user session.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionRecord {
+    pub session_id: String,
+    pub username: String,
+    pub wave_index: u32,
+    /// Coordinator-defined grouping key for sessions intended to share a match.
+    pub match_group: String,
+    pub lobby_code: Option<String>,
+    pub game_id: Option<u32>,
+    pub started_at_unix_ms: u64,
+    pub finished_at_unix_ms: Option<u64>,
+    pub outcome: SessionOutcome,
+    #[serde(default)]
+    pub lifecycle: Vec<SessionLifecycleRecord>,
+    pub failure: Option<SessionFailureRecord>,
+    #[serde(default)]
+    pub metrics: SessionMetrics,
+    /// Additional session-level diagnostics retained in failure JSON.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub diagnostics: BTreeMap<String, String>,
+}
+
+impl SessionRecord {
+    pub fn new(
+        session_id: impl Into<String>,
+        username: impl Into<String>,
+        wave_index: u32,
+        match_group: impl Into<String>,
+        started_at_unix_ms: u64,
+    ) -> Self {
+        Self {
+            session_id: session_id.into(),
+            username: username.into(),
+            wave_index,
+            match_group: match_group.into(),
+            lobby_code: None,
+            game_id: None,
+            started_at_unix_ms,
+            finished_at_unix_ms: None,
+            outcome: SessionOutcome::Incomplete,
+            lifecycle: vec![SessionLifecycleRecord::new(
+                SessionPhase::Created,
+                started_at_unix_ms,
+            )],
+            failure: None,
+            metrics: SessionMetrics::default(),
+            diagnostics: BTreeMap::new(),
+        }
+    }
+
+    pub fn record_lifecycle(&mut self, record: SessionLifecycleRecord) {
+        self.lifecycle.push(record);
+    }
+
+    pub fn complete(&mut self, finished_at_unix_ms: u64) {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self.outcome = SessionOutcome::Completed;
+        self.lifecycle.push(SessionLifecycleRecord::new(
+            SessionPhase::Complete,
+            finished_at_unix_ms,
+        ));
+    }
+
+    pub fn fail(&mut self, failure: SessionFailureRecord) {
+        self.finished_at_unix_ms = Some(failure.at_unix_ms);
+        self.outcome = SessionOutcome::Failed;
+        self.lifecycle.push(
+            SessionLifecycleRecord::new(failure.phase, failure.at_unix_ms)
+                .with_message(failure.message.clone()),
+        );
+        self.failure = Some(failure);
+    }
+
+    pub fn cancel(&mut self, finished_at_unix_ms: u64, reason: impl Into<String>) {
+        self.finished_at_unix_ms = Some(finished_at_unix_ms);
+        self.outcome = SessionOutcome::Cancelled;
+        self.lifecycle.push(
+            SessionLifecycleRecord::new(SessionPhase::Cleanup, finished_at_unix_ms)
+                .with_message(reason),
+        );
+    }
+
+    pub fn duration_ms(&self) -> Option<u64> {
+        self.finished_at_unix_ms
+            .map(|finished| finished.saturating_sub(self.started_at_unix_ms))
+    }
+
+    pub fn is_failed(&self) -> bool {
+        self.outcome == SessionOutcome::Failed || self.failure.is_some()
+    }
+
+    pub fn needs_detail_artifact(&self) -> bool {
+        self.outcome != SessionOutcome::Completed || self.failure.is_some()
+    }
+}
+
+/// Complete coordinator input used to build and write a report.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoadTestRun {
+    pub run_id: String,
+    pub target: String,
+    pub started_at_unix_ms: u64,
+    pub finished_at_unix_ms: u64,
+    pub configured_max_concurrency: usize,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub metadata: BTreeMap<String, String>,
+    #[serde(default)]
+    pub ramp_stages: Vec<RampStageRecord>,
+    #[serde(default)]
+    pub infrastructure_samples: Vec<InfrastructureSample>,
+    #[serde(default)]
+    pub games: GameRunCounts,
+    #[serde(default)]
+    pub pairing_violation_details: Vec<String>,
+    pub sessions: Vec<SessionRecord>,
+}
+
+impl LoadTestRun {
+    pub fn new(
+        run_id: impl Into<String>,
+        target: impl Into<String>,
+        started_at_unix_ms: u64,
+        configured_max_concurrency: usize,
+    ) -> Self {
+        Self {
+            run_id: run_id.into(),
+            target: target.into(),
+            started_at_unix_ms,
+            finished_at_unix_ms: started_at_unix_ms,
+            configured_max_concurrency,
+            metadata: BTreeMap::new(),
+            ramp_stages: Vec::new(),
+            infrastructure_samples: Vec::new(),
+            games: GameRunCounts::default(),
+            pairing_violation_details: Vec::new(),
+            sessions: Vec::new(),
+        }
+    }
+}
+
+/// A nearest-rank percentile. `percentile` is expressed from `0.0` to `100.0`.
+/// Values outside that range are clamped; NaN and empty samples return `None`.
+pub fn percentile(values: &[u64], percentile: f64) -> Option<u64> {
+    if values.is_empty() || !percentile.is_finite() {
+        return None;
+    }
+
+    let mut sorted = values.to_vec();
+    sorted.sort_unstable();
+
+    let percentile = percentile.clamp(0.0, 100.0);
+    if percentile == 0.0 {
+        return sorted.first().copied();
+    }
+
+    let rank = ((percentile / 100.0) * sorted.len() as f64).ceil() as usize;
+    sorted.get(rank.saturating_sub(1)).copied()
+}
+
+/// Summary of a collection of millisecond samples.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DistributionSummary {
+    pub samples: usize,
+    pub min_ms: Option<u64>,
+    pub max_ms: Option<u64>,
+    pub mean_ms: Option<f64>,
+    pub p50_ms: Option<u64>,
+    pub p95_ms: Option<u64>,
+    pub p99_ms: Option<u64>,
+}
+
+impl DistributionSummary {
+    pub fn from_samples(samples: &[u64]) -> Self {
+        let mean_ms = if samples.is_empty() {
+            None
+        } else {
+            let sum = samples.iter().map(|value| *value as u128).sum::<u128>();
+            Some(sum as f64 / samples.len() as f64)
+        };
+
+        Self {
+            samples: samples.len(),
+            min_ms: samples.iter().min().copied(),
+            max_ms: samples.iter().max().copied(),
+            mean_ms,
+            p50_ms: percentile(samples, 50.0),
+            p95_ms: percentile(samples, 95.0),
+            p99_ms: percentile(samples, 99.0),
+        }
+    }
+}
+
+impl Default for DistributionSummary {
+    fn default() -> Self {
+        Self::from_samples(&[])
+    }
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TrafficTotals {
+    pub messages_sent: u64,
+    pub messages_received: u64,
+    pub game_events_received: u64,
+    pub commands_sent: u64,
+    pub disconnects: u64,
+    pub reconnects: u64,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct AggregateMetrics {
+    pub session_duration_ms: DistributionSummary,
+    pub guest_auth_ms: DistributionSummary,
+    pub websocket_connect_ms: DistributionSummary,
+    pub lobby_ready_ms: DistributionSummary,
+    pub matchmaking_wait_ms: DistributionSummary,
+    pub game_join_ms: DistributionSummary,
+    pub game_duration_ms: DistributionSummary,
+    pub websocket_rtt_ms: DistributionSummary,
+    pub traffic: TrafficTotals,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SessionCounts {
+    pub total: usize,
+    pub completed: usize,
+    pub failed: usize,
+    pub cancelled: usize,
+    pub incomplete: usize,
+    pub success_rate_percent: f64,
+    pub failure_rate_percent: f64,
+    /// Peak overlapping logical sessions after their authentication token was
+    /// written to the initial WebSocket. A logical session remains active across
+    /// short reconnect gaps; this does not claim server-side authentication was
+    /// confirmed or that one transport socket stayed continuously open.
+    pub peak_token_sent_concurrency: usize,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SessionSummary {
+    pub session_id: String,
+    pub username: String,
+    pub wave_index: u32,
+    pub match_group: String,
+    pub lobby_code: Option<String>,
+    pub game_id: Option<u32>,
+    pub outcome: SessionOutcome,
+    /// `timeboxed` when a healthy untimed game reached its configured play window.
+    pub completion_kind: Option<String>,
+    pub duration_ms: Option<u64>,
+    pub failure_phase: Option<SessionPhase>,
+    pub failure_message: Option<String>,
+    /// Relative link from `index.html` to the detailed non-completed session record.
+    pub detail_file: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AggregateReport {
+    pub schema_version: u32,
+    pub generated_at_unix_ms: u64,
+    pub run_id: String,
+    pub target: String,
+    pub started_at_unix_ms: u64,
+    pub finished_at_unix_ms: u64,
+    pub duration_ms: u64,
+    pub configured_max_concurrency: usize,
+    pub metadata: BTreeMap<String, String>,
+    pub ramp_stages: Vec<RampStageRecord>,
+    pub infrastructure_samples: Vec<InfrastructureSample>,
+    pub games: GameRunCounts,
+    pub pairing_violation_details: Vec<String>,
+    pub session_counts: SessionCounts,
+    pub metrics: AggregateMetrics,
+    pub failures_by_phase: BTreeMap<String, usize>,
+    pub failures_by_message: BTreeMap<String, usize>,
+    pub sessions: Vec<SessionSummary>,
+}
+
+impl AggregateReport {
+    pub fn from_run(run: &LoadTestRun) -> Self {
+        aggregate_report(run)
+    }
+}
+
+/// Build the in-memory aggregate without writing any files.
+pub fn aggregate_report(run: &LoadTestRun) -> AggregateReport {
+    let mut completed = 0;
+    let mut failed = 0;
+    let mut cancelled = 0;
+    let mut incomplete = 0;
+    let mut failures_by_phase = BTreeMap::new();
+    let mut failures_by_message = BTreeMap::new();
+    let mut detail_ordinal = 0usize;
+
+    let mut session_durations = Vec::new();
+    let mut guest_auth = Vec::new();
+    let mut websocket_connect = Vec::new();
+    let mut lobby_ready = Vec::new();
+    let mut matchmaking_wait = Vec::new();
+    let mut game_join = Vec::new();
+    let mut game_duration = Vec::new();
+    let mut websocket_rtt = Vec::new();
+    let mut traffic = TrafficTotals::default();
+
+    let sessions = run
+        .sessions
+        .iter()
+        .map(|session| {
+            match session.outcome {
+                SessionOutcome::Completed => completed += 1,
+                SessionOutcome::Failed => failed += 1,
+                SessionOutcome::Cancelled => cancelled += 1,
+                SessionOutcome::Incomplete => incomplete += 1,
+            }
+
+            if let Some(value) = session.duration_ms() {
+                session_durations.push(value);
+            }
+            push_option(&mut guest_auth, session.metrics.guest_auth_ms);
+            push_option(&mut websocket_connect, session.metrics.websocket_connect_ms);
+            push_option(&mut lobby_ready, session.metrics.lobby_ready_ms);
+            push_option(&mut matchmaking_wait, session.metrics.matchmaking_wait_ms);
+            push_option(&mut game_join, session.metrics.game_join_ms);
+            push_option(&mut game_duration, session.metrics.game_duration_ms);
+            websocket_rtt.extend(session.metrics.websocket_rtt_ms.iter().copied());
+
+            traffic.messages_sent = traffic
+                .messages_sent
+                .saturating_add(session.metrics.messages_sent);
+            traffic.messages_received = traffic
+                .messages_received
+                .saturating_add(session.metrics.messages_received);
+            traffic.game_events_received = traffic
+                .game_events_received
+                .saturating_add(session.metrics.game_events_received);
+            traffic.commands_sent = traffic
+                .commands_sent
+                .saturating_add(session.metrics.commands_sent);
+            traffic.disconnects = traffic
+                .disconnects
+                .saturating_add(session.metrics.disconnects);
+            traffic.reconnects = traffic
+                .reconnects
+                .saturating_add(session.metrics.reconnects);
+
+            let detail_file = if session.needs_detail_artifact() {
+                detail_ordinal += 1;
+                Some(detail_relative_path(detail_ordinal, &session.session_id))
+            } else {
+                None
+            };
+
+            if let Some(failure) = &session.failure {
+                *failures_by_phase
+                    .entry(failure.phase.as_str().to_owned())
+                    .or_insert(0) += 1;
+                *failures_by_message
+                    .entry(failure.message.clone())
+                    .or_insert(0) += 1;
+            }
+
+            SessionSummary {
+                session_id: session.session_id.clone(),
+                username: session.username.clone(),
+                wave_index: session.wave_index,
+                match_group: session.match_group.clone(),
+                lobby_code: session.lobby_code.clone(),
+                game_id: session.game_id,
+                outcome: session.outcome,
+                completion_kind: session.diagnostics.get("completion_kind").cloned(),
+                duration_ms: session.duration_ms(),
+                failure_phase: session.failure.as_ref().map(|value| value.phase),
+                failure_message: session.failure.as_ref().map(|value| value.message.clone()),
+                detail_file,
+            }
+        })
+        .collect();
+
+    let total = run.sessions.len();
+    let denominator = total.max(1) as f64;
+
+    AggregateReport {
+        schema_version: REPORT_SCHEMA_VERSION,
+        generated_at_unix_ms: unix_time_ms(),
+        run_id: run.run_id.clone(),
+        target: run.target.clone(),
+        started_at_unix_ms: run.started_at_unix_ms,
+        finished_at_unix_ms: run.finished_at_unix_ms,
+        duration_ms: run
+            .finished_at_unix_ms
+            .saturating_sub(run.started_at_unix_ms),
+        configured_max_concurrency: run.configured_max_concurrency,
+        metadata: run.metadata.clone(),
+        ramp_stages: run.ramp_stages.clone(),
+        infrastructure_samples: run.infrastructure_samples.clone(),
+        games: run.games.clone(),
+        pairing_violation_details: run.pairing_violation_details.clone(),
+        session_counts: SessionCounts {
+            total,
+            completed,
+            failed,
+            cancelled,
+            incomplete,
+            success_rate_percent: if total == 0 {
+                0.0
+            } else {
+                completed as f64 * 100.0 / denominator
+            },
+            failure_rate_percent: if total == 0 {
+                0.0
+            } else {
+                failed as f64 * 100.0 / denominator
+            },
+            peak_token_sent_concurrency: peak_token_sent_concurrency(run),
+        },
+        metrics: AggregateMetrics {
+            session_duration_ms: DistributionSummary::from_samples(&session_durations),
+            guest_auth_ms: DistributionSummary::from_samples(&guest_auth),
+            websocket_connect_ms: DistributionSummary::from_samples(&websocket_connect),
+            lobby_ready_ms: DistributionSummary::from_samples(&lobby_ready),
+            matchmaking_wait_ms: DistributionSummary::from_samples(&matchmaking_wait),
+            game_join_ms: DistributionSummary::from_samples(&game_join),
+            game_duration_ms: DistributionSummary::from_samples(&game_duration),
+            websocket_rtt_ms: DistributionSummary::from_samples(&websocket_rtt),
+            traffic,
+        },
+        failures_by_phase,
+        failures_by_message,
+        sessions,
+    }
+}
+
+fn push_option(values: &mut Vec<u64>, value: Option<u64>) {
+    if let Some(value) = value {
+        values.push(value);
+    }
+}
+
+fn peak_token_sent_concurrency(run: &LoadTestRun) -> usize {
+    // Token-sent logical sessions are half-open intervals [token, finish).
+    // Finish events sort before starts at the same timestamp, avoiding a false
+    // overlap. Sessions that never wrote a token do not inflate this metric.
+    let mut events = Vec::with_capacity(run.sessions.len() * 2);
+    for session in &run.sessions {
+        let Some(connected_at) = session
+            .lifecycle
+            .iter()
+            .find(|event| event.phase == SessionPhase::WebSocketAuthentication)
+            .map(|event| event.at_unix_ms)
+        else {
+            continue;
+        };
+        let finish = session
+            .finished_at_unix_ms
+            .unwrap_or(run.finished_at_unix_ms);
+        if finish <= connected_at {
+            // Preserve visibility for zero-duration records.
+            events.push((connected_at, 1i8));
+            events.push((connected_at.saturating_add(1), -1i8));
+        } else {
+            events.push((connected_at, 1i8));
+            events.push((finish, -1i8));
+        }
+    }
+    events.sort_unstable_by_key(|(at, delta)| (*at, *delta));
+
+    let mut current = 0usize;
+    let mut peak = 0usize;
+    for (_, delta) in events {
+        if delta < 0 {
+            current = current.saturating_sub(1);
+        } else {
+            current = current.saturating_add(1);
+            peak = peak.max(current);
+        }
+    }
+    peak
+}
+
+/// Files written by [`write_report`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WrittenReport {
+    pub summary_json: PathBuf,
+    pub index_html: PathBuf,
+    pub session_detail_json: Vec<PathBuf>,
+}
+
+#[derive(Debug)]
+pub enum ReportError {
+    Io(std::io::Error),
+    Json(serde_json::Error),
+}
+
+impl fmt::Display for ReportError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "report I/O error: {error}"),
+            Self::Json(error) => write!(formatter, "report JSON error: {error}"),
+        }
+    }
+}
+
+impl Error for ReportError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::Io(error) => Some(error),
+            Self::Json(error) => Some(error),
+        }
+    }
+}
+
+impl From<std::io::Error> for ReportError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+impl From<serde_json::Error> for ReportError {
+    fn from(error: serde_json::Error) -> Self {
+        Self::Json(error)
+    }
+}
+
+/// Write aggregate and per-non-completed-session artifacts beneath `output_dir`.
+pub fn write_report(
+    output_dir: impl AsRef<Path>,
+    run: &LoadTestRun,
+) -> Result<WrittenReport, ReportError> {
+    let output_dir = output_dir.as_ref();
+    fs::create_dir_all(output_dir)?;
+    let failures_dir = output_dir.join("failures");
+    clear_existing_failure_artifacts(&failures_dir)?;
+
+    let report = aggregate_report(run);
+    let summary_json = output_dir.join("summary.json");
+    fs::write(&summary_json, serde_json::to_vec_pretty(&report)?)?;
+
+    let mut session_detail_json = Vec::new();
+    let mut detail_ordinal = 0usize;
+    for session in &run.sessions {
+        if !session.needs_detail_artifact() {
+            continue;
+        }
+
+        detail_ordinal += 1;
+        fs::create_dir_all(&failures_dir)?;
+        let path = output_dir.join(detail_relative_path(detail_ordinal, &session.session_id));
+        fs::write(&path, serde_json::to_vec_pretty(session)?)?;
+        session_detail_json.push(path);
+    }
+
+    let index_html = output_dir.join("index.html");
+    fs::write(&index_html, render_html(&report))?;
+
+    Ok(WrittenReport {
+        summary_json,
+        index_html,
+        session_detail_json,
+    })
+}
+
+fn clear_existing_failure_artifacts(failures_dir: &Path) -> Result<(), std::io::Error> {
+    let metadata = match fs::symlink_metadata(failures_dir) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_dir() {
+        fs::remove_dir_all(failures_dir)
+    } else {
+        // `symlink_metadata` does not follow a symlink, so this only removes the
+        // exact run-scoped path rather than anything it may point at.
+        fs::remove_file(failures_dir)
+    }
+}
+
+fn detail_relative_path(ordinal: usize, session_id: &str) -> String {
+    format!(
+        "failures/{ordinal:05}-{}.json",
+        safe_filename_component(session_id)
+    )
+}
+
+fn safe_filename_component(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || matches!(character, '-' | '_' | '.') {
+                character
+            } else {
+                '_'
+            }
+        })
+        .take(80)
+        .collect();
+
+    if sanitized.is_empty() {
+        "session".to_owned()
+    } else {
+        sanitized
+    }
+}
+
+fn html_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for character in value.chars() {
+        match character {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&#39;"),
+            _ => escaped.push(character),
+        }
+    }
+    escaped
+}
+
+fn render_html(report: &AggregateReport) -> String {
+    let counts = &report.session_counts;
+    let mut html = String::with_capacity(24_000);
+    html.push_str(
+        "<!doctype html><html lang=\"en\"><head><meta charset=\"utf-8\">\
+         <meta name=\"viewport\" content=\"width=device-width,initial-scale=1\">",
+    );
+    let _ = write!(
+        html,
+        "<title>Snaketron load test {}</title>",
+        html_escape(&report.run_id)
+    );
+    html.push_str(
+        "<style>\
+         :root{color-scheme:light;font-family:Inter,ui-sans-serif,system-ui,sans-serif;\
+         background:#f4f5f7;color:#15171a}body{margin:0;padding:32px}main{max-width:1280px;margin:auto}\
+         h1{margin:0 0 6px;font-size:30px}h2{margin-top:32px}.sub{color:#62666d;margin:0 0 24px}\
+         .cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(160px,1fr));gap:12px}\
+         .card,section{background:#fff;border:1px solid #dedfe2;border-radius:10px;padding:18px}\
+         .card b{display:block;font-size:28px;margin-top:6px}.label{font-size:12px;text-transform:uppercase;\
+         letter-spacing:.08em;color:#62666d}table{width:100%;border-collapse:collapse;background:#fff}\
+         th,td{text-align:left;border-bottom:1px solid #e6e7e9;padding:10px 12px;font-size:13px}\
+         th{background:#f8f8f9}.scroll{overflow:auto;border:1px solid #dedfe2;border-radius:10px}\
+         .completed{color:#087a44}.failed{color:#b42318}.cancelled,.incomplete{color:#8a5200}\
+         a{color:#155eef}code{font-size:12px}@media(max-width:700px){body{padding:18px}th,td{white-space:nowrap}}\
+         </style></head><body><main>",
+    );
+
+    let _ = write!(
+        html,
+        "<h1>Snaketron load test</h1><p class=\"sub\">Run <code>{}</code> against {} · \
+         <a href=\"summary.json\">summary.json</a></p>",
+        html_escape(&report.run_id),
+        html_escape(&report.target),
+    );
+    let _ = write!(
+        html,
+        "<div class=\"cards\">\
+         <div class=\"card\"><span class=\"label\">Sessions</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Completed</span><b class=\"completed\">{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Failed</span><b class=\"failed\">{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Success rate</span><b>{:.1}%</b></div>\
+         <div class=\"card\"><span class=\"label\">Peak token-sent sessions</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Configured max</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Games observed</span><b>{}/{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Authoritative games</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Timeboxed games</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Pairing violations</span><b class=\"{}\">{}</b></div>\
+         </div>",
+        counts.total,
+        counts.completed,
+        counts.failed,
+        counts.success_rate_percent,
+        counts.peak_token_sent_concurrency,
+        report.configured_max_concurrency,
+        report.games.observed,
+        report.games.expected,
+        report.games.completed,
+        report.games.timeboxed,
+        if report.games.pairing_violations == 0 {
+            "completed"
+        } else {
+            "failed"
+        },
+        report.games.pairing_violations,
+    );
+    if let Some(threshold) = report.metadata.get("threshold_result") {
+        let autoscaling = report
+            .metadata
+            .get("autoscaling_signal")
+            .map(String::as_str)
+            .unwrap_or("not_recorded");
+        let _ = write!(
+            html,
+            "<p class=\"sub\">Threshold result: <code>{}</code> · Autoscaling: <code>{}</code></p>",
+            html_escape(threshold),
+            html_escape(autoscaling),
+        );
+        if let Some(failures) = report.metadata.get("threshold_failures") {
+            let _ = write!(
+                html,
+                "<p class=\"failed\">Threshold failures: {}</p>",
+                html_escape(failures),
+            );
+        }
+    }
+
+    html.push_str(
+        "<h2>Latency and duration</h2><div class=\"scroll\"><table><thead><tr>\
+         <th>Metric</th><th>Samples</th><th>Mean</th><th>P50</th><th>P95</th><th>P99</th><th>Max</th>\
+         </tr></thead><tbody>",
+    );
+    append_distribution_row(
+        &mut html,
+        "Session duration",
+        &report.metrics.session_duration_ms,
+    );
+    append_distribution_row(
+        &mut html,
+        "Guest authentication",
+        &report.metrics.guest_auth_ms,
+    );
+    append_distribution_row(
+        &mut html,
+        "WebSocket connect",
+        &report.metrics.websocket_connect_ms,
+    );
+    append_distribution_row(&mut html, "Lobby ready", &report.metrics.lobby_ready_ms);
+    append_distribution_row(
+        &mut html,
+        "Matchmaking wait",
+        &report.metrics.matchmaking_wait_ms,
+    );
+    append_distribution_row(&mut html, "Game join", &report.metrics.game_join_ms);
+    append_distribution_row(&mut html, "Game duration", &report.metrics.game_duration_ms);
+    append_distribution_row(&mut html, "WebSocket RTT", &report.metrics.websocket_rtt_ms);
+    html.push_str("</tbody></table></div>");
+
+    let traffic = &report.metrics.traffic;
+    let _ = write!(
+        html,
+        "<h2>Traffic</h2><div class=\"cards\">\
+         <div class=\"card\"><span class=\"label\">Messages sent</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Messages received</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Game events</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Commands sent</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Disconnects</span><b>{}</b></div>\
+         <div class=\"card\"><span class=\"label\">Reconnects</span><b>{}</b></div></div>",
+        traffic.messages_sent,
+        traffic.messages_received,
+        traffic.game_events_received,
+        traffic.commands_sent,
+        traffic.disconnects,
+        traffic.reconnects,
+    );
+
+    if !report.ramp_stages.is_empty() {
+        html.push_str(
+            "<h2>Ramp stages</h2><div class=\"scroll\"><table><thead><tr>\
+             <th>Stage</th><th>Token-sent target</th><th>Reached</th><th>Launched</th><th>Token-sent start</th><th>Token-sent end</th>\
+             <th>Duration</th></tr></thead><tbody>",
+        );
+        for stage in &report.ramp_stages {
+            let _ = write!(
+                html,
+                "<tr><td>{}</td><td>{}</td><td class=\"{}\">{}</td><td>{}</td><td>{}</td><td>{}</td><td>{} ms</td></tr>",
+                stage.stage_index + 1,
+                stage.target_concurrency,
+                if stage.target_reached {
+                    "completed"
+                } else {
+                    "failed"
+                },
+                if stage.target_reached { "yes" } else { "no" },
+                stage.sessions_launched,
+                stage.active_sessions_at_start,
+                stage.active_sessions_at_end,
+                stage
+                    .finished_at_unix_ms
+                    .saturating_sub(stage.started_at_unix_ms),
+            );
+        }
+        html.push_str("</tbody></table></div>");
+    }
+
+    if !report.infrastructure_samples.is_empty() {
+        let selected_region = report.metadata.get("region");
+        let peak_users = selected_region
+            .and_then(|region| {
+                report
+                    .infrastructure_samples
+                    .iter()
+                    .filter_map(|sample| sample.regional_user_counts.get(region).copied())
+                    .max()
+            })
+            .unwrap_or(0);
+        let baseline_servers = selected_region
+            .and_then(|region| {
+                report
+                    .infrastructure_samples
+                    .first()
+                    .and_then(|sample| sample.regional_server_counts.get(region))
+                    .copied()
+            })
+            .unwrap_or(0);
+        let peak_servers = selected_region
+            .and_then(|region| {
+                report
+                    .infrastructure_samples
+                    .iter()
+                    .filter_map(|sample| sample.regional_server_counts.get(region).copied())
+                    .max()
+            })
+            .unwrap_or(0);
+        let peak_backends = report
+            .infrastructure_samples
+            .iter()
+            .map(|sample| sample.observed_backend_hints)
+            .max()
+            .unwrap_or(0);
+        let sample_errors = report
+            .infrastructure_samples
+            .iter()
+            .filter(|sample| sample.error.is_some())
+            .count();
+        let _ = write!(
+            html,
+            "<h2>Infrastructure observations</h2><div class=\"cards\">\
+             <div class=\"card\"><span class=\"label\">Peak selected-region users</span><b>{peak_users}</b></div>\
+             <div class=\"card\"><span class=\"label\">Active servers baseline</span><b>{baseline_servers}</b></div>\
+             <div class=\"card\"><span class=\"label\">Active servers peak</span><b>{peak_servers}</b></div>\
+             <div class=\"card\"><span class=\"label\">Backend hints seen</span><b>{peak_backends}</b></div>\
+             <div class=\"card\"><span class=\"label\">Observer errors</span><b>{sample_errors}</b></div></div>\
+             <p class=\"sub\">Active servers come from TTL-backed service registrations; backend hints are only a secondary routing signal.</p>",
+        );
+    }
+
+    html.push_str(
+        "<h2>Sessions</h2><div class=\"scroll\"><table><thead><tr>\
+         <th>Session</th><th>User</th><th>Wave</th><th>Match group</th><th>Lobby</th>\
+         <th>Game</th><th>Outcome</th><th>Completion</th><th>Duration</th><th>Details</th></tr></thead><tbody>",
+    );
+    for session in &report.sessions {
+        let detail_cell = match (&session.detail_file, &session.failure_message) {
+            (Some(path), Some(message)) => format!(
+                "<a href=\"{}\">{}</a>",
+                html_escape(path),
+                html_escape(message),
+            ),
+            (Some(path), None) => format!("<a href=\"{}\">details</a>", html_escape(path),),
+            _ => "&mdash;".to_owned(),
+        };
+        let _ = write!(
+            html,
+            "<tr><td><code>{}</code></td><td>{}</td><td>{}</td><td>{}</td><td>{}</td>\
+             <td>{}</td><td class=\"{}\">{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+            html_escape(&session.session_id),
+            html_escape(&session.username),
+            session.wave_index,
+            html_escape(&session.match_group),
+            session
+                .lobby_code
+                .as_deref()
+                .map(html_escape)
+                .unwrap_or_else(|| "&mdash;".to_owned()),
+            session
+                .game_id
+                .map(|value| value.to_string())
+                .unwrap_or_else(|| "&mdash;".to_owned()),
+            session.outcome.as_str(),
+            session.outcome,
+            session
+                .completion_kind
+                .as_deref()
+                .map(html_escape)
+                .unwrap_or_else(|| {
+                    if session.outcome == SessionOutcome::Completed {
+                        "authoritative".to_owned()
+                    } else {
+                        "&mdash;".to_owned()
+                    }
+                }),
+            format_optional_ms(session.duration_ms),
+            detail_cell,
+        );
+    }
+    html.push_str("</tbody></table></div></main></body></html>");
+    html
+}
+
+fn append_distribution_row(html: &mut String, label: &str, summary: &DistributionSummary) {
+    let mean = summary
+        .mean_ms
+        .map(|value| format!("{value:.1} ms"))
+        .unwrap_or_else(|| "&mdash;".to_owned());
+    let _ = write!(
+        html,
+        "<tr><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td><td>{}</td></tr>",
+        html_escape(label),
+        summary.samples,
+        mean,
+        format_optional_ms(summary.p50_ms),
+        format_optional_ms(summary.p95_ms),
+        format_optional_ms(summary.p99_ms),
+        format_optional_ms(summary.max_ms),
+    );
+}
+
+fn format_optional_ms(value: Option<u64>) -> String {
+    value
+        .map(|value| format!("{value} ms"))
+        .unwrap_or_else(|| "&mdash;".to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn percentile_uses_nearest_rank_and_handles_edges() {
+        let descending: Vec<u64> = (1..=100).rev().collect();
+        assert_eq!(percentile(&descending, 0.0), Some(1));
+        assert_eq!(percentile(&descending, 50.0), Some(50));
+        assert_eq!(percentile(&descending, 95.0), Some(95));
+        assert_eq!(percentile(&descending, 99.0), Some(99));
+        assert_eq!(percentile(&descending, 100.0), Some(100));
+        assert_eq!(percentile(&descending, -10.0), Some(1));
+        assert_eq!(percentile(&descending, 110.0), Some(100));
+        assert_eq!(percentile(&[], 95.0), None);
+        assert_eq!(percentile(&descending, f64::NAN), None);
+    }
+
+    #[test]
+    fn aggregation_counts_outcomes_percentiles_traffic_and_concurrency() {
+        let mut first = SessionRecord::new("s1", "user1", 0, "m1", 0);
+        first.metrics.guest_auth_ms = Some(10);
+        first.metrics.matchmaking_wait_ms = Some(20);
+        first.metrics.websocket_rtt_ms = vec![5, 15];
+        first.metrics.messages_sent = 7;
+        first.record_lifecycle(SessionLifecycleRecord::new(
+            SessionPhase::WebSocketAuthentication,
+            1,
+        ));
+        first
+            .diagnostics
+            .insert("completion_kind".to_owned(), "timeboxed".to_owned());
+        first.complete(100);
+
+        let mut second = SessionRecord::new("s2", "user2", 0, "m1", 50);
+        second.metrics.guest_auth_ms = Some(20);
+        second.metrics.matchmaking_wait_ms = Some(100);
+        second.metrics.websocket_rtt_ms = vec![25];
+        second.metrics.messages_sent = 11;
+        second.record_lifecycle(SessionLifecycleRecord::new(
+            SessionPhase::WebSocketAuthentication,
+            51,
+        ));
+        second.fail(SessionFailureRecord::new(
+            SessionPhase::Matchmaking,
+            250,
+            "match timed out",
+        ));
+
+        let mut third = SessionRecord::new("s3", "user3", 1, "m2", 200);
+        third.metrics.guest_auth_ms = Some(30);
+        third.metrics.matchmaking_wait_ms = Some(60);
+        third.metrics.messages_sent = 13;
+        third.record_lifecycle(SessionLifecycleRecord::new(
+            SessionPhase::WebSocketAuthentication,
+            201,
+        ));
+        third.complete(400);
+
+        let run = LoadTestRun {
+            run_id: "run-1".to_owned(),
+            target: "wss://example.test/ws".to_owned(),
+            started_at_unix_ms: 0,
+            finished_at_unix_ms: 400,
+            configured_max_concurrency: 4,
+            metadata: BTreeMap::new(),
+            ramp_stages: Vec::new(),
+            infrastructure_samples: Vec::new(),
+            games: GameRunCounts {
+                expected: 2,
+                observed: 2,
+                completed: 1,
+                timeboxed: 1,
+                pairing_violations: 0,
+            },
+            pairing_violation_details: Vec::new(),
+            sessions: vec![first, second, third],
+        };
+
+        let report = aggregate_report(&run);
+        assert_eq!(report.session_counts.total, 3);
+        assert_eq!(report.session_counts.completed, 2);
+        assert_eq!(report.session_counts.failed, 1);
+        assert_eq!(report.session_counts.peak_token_sent_concurrency, 2);
+        assert!((report.session_counts.success_rate_percent - 66.666_666).abs() < 0.001);
+        assert_eq!(report.metrics.guest_auth_ms.p50_ms, Some(20));
+        assert_eq!(report.metrics.guest_auth_ms.p95_ms, Some(30));
+        assert_eq!(report.metrics.matchmaking_wait_ms.p50_ms, Some(60));
+        assert_eq!(report.metrics.websocket_rtt_ms.p95_ms, Some(25));
+        assert_eq!(report.metrics.traffic.messages_sent, 31);
+        assert_eq!(report.games.completed, 1);
+        assert_eq!(report.games.timeboxed, 1);
+        assert_eq!(
+            report.sessions[0].completion_kind.as_deref(),
+            Some("timeboxed")
+        );
+        assert_eq!(
+            report.failures_by_phase.get("matchmaking").copied(),
+            Some(1)
+        );
+        assert_eq!(
+            report.failures_by_message.get("match timed out").copied(),
+            Some(1)
+        );
+        assert_eq!(
+            report.sessions[1].detail_file.as_deref(),
+            Some("failures/00001-s2.json")
+        );
+    }
+
+    #[test]
+    fn html_escape_covers_text_and_attribute_metacharacters() {
+        assert_eq!(html_escape("<&>\"' safe"), "&lt;&amp;&gt;&quot;&#39; safe");
+
+        let mut session = SessionRecord::new(
+            "<session>",
+            "<script>alert(1)</script>",
+            0,
+            "match & one",
+            0,
+        );
+        session.fail(SessionFailureRecord::new(
+            SessionPhase::Playing,
+            10,
+            "bad <message> & \"quote\"",
+        ));
+        let report = aggregate_report(&LoadTestRun {
+            run_id: "<run>".to_owned(),
+            target: "https://example.test/?a=1&b=2".to_owned(),
+            started_at_unix_ms: 0,
+            finished_at_unix_ms: 10,
+            configured_max_concurrency: 1,
+            metadata: BTreeMap::new(),
+            ramp_stages: Vec::new(),
+            infrastructure_samples: Vec::new(),
+            games: GameRunCounts::default(),
+            pairing_violation_details: Vec::new(),
+            sessions: vec![session],
+        });
+        let rendered = render_html(&report);
+        assert!(!rendered.contains("<script>alert(1)</script>"));
+        assert!(rendered.contains("&lt;script&gt;alert(1)&lt;/script&gt;"));
+        assert!(rendered.contains("bad &lt;message&gt; &amp; &quot;quote&quot;"));
+        assert!(rendered.contains("Authoritative games"));
+        assert!(rendered.contains("Timeboxed games"));
+    }
+
+    #[test]
+    fn writer_replaces_run_scoped_and_links_noncompleted_artifacts() {
+        let mut failed = SessionRecord::new("session-1", "user1", 0, "group-1", 1);
+        failed.fail(SessionFailureRecord::new(
+            SessionPhase::GameJoin,
+            2,
+            "snapshot unavailable",
+        ));
+        let mut run = LoadTestRun::new("artifact-test", "http://example.test", 1, 1);
+        run.finished_at_unix_ms = 2;
+        run.sessions.push(failed);
+
+        let output = std::env::temp_dir().join(format!(
+            "snaketron-loadtest-report-{}-{}",
+            std::process::id(),
+            unix_time_ms()
+        ));
+        let written = write_report(&output, &run).unwrap();
+
+        assert!(written.summary_json.is_file());
+        assert!(written.index_html.is_file());
+        assert_eq!(written.session_detail_json.len(), 1);
+        assert!(written.session_detail_json[0].is_file());
+        let html = fs::read_to_string(&written.index_html).unwrap();
+        assert!(html.contains("failures/00001-session-1.json"));
+
+        let first_failure_path = written.session_detail_json[0].clone();
+        let stale_path = output.join("failures/stale.json");
+        fs::write(&stale_path, b"stale").unwrap();
+        let mut cancelled = SessionRecord::new("session-2", "user2", 1, "group-2", 3);
+        cancelled.cancel(4, "drain timeout");
+        let incomplete = SessionRecord::new("session-3", "user3", 1, "group-2", 3);
+        let mut replacement_run = LoadTestRun::new("artifact-test", "http://example.test", 3, 2);
+        replacement_run.finished_at_unix_ms = 4;
+        replacement_run.sessions = vec![cancelled, incomplete];
+
+        let rewritten = write_report(&output, &replacement_run).unwrap();
+        assert_eq!(rewritten.session_detail_json.len(), 2);
+        assert!(!first_failure_path.exists());
+        assert!(!stale_path.exists());
+        assert!(
+            rewritten
+                .session_detail_json
+                .iter()
+                .all(|path| path.is_file())
+        );
+        let html = fs::read_to_string(&rewritten.index_html).unwrap();
+        assert!(html.contains("failures/00001-session-2.json"));
+        assert!(html.contains("failures/00002-session-3.json"));
+
+        fs::remove_dir_all(output).unwrap();
+    }
+}

--- a/loadtest/src/session.rs
+++ b/loadtest/src/session.rs
@@ -1,0 +1,2665 @@
+//! One coordinated match group and its virtual-user sessions.
+
+use crate::config::CommandProfile;
+use crate::report::{
+    SessionFailureRecord, SessionLifecycleRecord, SessionOutcome, SessionPhase, SessionRecord,
+    unix_time_ms,
+};
+use crate::target::BackendHintRegistry;
+use anyhow::{Context, Result, anyhow};
+use chrono::Utc;
+use common::{
+    Direction, GameCommand, GameEngine, GameEvent, GameState, GameStatus, GameType, QueueMode,
+    calculate_ai_move,
+};
+use futures_util::{SinkExt, StreamExt, future::join_all};
+use reqwest::{Client, Url};
+use serde::Deserialize;
+use server::lobby_manager::LobbyPreferences;
+use server::ws_server::WSMessage;
+use std::collections::{BTreeSet, VecDeque};
+use std::time::{Duration, Instant};
+use tokio::net::TcpStream;
+use tokio::sync::{Barrier, mpsc, watch};
+use tokio::time::{Interval, MissedTickBehavior, interval, interval_at};
+use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+use tokio_tungstenite::tungstenite::http::header::{COOKIE, ORIGIN};
+use tokio_tungstenite::tungstenite::http::{HeaderMap, Request};
+use tokio_tungstenite::tungstenite::protocol::Message;
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async};
+use tokio_util::sync::CancellationToken;
+
+type Socket = WebSocketStream<MaybeTlsStream<TcpStream>>;
+
+const PING_INTERVAL: Duration = Duration::from_secs(5);
+const RECONNECT_DELAY: Duration = Duration::from_secs(2);
+const MAX_RECONNECTS: u32 = 2;
+const RECENT_EVENT_LIMIT: usize = 32;
+const GAME_TIMEOUT_MARGIN: Duration = Duration::from_secs(45);
+
+#[derive(Debug, Clone)]
+pub struct SessionSettings {
+    pub api_origin: Url,
+    pub websocket_url: Url,
+    pub origin: String,
+    pub game_type: GameType,
+    pub queue_mode: QueueMode,
+    pub selected_mode: String,
+    pub competitive: bool,
+    pub connect_timeout: Duration,
+    pub lobby_timeout: Duration,
+    pub queue_timeout: Duration,
+    pub untimed_play_duration: Duration,
+    pub command_profile: CommandProfile,
+    pub backend_hints: BackendHintRegistry,
+}
+
+#[derive(Debug, Clone)]
+pub struct MatchGroupSpec {
+    pub run_id: String,
+    pub wave_index: u32,
+    pub group_index: u64,
+    pub session_indices: Vec<u64>,
+}
+
+impl MatchGroupSpec {
+    pub fn group_id(&self) -> String {
+        format!("wave-{:04}-game-{:06}", self.wave_index, self.group_index)
+    }
+}
+
+#[derive(Debug)]
+pub struct MatchGroupResult {
+    pub sessions: Vec<SessionRecord>,
+    pub expected_game_count: usize,
+    pub observed_game_ids: BTreeSet<u32>,
+    pub pairing_violation: Option<String>,
+}
+
+/// Per-session activity emitted before the enclosing match-group task ends.
+/// The coordinator uses this to maintain token-sent logical-session concurrency,
+/// including across the short reconnect gaps within one session lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionActivityEvent {
+    Connected { session_index: u64 },
+    Terminal { session_index: u64 },
+}
+
+struct SessionActivityLease {
+    session_index: u64,
+    sender: mpsc::UnboundedSender<SessionActivityEvent>,
+    connected: bool,
+}
+
+impl SessionActivityLease {
+    fn new(session_index: u64, sender: mpsc::UnboundedSender<SessionActivityEvent>) -> Self {
+        Self {
+            session_index,
+            sender,
+            connected: false,
+        }
+    }
+
+    fn mark_connected(&mut self) {
+        if self.connected {
+            return;
+        }
+        self.connected = true;
+        let _ = self.sender.send(SessionActivityEvent::Connected {
+            session_index: self.session_index,
+        });
+    }
+}
+
+impl Drop for SessionActivityLease {
+    fn drop(&mut self) {
+        let _ = self.sender.send(SessionActivityEvent::Terminal {
+            session_index: self.session_index,
+        });
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GuestResponse {
+    token: String,
+    user: GuestUser,
+}
+
+#[derive(Debug, Deserialize)]
+struct GuestUser {
+    id: i32,
+    username: String,
+}
+
+struct LiveSession {
+    record: SessionRecord,
+    user_id: u32,
+    token: String,
+    socket: Socket,
+    websocket_url: Url,
+    origin: String,
+    backend_hints: BackendHintRegistry,
+    // Kept only in memory so reconnect handshakes behave like a browser cookie
+    // jar. The transport value must never enter diagnostics or reports.
+    sticky_cookie: Option<String>,
+    last_lobby_members: BTreeSet<u32>,
+    recent_events: VecDeque<String>,
+    clock_offset_ms: i64,
+    reconnects: u32,
+    activity_lease: SessionActivityLease,
+}
+
+struct PlayedSession {
+    record: SessionRecord,
+    snapshot_user_ids: BTreeSet<u32>,
+}
+
+struct GameRuntime {
+    engine: GameEngine,
+    snake_id: u32,
+    snapshot_user_ids: BTreeSet<u32>,
+    ai_interval: Interval,
+    last_decision_tick: Option<u32>,
+    pending_direction: Option<Direction>,
+    outstanding_ping: Option<(i64, Instant)>,
+}
+
+impl GameRuntime {
+    fn from_snapshot(
+        game_id: u32,
+        user_id: u32,
+        game_state: GameState,
+        clock_offset_ms: i64,
+    ) -> Result<Self> {
+        let (snapshot_user_ids, snake_id) = snapshot_identity(game_id, user_id, &game_state)?;
+        let ai_interval = ai_interval_for(&game_state, clock_offset_ms);
+        let mut engine = GameEngine::new_from_state(game_id, game_state);
+        engine.set_local_player_id(user_id);
+        Ok(Self {
+            engine,
+            snake_id,
+            snapshot_user_ids,
+            ai_interval,
+            last_decision_tick: None,
+            pending_direction: None,
+            outstanding_ping: None,
+        })
+    }
+
+    /// Replace all client-predicted state with one authoritative snapshot.
+    /// Returns true when that snapshot is already terminal.
+    fn apply_snapshot(
+        &mut self,
+        game_id: u32,
+        user_id: u32,
+        game_state: GameState,
+        clock_offset_ms: i64,
+    ) -> Result<bool> {
+        let (snapshot_user_ids, snake_id) = snapshot_identity(game_id, user_id, &game_state)?;
+        self.snapshot_user_ids = snapshot_user_ids;
+        if matches!(&game_state.status, GameStatus::Complete { .. }) {
+            return Ok(true);
+        }
+
+        let ai_interval = ai_interval_for(&game_state, clock_offset_ms);
+        let mut engine = GameEngine::new_from_state(game_id, game_state);
+        engine.set_local_player_id(user_id);
+        self.engine = engine;
+        self.snake_id = snake_id;
+        self.ai_interval = ai_interval;
+        self.last_decision_tick = None;
+        self.pending_direction = None;
+        self.outstanding_ping = None;
+        Ok(false)
+    }
+}
+
+enum SnapshotWaitError {
+    Retryable(anyhow::Error),
+    Fatal(anyhow::Error),
+}
+
+enum PreGameWaitError {
+    Recoverable(anyhow::Error),
+    Fatal(anyhow::Error),
+}
+
+impl PreGameWaitError {
+    fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            Self::Recoverable(error) | Self::Fatal(error) => error,
+        }
+    }
+}
+
+enum DriveAiError {
+    Engine(anyhow::Error),
+    Transport(anyhow::Error),
+}
+
+impl SnapshotWaitError {
+    fn into_anyhow(self) -> anyhow::Error {
+        match self {
+            Self::Retryable(error) | Self::Fatal(error) => error,
+        }
+    }
+}
+
+/// Create a complete party, release it at the wave barrier, queue its host,
+/// and drive every snake until authoritative completion or, for inherently
+/// untimed modes, the configured successful active-play window.
+pub async fn run_match_group(
+    spec: MatchGroupSpec,
+    settings: SessionSettings,
+    http_client: Client,
+    activity_events: mpsc::UnboundedSender<SessionActivityEvent>,
+    wave_barrier: std::sync::Arc<Barrier>,
+    cancellation: CancellationToken,
+) -> MatchGroupResult {
+    let expected_game_count = 1;
+    let group_id = spec.group_id();
+    let wave_timeout = settings
+        .connect_timeout
+        .saturating_mul(2)
+        .saturating_add(settings.lobby_timeout.saturating_mul(3));
+    let mut prepared = join_all(spec.session_indices.iter().map(|session_index| {
+        prepare_session(
+            &spec.run_id,
+            spec.wave_index,
+            &group_id,
+            *session_index,
+            &settings,
+            &http_client,
+            activity_events.clone(),
+            &cancellation,
+        )
+    }))
+    .await;
+
+    if prepared.iter().any(Result::is_err) {
+        // Failed groups still arrive at the barrier so healthy groups in the
+        // same wave can be released instead of deadlocking.
+        wait_at_wave_barrier(&wave_barrier, wave_timeout, &cancellation).await;
+        let mut sessions = Vec::with_capacity(prepared.len());
+        for result in prepared.drain(..) {
+            match result {
+                Ok(mut live) => {
+                    if cancellation.is_cancelled() {
+                        live.record.cancel(
+                            unix_time_ms(),
+                            "load-test cancellation interrupted group preparation",
+                        );
+                    } else {
+                        live.fail(
+                            SessionPhase::LobbyReady,
+                            "another member of this deterministic match group failed preparation",
+                        );
+                    }
+                    let _ = live.socket.close(None).await;
+                    sessions.push(live.into_record());
+                }
+                Err(record) => sessions.push(record),
+            }
+        }
+        return MatchGroupResult {
+            sessions,
+            expected_game_count,
+            observed_game_ids: BTreeSet::new(),
+            pairing_violation: None,
+        };
+    }
+
+    let mut sessions: Vec<LiveSession> = prepared
+        .drain(..)
+        .map(|result| result.expect("preparation errors handled above"))
+        .collect();
+
+    let lobby_result = prepare_lobby(&mut sessions, &settings, &cancellation).await;
+    if let Err(error) = lobby_result {
+        wait_at_wave_barrier(&wave_barrier, wave_timeout, &cancellation).await;
+        let records = if cancellation.is_cancelled() {
+            cancel_and_close_all(
+                sessions,
+                "load-test cancellation interrupted lobby preparation",
+            )
+            .await
+        } else {
+            let message = format!("lobby preparation failed: {error:#}");
+            fail_and_close_all(sessions, SessionPhase::LobbyReady, &message).await
+        };
+        return MatchGroupResult {
+            sessions: records,
+            expected_game_count,
+            observed_game_ids: BTreeSet::new(),
+            pairing_violation: None,
+        };
+    }
+
+    if !wait_at_wave_barrier(&wave_barrier, wave_timeout, &cancellation).await {
+        let records = if cancellation.is_cancelled() {
+            cancel_and_close_all(
+                sessions,
+                "load-test cancellation interrupted wave coordination",
+            )
+            .await
+        } else {
+            fail_and_close_all(
+                sessions,
+                SessionPhase::Matchmaking,
+                "wave coordination barrier timed out",
+            )
+            .await
+        };
+        return MatchGroupResult {
+            sessions: records,
+            expected_game_count,
+            observed_game_ids: BTreeSet::new(),
+            pairing_violation: None,
+        };
+    }
+
+    let queue_started = Instant::now();
+    for session in &mut sessions {
+        session.record.record_lifecycle(
+            SessionLifecycleRecord::new(SessionPhase::Matchmaking, unix_time_ms())
+                .with_message("coordinated wave released"),
+        );
+    }
+
+    let expected_user_ids: BTreeSet<u32> = sessions.iter().map(|session| session.user_id).collect();
+    let (group_game_id, _) = watch::channel(None::<u32>);
+    let preferences = LobbyPreferences {
+        selected_modes: vec![settings.selected_mode.clone()],
+        competitive: settings.competitive,
+    };
+    let lobby_code = sessions[0]
+        .record
+        .lobby_code
+        .clone()
+        .expect("prepared lobby host must retain its lobby code");
+    if let Err(error) = queue_lobby_with_recovery(
+        &mut sessions[0],
+        &settings,
+        &lobby_code,
+        &preferences,
+        &expected_user_ids,
+        &cancellation,
+    )
+    .await
+    {
+        let records = if cancellation.is_cancelled() {
+            cancel_and_close_all(
+                sessions,
+                "load-test cancellation interrupted matchmaking queue entry",
+            )
+            .await
+        } else {
+            fail_and_close_all(
+                sessions,
+                SessionPhase::Matchmaking,
+                &format!("failed to queue lobby host: {error:#}"),
+            )
+            .await
+        };
+        return MatchGroupResult {
+            sessions: records,
+            expected_game_count,
+            observed_game_ids: BTreeSet::new(),
+            pairing_violation: None,
+        };
+    }
+
+    let played = join_all(sessions.into_iter().map(|session| {
+        play_session(
+            session,
+            settings.clone(),
+            expected_user_ids.clone(),
+            group_game_id.clone(),
+            queue_started,
+            cancellation.clone(),
+        )
+    }))
+    .await;
+
+    validate_group(played, &expected_user_ids, expected_game_count)
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn prepare_session(
+    run_id: &str,
+    wave_index: u32,
+    group_id: &str,
+    session_index: u64,
+    settings: &SessionSettings,
+    http_client: &Client,
+    activity_events: mpsc::UnboundedSender<SessionActivityEvent>,
+    cancellation: &CancellationToken,
+) -> std::result::Result<LiveSession, SessionRecord> {
+    // Created before any fallible work so every planned session produces a
+    // terminal activity event, including guest-authentication failures.
+    let activity_lease = SessionActivityLease::new(session_index, activity_events);
+    let started_at = unix_time_ms();
+    let session_id = format!("session-{session_index:08}");
+    let username = deterministic_username(run_id, session_index);
+    let mut record = SessionRecord::new(
+        session_id,
+        username.clone(),
+        wave_index,
+        group_id,
+        started_at,
+    );
+
+    record.record_lifecycle(SessionLifecycleRecord::new(
+        SessionPhase::GuestAuthentication,
+        unix_time_ms(),
+    ));
+    let auth_started = Instant::now();
+    let guest_result = tokio::select! {
+        _ = cancellation.cancelled() => {
+            record.cancel(
+                unix_time_ms(),
+                "load-test cancellation interrupted guest authentication",
+            );
+            return Err(record);
+        }
+        result = create_guest(
+            http_client,
+            &settings.api_origin,
+            &username,
+            settings.connect_timeout,
+        ) => result,
+    };
+    let guest = match guest_result {
+        Ok(guest) => guest,
+        Err(error) => {
+            fail_record(
+                &mut record,
+                SessionPhase::GuestAuthentication,
+                format!("{error:#}"),
+            );
+            return Err(record);
+        }
+    };
+    record.metrics.guest_auth_ms = Some(elapsed_ms(auth_started));
+    record.username = guest.user.username.clone();
+
+    let user_id = match u32::try_from(guest.user.id) {
+        Ok(user_id) => user_id,
+        Err(_) => {
+            fail_record(
+                &mut record,
+                SessionPhase::GuestAuthentication,
+                "guest API returned an invalid user ID",
+            );
+            return Err(record);
+        }
+    };
+    record
+        .diagnostics
+        .insert("user_id".to_owned(), user_id.to_string());
+
+    record.record_lifecycle(SessionLifecycleRecord::new(
+        SessionPhase::WebSocketConnect,
+        unix_time_ms(),
+    ));
+    let connect_started = Instant::now();
+    let connect_result = tokio::select! {
+        _ = cancellation.cancelled() => {
+            record.cancel(
+                unix_time_ms(),
+                "load-test cancellation interrupted WebSocket connection",
+            );
+            return Err(record);
+        }
+        result = connect_socket(
+            &settings.websocket_url,
+            &settings.origin,
+            settings.connect_timeout,
+            &settings.backend_hints,
+            None,
+        ) => result,
+    };
+    let (socket, backend, sticky_cookie) = match connect_result {
+        Ok(value) => value,
+        Err(error) => {
+            fail_record(
+                &mut record,
+                SessionPhase::WebSocketConnect,
+                format!("{error:#}"),
+            );
+            return Err(record);
+        }
+    };
+    record.metrics.websocket_connect_ms = Some(elapsed_ms(connect_started));
+    if let Some(backend) = backend {
+        record
+            .diagnostics
+            .insert("websocket_backend".to_owned(), backend);
+    }
+
+    let mut session = LiveSession {
+        record,
+        user_id,
+        token: guest.token,
+        socket,
+        websocket_url: settings.websocket_url.clone(),
+        origin: settings.origin.clone(),
+        backend_hints: settings.backend_hints.clone(),
+        sticky_cookie,
+        last_lobby_members: BTreeSet::new(),
+        recent_events: VecDeque::new(),
+        clock_offset_ms: 0,
+        reconnects: 0,
+        activity_lease,
+    };
+
+    let token = session.token.clone();
+    if let Err(error) = session
+        .send_cancellable(WSMessage::Token(token), cancellation)
+        .await
+    {
+        if cancellation.is_cancelled() {
+            session.record.cancel(
+                unix_time_ms(),
+                "load-test cancellation interrupted WebSocket authentication",
+            );
+            return Err(session.into_record());
+        }
+        session.fail(
+            SessionPhase::WebSocketAuthentication,
+            format!("failed to send authentication token: {error:#}"),
+        );
+        return Err(session.into_record());
+    }
+    // The token has crossed the initial socket, which is the report's logical
+    // concurrency boundary. The ordered ping below then confirms processing
+    // and establishes the server clock offset before any game timing occurs.
+    session.record.record_lifecycle(
+        SessionLifecycleRecord::new(SessionPhase::WebSocketAuthentication, unix_time_ms())
+            .with_message("token sent; awaiting ordered clock-sync pong"),
+    );
+    session.activity_lease.mark_connected();
+    if let Err(error) =
+        send_tagged_ping_and_wait(&mut session, None, settings.connect_timeout, cancellation).await
+    {
+        if cancellation.is_cancelled() {
+            session.record.cancel(
+                unix_time_ms(),
+                "load-test cancellation interrupted WebSocket authentication",
+            );
+            return Err(session.into_record());
+        }
+        session.fail(
+            SessionPhase::WebSocketAuthentication,
+            format!("authentication clock-sync ping failed: {error:#}"),
+        );
+        return Err(session.into_record());
+    }
+    session.record.record_lifecycle(
+        SessionLifecycleRecord::new(SessionPhase::WebSocketAuthentication, unix_time_ms())
+            .with_message("token processed; server clock synchronized"),
+    );
+    Ok(session)
+}
+
+async fn prepare_lobby(
+    sessions: &mut [LiveSession],
+    settings: &SessionSettings,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    if sessions.is_empty() {
+        return Err(anyhow!("match group has no sessions"));
+    }
+    let lobby_started = Instant::now();
+
+    sessions[0]
+        .record
+        .record_lifecycle(SessionLifecycleRecord::new(
+            SessionPhase::LobbyCreate,
+            unix_time_ms(),
+        ));
+    let lobby_code = create_lobby_with_recovery(&mut sessions[0], settings, cancellation).await?;
+    sessions[0].record.lobby_code = Some(lobby_code.clone());
+
+    let preferences = LobbyPreferences {
+        selected_modes: vec![settings.selected_mode.clone()],
+        competitive: settings.competitive,
+    };
+    send_preferences_with_recovery(
+        &mut sessions[0],
+        settings,
+        &lobby_code,
+        &preferences,
+        None,
+        cancellation,
+    )
+    .await?;
+
+    let joins = sessions.iter_mut().skip(1).map(|session| {
+        let lobby_code = lobby_code.clone();
+        let preferences = preferences.clone();
+        let cancellation = cancellation.clone();
+        async move {
+            session.record.record_lifecycle(SessionLifecycleRecord::new(
+                SessionPhase::LobbyJoin,
+                unix_time_ms(),
+            ));
+            join_lobby_with_recovery(session, settings, &lobby_code, &preferences, &cancellation)
+                .await
+        }
+    });
+    for result in join_all(joins).await {
+        result?;
+    }
+
+    // Followers subscribe to lobby updates as part of JoinLobby. Re-broadcast the
+    // authoritative preferences after every JoinedLobby acknowledgement so none
+    // can miss the host's first update during that subscription window.
+    send_preferences_with_recovery(
+        &mut sessions[0],
+        settings,
+        &lobby_code,
+        &preferences,
+        None,
+        cancellation,
+    )
+    .await?;
+
+    let expected: BTreeSet<u32> = sessions.iter().map(|session| session.user_id).collect();
+    let ready = sessions.iter_mut().map(|session| {
+        let expected = expected.clone();
+        let lobby_code = lobby_code.clone();
+        let preferences = preferences.clone();
+        let cancellation = cancellation.clone();
+        async move {
+            wait_for_lobby_roster_with_recovery(
+                session,
+                settings,
+                &lobby_code,
+                &preferences,
+                &expected,
+                &cancellation,
+            )
+            .await?;
+            session.record.metrics.lobby_ready_ms = Some(elapsed_ms(lobby_started));
+            session.record.record_lifecycle(
+                SessionLifecycleRecord::new(SessionPhase::LobbyReady, unix_time_ms())
+                    .with_elapsed_ms(elapsed_ms(lobby_started)),
+            );
+            Ok::<(), anyhow::Error>(())
+        }
+    });
+    for result in join_all(ready).await {
+        result?;
+    }
+    Ok(())
+}
+
+async fn create_lobby_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    cancellation: &CancellationToken,
+) -> Result<String> {
+    loop {
+        if let Err(error) = session
+            .send_cancellable(WSMessage::CreateLobby, cancellation)
+            .await
+        {
+            recover_pre_game_socket(session, settings, cancellation, error).await?;
+            continue;
+        }
+
+        match session
+            .wait_for_pre_game(
+                settings.lobby_timeout,
+                cancellation,
+                |message| match message {
+                    WSMessage::LobbyCreated { lobby_code } => Some(lobby_code.clone()),
+                    _ => None,
+                },
+            )
+            .await
+        {
+            Ok(lobby_code) => return Ok(lobby_code),
+            Err(PreGameWaitError::Recoverable(error)) => {
+                // The acknowledgement may have been lost after creation. A
+                // retry can leave a short-lived orphan lobby, but never mixes
+                // this deterministic group with an unknown lobby.
+                recover_pre_game_socket(session, settings, cancellation, error).await?;
+            }
+            Err(error) => return Err(error.into_anyhow()).context("waiting for LobbyCreated"),
+        }
+    }
+}
+
+async fn join_lobby_once(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    cancellation: &CancellationToken,
+) -> std::result::Result<(), PreGameWaitError> {
+    session
+        .send_cancellable(
+            WSMessage::JoinLobby {
+                lobby_code: lobby_code.to_owned(),
+                preferences: Some(preferences.clone()),
+            },
+            cancellation,
+        )
+        .await
+        .map_err(PreGameWaitError::Recoverable)?;
+    let joined_code = session
+        .wait_for_pre_game(
+            settings.lobby_timeout,
+            cancellation,
+            |message| match message {
+                WSMessage::JoinedLobby { lobby_code } => Some(lobby_code.clone()),
+                _ => None,
+            },
+        )
+        .await?;
+    if joined_code != lobby_code {
+        return Err(PreGameWaitError::Fatal(anyhow!(
+            "server joined session to lobby {joined_code}, expected {lobby_code}"
+        )));
+    }
+    session.record.lobby_code = Some(joined_code);
+    Ok(())
+}
+
+async fn join_lobby_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    match join_lobby_once(session, settings, lobby_code, preferences, cancellation).await {
+        Ok(()) => Ok(()),
+        Err(PreGameWaitError::Recoverable(error)) => {
+            restore_lobby_membership(
+                session,
+                settings,
+                lobby_code,
+                preferences,
+                None,
+                cancellation,
+                error,
+            )
+            .await
+        }
+        Err(error) => Err(error.into_anyhow()),
+    }
+}
+
+fn preferences_message(preferences: &LobbyPreferences) -> WSMessage {
+    WSMessage::UpdateLobbyPreferences {
+        selected_modes: preferences.selected_modes.clone(),
+        competitive: preferences.competitive,
+    }
+}
+
+async fn send_preferences_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    expected_user_ids: Option<&BTreeSet<u32>>,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    match session
+        .send_cancellable(preferences_message(preferences), cancellation)
+        .await
+    {
+        Ok(()) => Ok(()),
+        Err(error) => {
+            restore_lobby_membership(
+                session,
+                settings,
+                lobby_code,
+                preferences,
+                expected_user_ids,
+                cancellation,
+                error,
+            )
+            .await
+        }
+    }
+}
+
+async fn wait_for_lobby_roster_once(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    expected_user_ids: &BTreeSet<u32>,
+    cancellation: &CancellationToken,
+) -> std::result::Result<(), PreGameWaitError> {
+    if &session.last_lobby_members == expected_user_ids {
+        return Ok(());
+    }
+    session
+        .wait_for_pre_game(
+            settings.lobby_timeout,
+            cancellation,
+            |message| match message {
+                WSMessage::LobbyUpdate {
+                    lobby_code: actual_code,
+                    members,
+                    ..
+                } if actual_code == lobby_code => {
+                    let actual: BTreeSet<u32> =
+                        members.iter().map(|member| member.user_id).collect();
+                    (actual == *expected_user_ids).then_some(())
+                }
+                _ => None,
+            },
+        )
+        .await
+}
+
+async fn wait_for_lobby_roster_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    expected_user_ids: &BTreeSet<u32>,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    match wait_for_lobby_roster_once(
+        session,
+        settings,
+        lobby_code,
+        expected_user_ids,
+        cancellation,
+    )
+    .await
+    {
+        Ok(()) => Ok(()),
+        Err(PreGameWaitError::Recoverable(error)) => {
+            restore_lobby_membership(
+                session,
+                settings,
+                lobby_code,
+                preferences,
+                Some(expected_user_ids),
+                cancellation,
+                error,
+            )
+            .await
+        }
+        Err(error) => Err(error.into_anyhow()),
+    }
+}
+
+async fn restore_lobby_membership(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    expected_user_ids: Option<&BTreeSet<u32>>,
+    cancellation: &CancellationToken,
+    mut cause: anyhow::Error,
+) -> Result<()> {
+    loop {
+        recover_pre_game_socket(session, settings, cancellation, cause).await?;
+        session.last_lobby_members.clear();
+
+        if let Err(error) =
+            join_lobby_once(session, settings, lobby_code, preferences, cancellation).await
+        {
+            match error {
+                PreGameWaitError::Recoverable(error) => {
+                    cause = error;
+                    continue;
+                }
+                PreGameWaitError::Fatal(error) => return Err(error),
+            }
+        }
+
+        if let Err(error) = session
+            .send_cancellable(preferences_message(preferences), cancellation)
+            .await
+        {
+            cause = error;
+            continue;
+        }
+
+        if let Some(expected_user_ids) = expected_user_ids {
+            match wait_for_lobby_roster_once(
+                session,
+                settings,
+                lobby_code,
+                expected_user_ids,
+                cancellation,
+            )
+            .await
+            {
+                Ok(()) => {}
+                Err(PreGameWaitError::Recoverable(error)) => {
+                    cause = error;
+                    continue;
+                }
+                Err(PreGameWaitError::Fatal(error)) => return Err(error),
+            }
+        }
+
+        session.record.record_lifecycle(
+            SessionLifecycleRecord::new(SessionPhase::LobbyReady, unix_time_ms())
+                .with_message("reconnected and restored exact lobby membership"),
+        );
+        return Ok(());
+    }
+}
+
+async fn recover_pre_game_socket(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    cancellation: &CancellationToken,
+    cause: anyhow::Error,
+) -> Result<()> {
+    session.record.metrics.disconnects = session.record.metrics.disconnects.saturating_add(1);
+    let mut last_error = cause;
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(anyhow!(
+                "operation cancelled while restoring pre-game session"
+            ));
+        }
+        if session.reconnects >= MAX_RECONNECTS {
+            return Err(anyhow!(
+                "websocket recovery budget exhausted before game assignment: {last_error:#}"
+            ));
+        }
+
+        session.reconnects += 1;
+        session.record.metrics.reconnects = session.record.metrics.reconnects.saturating_add(1);
+        session
+            .record
+            .diagnostics
+            .insert("reconnects".to_owned(), session.reconnects.to_string());
+        tokio::select! {
+            _ = cancellation.cancelled() => {
+                return Err(anyhow!("operation cancelled while restoring pre-game session"));
+            }
+            _ = tokio::time::sleep(RECONNECT_DELAY) => {}
+        }
+
+        session.record.record_lifecycle(
+            SessionLifecycleRecord::new(SessionPhase::WebSocketConnect, unix_time_ms())
+                .with_message("reconnecting before game assignment"),
+        );
+        match session
+            .reconnect(settings.connect_timeout, cancellation)
+            .await
+        {
+            Ok(()) => {
+                session.record.record_lifecycle(
+                    SessionLifecycleRecord::new(
+                        SessionPhase::WebSocketAuthentication,
+                        unix_time_ms(),
+                    )
+                    .with_message("re-authenticated before game assignment"),
+                );
+                return Ok(());
+            }
+            Err(error) => {
+                last_error = error.context("reconnecting and re-authenticating pre-game socket");
+            }
+        }
+    }
+}
+
+async fn queue_lobby_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    lobby_code: &str,
+    preferences: &LobbyPreferences,
+    expected_user_ids: &BTreeSet<u32>,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    loop {
+        match session
+            .send_cancellable(
+                WSMessage::QueueForMatch {
+                    game_type: settings.game_type.clone(),
+                    queue_mode: settings.queue_mode.clone(),
+                },
+                cancellation,
+            )
+            .await
+        {
+            Ok(()) => return Ok(()),
+            Err(error) => {
+                restore_lobby_membership(
+                    session,
+                    settings,
+                    lobby_code,
+                    preferences,
+                    Some(expected_user_ids),
+                    cancellation,
+                    error.context("sending QueueForMatch before disconnect"),
+                )
+                .await?;
+            }
+        }
+    }
+}
+
+async fn play_session(
+    mut session: LiveSession,
+    settings: SessionSettings,
+    expected_user_ids: BTreeSet<u32>,
+    group_game_id: watch::Sender<Option<u32>>,
+    queue_started: Instant,
+    cancellation: CancellationToken,
+) -> PlayedSession {
+    let result = play_session_inner(
+        &mut session,
+        &settings,
+        &expected_user_ids,
+        &group_game_id,
+        queue_started,
+        &cancellation,
+    )
+    .await;
+    let snapshot_user_ids = match result {
+        Ok(ids) => ids,
+        Err(error) => {
+            if cancellation.is_cancelled() {
+                session
+                    .record
+                    .cancel(unix_time_ms(), "load-test cancellation interrupted session");
+                BTreeSet::new()
+            } else {
+                if session.record.failure.is_none() {
+                    let phase = if session.record.game_id.is_none() {
+                        SessionPhase::Matchmaking
+                    } else if session
+                        .record
+                        .lifecycle
+                        .iter()
+                        .any(|event| event.phase == SessionPhase::GameSnapshot)
+                    {
+                        SessionPhase::Playing
+                    } else {
+                        SessionPhase::GameJoin
+                    };
+                    session.fail(phase, format!("{error:#}"));
+                }
+                BTreeSet::new()
+            }
+        }
+    };
+    let _ = session.socket.close(None).await;
+    PlayedSession {
+        record: session.into_record(),
+        snapshot_user_ids,
+    }
+}
+
+async fn play_session_inner(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    expected_user_ids: &BTreeSet<u32>,
+    group_game_id: &watch::Sender<Option<u32>>,
+    queue_started: Instant,
+    cancellation: &CancellationToken,
+) -> Result<BTreeSet<u32>> {
+    let game_id = wait_for_match_with_recovery(
+        session,
+        settings,
+        expected_user_ids,
+        group_game_id,
+        settings.queue_timeout,
+        cancellation,
+    )
+    .await?;
+    session.record.game_id = Some(game_id);
+    session.record.metrics.matchmaking_wait_ms = Some(elapsed_ms(queue_started));
+    session.record.record_lifecycle(
+        SessionLifecycleRecord::new(SessionPhase::GameJoin, unix_time_ms())
+            .with_elapsed_ms(elapsed_ms(queue_started)),
+    );
+    let snapshot_started = Instant::now();
+    let initial_snapshot = match session
+        .send_cancellable(WSMessage::JoinGame(game_id), cancellation)
+        .await
+    {
+        Ok(()) => {
+            wait_for_game_snapshot(session, game_id, settings.queue_timeout, cancellation).await
+        }
+        Err(error) => Err(SnapshotWaitError::Retryable(
+            error.context("sending initial JoinGame"),
+        )),
+    };
+    let game_state = match initial_snapshot {
+        Ok(game_state) => game_state,
+        Err(SnapshotWaitError::Retryable(error)) => {
+            recover_game_snapshot(session, settings, game_id, cancellation, error).await?
+        }
+        Err(error) => {
+            return Err(error.into_anyhow()).context("waiting for initial game snapshot");
+        }
+    };
+
+    session.record.metrics.game_join_ms = Some(elapsed_ms(snapshot_started));
+    session.record.record_lifecycle(
+        SessionLifecycleRecord::new(SessionPhase::GameSnapshot, unix_time_ms())
+            .with_elapsed_ms(elapsed_ms(snapshot_started)),
+    );
+    let server_now_ms = Utc::now()
+        .timestamp_millis()
+        .saturating_add(session.clock_offset_ms);
+    let start_delay = duration_until_server_time(game_state.start_ms, server_now_ms);
+    let (active_game_window, timeboxed_untimed_game) = configured_game_window(
+        game_state.properties.time_limit_ms,
+        settings.untimed_play_duration,
+    );
+    let game_deadline = tokio::time::Instant::now() + start_delay + active_game_window;
+    let (initial_user_ids, _) = snapshot_identity(game_id, session.user_id, &game_state)?;
+    if matches!(&game_state.status, GameStatus::Complete { .. }) {
+        session.record.metrics.game_duration_ms = Some(0);
+        session.record.complete(unix_time_ms());
+        return Ok(initial_user_ids);
+    }
+
+    let mut runtime = GameRuntime::from_snapshot(
+        game_id,
+        session.user_id,
+        game_state,
+        session.clock_offset_ms,
+    )?;
+    session.record.record_lifecycle(SessionLifecycleRecord::new(
+        SessionPhase::Playing,
+        unix_time_ms(),
+    ));
+
+    let game_started = Instant::now();
+    let mut ping_interval = interval(PING_INTERVAL);
+    ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => {
+                session.record.cancel(unix_time_ms(), "load-test drain timeout reached");
+                return Ok(runtime.snapshot_user_ids.clone());
+            }
+            _ = tokio::time::sleep_until(game_deadline) => {
+                if timeboxed_untimed_game {
+                    let previous_ping = runtime
+                        .outstanding_ping
+                        .as_ref()
+                        .map(|(client_time, _)| *client_time);
+                    leave_game_and_confirm(
+                        session,
+                        previous_ping,
+                        settings.connect_timeout,
+                        cancellation,
+                    )
+                    .await
+                    .context("leaving a successfully timeboxed untimed game")?;
+                    let finished_at = unix_time_ms();
+                    session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                    session.record.diagnostics.insert(
+                        "completion_kind".to_owned(),
+                        "timeboxed".to_owned(),
+                    );
+                    session.record.record_lifecycle(
+                        SessionLifecycleRecord::new(SessionPhase::Cleanup, finished_at)
+                            .with_message("configured untimed play window completed"),
+                    );
+                    session.record.complete(finished_at);
+                    return Ok(runtime.snapshot_user_ids.clone());
+                }
+                return Err(anyhow!("game {game_id} exceeded its authoritative time limit plus margin"));
+            }
+            _ = ping_interval.tick() => {
+                let client_time = Utc::now().timestamp_millis();
+                match session.send(WSMessage::Ping { client_time }).await {
+                    Ok(()) => {
+                        runtime.outstanding_ping = Some((client_time, Instant::now()));
+                    }
+                    Err(error) => {
+                        let snapshot_complete = synchronize_game_runtime(
+                            session,
+                            &mut runtime,
+                            settings,
+                            game_id,
+                            cancellation,
+                            error.context("sending game-session ping"),
+                            "write-error recovery snapshot synchronized",
+                        )
+                        .await?;
+                        if snapshot_complete {
+                            session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                            session.record.complete(unix_time_ms());
+                            return Ok(runtime.snapshot_user_ids.clone());
+                        }
+                        ping_interval = interval(PING_INTERVAL);
+                        ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    }
+                }
+            }
+            _ = runtime.ai_interval.tick() => {
+                match drive_ai(
+                    session,
+                    &mut runtime.engine,
+                    runtime.snake_id,
+                    settings.command_profile,
+                    &mut runtime.last_decision_tick,
+                    &mut runtime.pending_direction,
+                ).await {
+                    Ok(()) => {}
+                    Err(DriveAiError::Engine(error)) => return Err(error),
+                    Err(DriveAiError::Transport(error)) => {
+                        let snapshot_complete = synchronize_game_runtime(
+                            session,
+                            &mut runtime,
+                            settings,
+                            game_id,
+                            cancellation,
+                            error,
+                            "command-write recovery snapshot synchronized",
+                        )
+                        .await?;
+                        if snapshot_complete {
+                            session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                            session.record.complete(unix_time_ms());
+                            return Ok(runtime.snapshot_user_ids.clone());
+                        }
+                        ping_interval = interval(PING_INTERVAL);
+                        ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    }
+                }
+            }
+            incoming = session.next_message() => {
+                let message = match incoming {
+                    Ok(message) => message,
+                    Err(error) => {
+                        let snapshot_complete = synchronize_game_runtime(
+                            session,
+                            &mut runtime,
+                            settings,
+                            game_id,
+                            cancellation,
+                            error,
+                            "reconnect snapshot synchronized",
+                        )
+                        .await?;
+                        if snapshot_complete {
+                            session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                            session.record.complete(unix_time_ms());
+                            return Ok(runtime.snapshot_user_ids.clone());
+                        }
+                        ping_interval = interval(PING_INTERVAL);
+                        ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                        continue;
+                    }
+                };
+
+                match message {
+                    WSMessage::Pong { client_time, server_time } => {
+                        if let Some((sent_client_time, sent_at)) = runtime.outstanding_ping.take()
+                            && sent_client_time == client_time
+                        {
+                            let rtt = elapsed_ms(sent_at);
+                            session.record.metrics.websocket_rtt_ms.push(rtt);
+                            let midpoint = client_time.saturating_add((rtt / 2) as i64);
+                            session.clock_offset_ms = server_time.saturating_sub(midpoint);
+                        }
+                    }
+                    WSMessage::GameEvent(event) if event.game_id == game_id => {
+                        session.record.metrics.game_events_received = session.record.metrics.game_events_received.saturating_add(1);
+                        match &event.event {
+                            GameEvent::Snapshot { game_state } => {
+                                let snapshot_complete = runtime.apply_snapshot(
+                                    game_id,
+                                    session.user_id,
+                                    game_state.clone(),
+                                    session.clock_offset_ms,
+                                )?;
+                                if snapshot_complete {
+                                    session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                                    session.record.complete(unix_time_ms());
+                                    return Ok(runtime.snapshot_user_ids.clone());
+                                }
+                            }
+                            GameEvent::StatusUpdated { status: GameStatus::Complete { .. } } => {
+                                runtime.engine.process_server_event(&event)?;
+                                session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                                session.record.complete(unix_time_ms());
+                                return Ok(runtime.snapshot_user_ids.clone());
+                            }
+                            _ => runtime.engine.process_server_event(&event)?,
+                        }
+                    }
+                    WSMessage::GameLoadFailed { game_id: failed, reason } if failed == game_id => {
+                        return Err(anyhow!("server could not load matched game {failed}: {reason}"));
+                    }
+                    WSMessage::AccessDenied { reason } => {
+                        return Err(anyhow!("server denied game session: {reason}"));
+                    }
+                    WSMessage::Shutdown => {
+                        let snapshot_complete = synchronize_game_runtime(
+                            session,
+                            &mut runtime,
+                            settings,
+                            game_id,
+                            cancellation,
+                            anyhow!("server requested WebSocket shutdown during game {game_id}"),
+                            "shutdown recovery snapshot synchronized",
+                        )
+                        .await?;
+                        if snapshot_complete {
+                            session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                            session.record.complete(unix_time_ms());
+                            return Ok(runtime.snapshot_user_ids.clone());
+                        }
+                        ping_interval = interval(PING_INTERVAL);
+                        ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    }
+                    WSMessage::ServerShutdown { reason, grace_period_seconds } => {
+                        let snapshot_complete = synchronize_game_runtime(
+                            session,
+                            &mut runtime,
+                            settings,
+                            game_id,
+                            cancellation,
+                            anyhow!(
+                                "server shutdown during game {game_id}: {reason} (grace {grace_period_seconds}s)"
+                            ),
+                            "server-shutdown recovery snapshot synchronized",
+                        )
+                        .await?;
+                        if snapshot_complete {
+                            session.record.metrics.game_duration_ms = Some(elapsed_ms(game_started));
+                            session.record.complete(unix_time_ms());
+                            return Ok(runtime.snapshot_user_ids.clone());
+                        }
+                        ping_interval = interval(PING_INTERVAL);
+                        ping_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn configured_game_window(
+    authoritative_time_limit_ms: Option<u32>,
+    untimed_play_duration: Duration,
+) -> (Duration, bool) {
+    match authoritative_time_limit_ms {
+        Some(value) => (
+            Duration::from_millis(value as u64) + GAME_TIMEOUT_MARGIN,
+            false,
+        ),
+        None => (untimed_play_duration, true),
+    }
+}
+
+fn duration_until_server_time(target_ms: i64, server_now_ms: i64) -> Duration {
+    Duration::from_millis(target_ms.saturating_sub(server_now_ms).max(0) as u64)
+}
+
+/// Send a leave followed by a uniquely tagged ping. A matching pong proves the
+/// server processed both frames in order; the WebSocket protocol has no
+/// dedicated LeaveGame acknowledgement.
+async fn leave_game_and_confirm(
+    session: &mut LiveSession,
+    previous_ping: Option<i64>,
+    timeout: Duration,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    session
+        .send_cancellable(WSMessage::LeaveGame, cancellation)
+        .await?;
+    send_tagged_ping_and_wait(session, previous_ping, timeout, cancellation).await
+}
+
+async fn send_tagged_ping_and_wait(
+    session: &mut LiveSession,
+    previous_ping: Option<i64>,
+    timeout: Duration,
+    cancellation: &CancellationToken,
+) -> Result<()> {
+    let client_time = previous_ping.map_or_else(
+        || Utc::now().timestamp_millis(),
+        |previous| {
+            Utc::now()
+                .timestamp_millis()
+                .max(previous.saturating_add(1))
+        },
+    );
+    let ping_started = Instant::now();
+    session
+        .send_cancellable(WSMessage::Ping { client_time }, cancellation)
+        .await?;
+    let deadline = tokio::time::Instant::now() + timeout;
+
+    loop {
+        let message = tokio::select! {
+            _ = cancellation.cancelled() => return Err(anyhow!("operation cancelled")),
+            _ = tokio::time::sleep_until(deadline) => {
+                return Err(anyhow!(
+                    "server did not acknowledge the application ping within {timeout:?}"
+                ));
+            }
+            incoming = session.next_message() => incoming?,
+        };
+        match message {
+            WSMessage::Pong {
+                client_time: echoed,
+                server_time,
+            } if echoed == client_time => {
+                let rtt = elapsed_ms(ping_started);
+                session.record.metrics.websocket_rtt_ms.push(rtt);
+                let midpoint = client_time.saturating_add((rtt / 2) as i64);
+                session.clock_offset_ms = server_time.saturating_sub(midpoint);
+                return Ok(());
+            }
+            WSMessage::GameEvent(_) => {
+                session.record.metrics.game_events_received = session
+                    .record
+                    .metrics
+                    .game_events_received
+                    .saturating_add(1);
+            }
+            WSMessage::AccessDenied { reason } => {
+                return Err(anyhow!("server denied the session: {reason}"));
+            }
+            WSMessage::Shutdown => {
+                return Err(anyhow!("server closed the connection before the pong"));
+            }
+            WSMessage::ServerShutdown { reason, .. } => {
+                return Err(anyhow!("server shutdown before the pong: {reason}"));
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn wait_for_game_snapshot(
+    session: &mut LiveSession,
+    game_id: u32,
+    timeout: Duration,
+    cancellation: &CancellationToken,
+) -> std::result::Result<GameState, SnapshotWaitError> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let message = tokio::select! {
+            _ = cancellation.cancelled() => {
+                return Err(SnapshotWaitError::Fatal(anyhow!("operation cancelled")));
+            }
+            _ = tokio::time::sleep_until(deadline) => {
+                return Err(SnapshotWaitError::Fatal(anyhow!(
+                    "waiting for game {game_id} snapshot timed out after {timeout:?}"
+                )));
+            }
+            incoming = session.next_message() => {
+                incoming.map_err(SnapshotWaitError::Retryable)?
+            }
+        };
+
+        match message {
+            WSMessage::GameEvent(event) if event.game_id == game_id => {
+                session.record.metrics.game_events_received = session
+                    .record
+                    .metrics
+                    .game_events_received
+                    .saturating_add(1);
+                if let GameEvent::Snapshot { game_state } = event.event {
+                    return Ok(game_state);
+                }
+            }
+            WSMessage::GameLoadFailed {
+                game_id: failed,
+                reason,
+            } if failed == game_id => {
+                return Err(SnapshotWaitError::Fatal(anyhow!(
+                    "server could not load matched game {failed}: {reason}"
+                )));
+            }
+            WSMessage::AccessDenied { reason } => {
+                return Err(SnapshotWaitError::Fatal(anyhow!(
+                    "server denied game session: {reason}"
+                )));
+            }
+            WSMessage::Shutdown => {
+                return Err(SnapshotWaitError::Retryable(anyhow!(
+                    "server requested WebSocket shutdown while loading game {game_id}"
+                )));
+            }
+            WSMessage::ServerShutdown {
+                reason,
+                grace_period_seconds,
+            } => {
+                return Err(SnapshotWaitError::Retryable(anyhow!(
+                    "server shutdown while loading game {game_id}: {reason} (grace {grace_period_seconds}s)"
+                )));
+            }
+            _ => {}
+        }
+    }
+}
+
+async fn recover_game_snapshot(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    game_id: u32,
+    cancellation: &CancellationToken,
+    cause: anyhow::Error,
+) -> Result<GameState> {
+    session.record.metrics.disconnects = session.record.metrics.disconnects.saturating_add(1);
+    let mut last_error = cause;
+
+    loop {
+        if cancellation.is_cancelled() {
+            return Err(anyhow!(
+                "operation cancelled while reconnecting to game {game_id}"
+            ));
+        }
+        if session.reconnects >= MAX_RECONNECTS {
+            return Err(anyhow!(
+                "websocket recovery budget exhausted for game {game_id}: {last_error:#}"
+            ));
+        }
+
+        session.reconnects += 1;
+        session.record.metrics.reconnects = session.record.metrics.reconnects.saturating_add(1);
+        session
+            .record
+            .diagnostics
+            .insert("reconnects".to_owned(), session.reconnects.to_string());
+
+        tokio::select! {
+            _ = cancellation.cancelled() => {
+                return Err(anyhow!("operation cancelled while reconnecting to game {game_id}"));
+            }
+            _ = tokio::time::sleep(RECONNECT_DELAY) => {}
+        }
+
+        if let Err(error) = session
+            .reconnect(settings.connect_timeout, cancellation)
+            .await
+        {
+            last_error = error.context("reconnecting and re-authenticating WebSocket");
+            continue;
+        }
+        if let Err(error) = session
+            .send_cancellable(WSMessage::JoinGame(game_id), cancellation)
+            .await
+        {
+            last_error = error.context("sending JoinGame after reconnect");
+            continue;
+        }
+
+        match wait_for_game_snapshot(session, game_id, settings.connect_timeout, cancellation).await
+        {
+            Ok(game_state) => return Ok(game_state),
+            Err(SnapshotWaitError::Retryable(error)) => {
+                session.record.metrics.disconnects =
+                    session.record.metrics.disconnects.saturating_add(1);
+                last_error = error;
+            }
+            Err(SnapshotWaitError::Fatal(error)) => return Err(error),
+        }
+    }
+}
+
+async fn synchronize_game_runtime(
+    session: &mut LiveSession,
+    runtime: &mut GameRuntime,
+    settings: &SessionSettings,
+    game_id: u32,
+    cancellation: &CancellationToken,
+    cause: anyhow::Error,
+    lifecycle_message: &'static str,
+) -> Result<bool> {
+    let game_state = recover_game_snapshot(session, settings, game_id, cancellation, cause).await?;
+    let snapshot_complete = runtime.apply_snapshot(
+        game_id,
+        session.user_id,
+        game_state,
+        session.clock_offset_ms,
+    )?;
+    session.record.record_lifecycle(
+        SessionLifecycleRecord::new(SessionPhase::GameSnapshot, unix_time_ms())
+            .with_message(lifecycle_message),
+    );
+    Ok(snapshot_complete)
+}
+
+fn snapshot_identity(
+    game_id: u32,
+    user_id: u32,
+    game_state: &GameState,
+) -> Result<(BTreeSet<u32>, u32)> {
+    let snapshot_user_ids = game_state.players.keys().copied().collect();
+    let snake_id = game_state
+        .players
+        .get(&user_id)
+        .map(|player| player.snake_id)
+        .ok_or_else(|| anyhow!("snapshot for game {game_id} omitted user {user_id}"))?;
+    Ok((snapshot_user_ids, snake_id))
+}
+
+fn ai_interval_for(game_state: &GameState, clock_offset_ms: i64) -> Interval {
+    let tick_ms = game_state.properties.tick_duration_ms.max(25) as u64;
+    let ai_period = Duration::from_millis(tick_ms.min(100));
+    let now_ms = Utc::now()
+        .timestamp_millis()
+        .saturating_add(clock_offset_ms);
+    let delay_to_next_tick = if now_ms < game_state.start_ms {
+        game_state.start_ms.saturating_sub(now_ms) as u64 + tick_ms
+    } else {
+        let elapsed_since_start = now_ms.saturating_sub(game_state.start_ms) as u64;
+        tick_ms.saturating_sub(elapsed_since_start % tick_ms)
+    };
+    let mut ai_interval = interval_at(
+        tokio::time::Instant::now() + Duration::from_millis(delay_to_next_tick),
+        ai_period,
+    );
+    ai_interval.set_missed_tick_behavior(MissedTickBehavior::Skip);
+    ai_interval
+}
+
+async fn wait_for_match_with_recovery(
+    session: &mut LiveSession,
+    settings: &SessionSettings,
+    expected_user_ids: &BTreeSet<u32>,
+    group_game_id: &watch::Sender<Option<u32>>,
+    timeout: Duration,
+    cancellation: &CancellationToken,
+) -> Result<u32> {
+    let lobby_code = session
+        .record
+        .lobby_code
+        .clone()
+        .ok_or_else(|| anyhow!("session lost its lobby code before matchmaking"))?;
+    let preferences = LobbyPreferences {
+        selected_modes: vec![settings.selected_mode.clone()],
+        competitive: settings.competitive,
+    };
+    let deadline = tokio::time::Instant::now() + timeout;
+    let mut group_game_updates = group_game_id.subscribe();
+
+    loop {
+        if let Some(game_id) = *group_game_id.borrow() {
+            return Ok(game_id);
+        }
+        let remaining = deadline.saturating_duration_since(tokio::time::Instant::now());
+        if remaining.is_zero() {
+            return Err(anyhow!(
+                "waiting for matchmaking notification timed out after {timeout:?}"
+            ));
+        }
+        let wait_result = tokio::select! {
+            result = session.wait_for_pre_game(
+                remaining,
+                cancellation,
+                |message| match message {
+                    WSMessage::JoinGame(game_id) => Some(*game_id),
+                    WSMessage::MatchFound { game_id } => Some(*game_id),
+                    _ => None,
+                },
+            ) => result,
+            changed = group_game_updates.changed() => {
+                if changed.is_err() {
+                    return Err(anyhow!(
+                        "deterministic match-group assignment channel closed"
+                    ));
+                }
+                if let Some(game_id) = *group_game_updates.borrow_and_update() {
+                    return Ok(game_id);
+                }
+                continue;
+            }
+        };
+        match wait_result {
+            Ok(game_id) => return share_group_game_id(group_game_id, game_id),
+            Err(PreGameWaitError::Fatal(error)) => {
+                return Err(error).context("waiting for matchmaking notification");
+            }
+            Err(PreGameWaitError::Recoverable(error)) => {
+                let restore = restore_lobby_membership(
+                    session,
+                    settings,
+                    &lobby_code,
+                    &preferences,
+                    Some(expected_user_ids),
+                    cancellation,
+                    error.context("matchmaking connection was interrupted"),
+                );
+                tokio::select! {
+                    result = tokio::time::timeout_at(deadline, restore) => {
+                        match result {
+                            Ok(result) => result?,
+                            Err(_) => {
+                                return Err(anyhow!(
+                                    "restoring lobby while waiting for a match exceeded {timeout:?}"
+                                ));
+                            }
+                        }
+                    }
+                    changed = group_game_updates.changed() => {
+                        changed.context("deterministic match-group assignment channel closed")?;
+                        if let Some(game_id) = *group_game_updates.borrow_and_update() {
+                            return Ok(game_id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn share_group_game_id(
+    group_game_id: &watch::Sender<Option<u32>>,
+    observed_game_id: u32,
+) -> Result<u32> {
+    let mut selected_game_id = observed_game_id;
+    let mut conflict = None;
+    group_game_id.send_if_modified(|current| {
+        if let Some(existing_game_id) = *current {
+            selected_game_id = existing_game_id;
+            if existing_game_id != observed_game_id {
+                conflict = Some(existing_game_id);
+            }
+            false
+        } else {
+            *current = Some(observed_game_id);
+            true
+        }
+    });
+    if let Some(existing_game_id) = conflict {
+        return Err(anyhow!(
+            "deterministic match group observed conflicting game IDs {existing_game_id} and {observed_game_id}"
+        ));
+    }
+    Ok(selected_game_id)
+}
+
+async fn drive_ai(
+    session: &mut LiveSession,
+    engine: &mut GameEngine,
+    snake_id: u32,
+    command_profile: CommandProfile,
+    last_decision_tick: &mut Option<u32>,
+    pending_direction: &mut Option<Direction>,
+) -> std::result::Result<(), DriveAiError> {
+    let now = Utc::now()
+        .timestamp_millis()
+        .saturating_add(session.clock_offset_ms);
+    engine
+        .rebuild_predicted_state(now)
+        .map_err(DriveAiError::Engine)?;
+    let predicted_tick = engine.get_predicted_tick();
+    if *last_decision_tick == Some(predicted_tick) {
+        return Ok(());
+    }
+    *last_decision_tick = Some(predicted_tick);
+
+    let Some(state) = engine.predicted_state() else {
+        return Ok(());
+    };
+    let Some(snake) = state.arena.snakes.get(snake_id as usize) else {
+        return Ok(());
+    };
+    if !snake.is_alive {
+        return Ok(());
+    }
+    let current_direction = snake.direction;
+    if *pending_direction == Some(current_direction) {
+        *pending_direction = None;
+    }
+    let direction =
+        calculate_ai_move(state, snake_id, current_direction).unwrap_or(current_direction);
+    if direction == current_direction && !command_profile.sends_unchanged_turns() {
+        return Ok(());
+    }
+    if !command_profile.sends_unchanged_turns() && pending_direction.is_some() {
+        return Ok(());
+    }
+
+    let command = engine
+        .process_local_command(GameCommand::Turn {
+            snake_id,
+            direction,
+        })
+        .map_err(DriveAiError::Engine)?;
+    session
+        .send(WSMessage::GameCommand(command))
+        .await
+        .map_err(|error| {
+            DriveAiError::Transport(error.context("sending AI game command over WebSocket"))
+        })?;
+    session.record.metrics.commands_sent = session.record.metrics.commands_sent.saturating_add(1);
+    if !command_profile.sends_unchanged_turns() {
+        *pending_direction = Some(direction);
+    }
+    Ok(())
+}
+
+impl LiveSession {
+    async fn send(&mut self, message: WSMessage) -> Result<()> {
+        let kind = message_kind(&message);
+        let payload = serde_json::to_string(&message)?;
+        self.socket.send(Message::Text(payload)).await?;
+        self.record.metrics.messages_sent = self.record.metrics.messages_sent.saturating_add(1);
+        self.remember(format!("sent:{kind}"));
+        Ok(())
+    }
+
+    async fn send_cancellable(
+        &mut self,
+        message: WSMessage,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        tokio::select! {
+            _ = cancellation.cancelled() => Err(anyhow!("operation cancelled")),
+            result = self.send(message) => result,
+        }
+    }
+
+    async fn next_message(&mut self) -> Result<WSMessage> {
+        loop {
+            let next = self
+                .socket
+                .next()
+                .await
+                .ok_or_else(|| anyhow!("websocket stream ended"))??;
+            match next {
+                Message::Text(text) => {
+                    let message: WSMessage = serde_json::from_str(&text).with_context(|| {
+                        format!("unrecognized websocket payload ({} bytes)", text.len())
+                    })?;
+                    self.record.metrics.messages_received =
+                        self.record.metrics.messages_received.saturating_add(1);
+                    let kind = message_kind(&message);
+                    self.remember(format!("received:{kind}"));
+                    if let WSMessage::LobbyUpdate { members, .. } = &message {
+                        self.last_lobby_members =
+                            members.iter().map(|member| member.user_id).collect();
+                    }
+                    return Ok(message);
+                }
+                Message::Ping(payload) => {
+                    self.socket.send(Message::Pong(payload)).await?;
+                }
+                Message::Close(frame) => {
+                    return Err(anyhow!("websocket closed: {frame:?}"));
+                }
+                _ => {}
+            }
+        }
+    }
+
+    async fn wait_for_pre_game<T, F>(
+        &mut self,
+        timeout: Duration,
+        cancellation: &CancellationToken,
+        mut matcher: F,
+    ) -> std::result::Result<T, PreGameWaitError>
+    where
+        F: FnMut(&WSMessage) -> Option<T>,
+    {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            tokio::select! {
+                _ = cancellation.cancelled() => {
+                    return Err(PreGameWaitError::Fatal(anyhow!("operation cancelled")));
+                }
+                _ = tokio::time::sleep_until(deadline) => {
+                    return Err(PreGameWaitError::Fatal(anyhow!(
+                        "operation timed out after {timeout:?}"
+                    )));
+                }
+                message = self.next_message() => {
+                    let message = message.map_err(PreGameWaitError::Recoverable)?;
+                    match &message {
+                        WSMessage::AccessDenied { reason } => {
+                            return Err(PreGameWaitError::Fatal(anyhow!(
+                                "server denied request: {reason}"
+                            )));
+                        }
+                        WSMessage::Shutdown => {
+                            return Err(PreGameWaitError::Recoverable(anyhow!(
+                                "server requested WebSocket shutdown"
+                            )));
+                        }
+                        WSMessage::ServerShutdown { reason, grace_period_seconds } => {
+                            return Err(PreGameWaitError::Recoverable(anyhow!(
+                                "server shutdown: {reason} (grace {grace_period_seconds}s)"
+                            )));
+                        }
+                        WSMessage::LobbyRegionMismatch {
+                            target_region,
+                            ws_url,
+                            lobby_code,
+                        } => {
+                            return Err(PreGameWaitError::Fatal(anyhow!(
+                                "lobby {lobby_code} moved to region {target_region} at {ws_url}"
+                            )));
+                        }
+                        _ => {}
+                    }
+                    if let Some(value) = matcher(&message) {
+                        return Ok(value);
+                    }
+                }
+            }
+        }
+    }
+
+    async fn reconnect(
+        &mut self,
+        timeout: Duration,
+        cancellation: &CancellationToken,
+    ) -> Result<()> {
+        let connect_result = tokio::select! {
+            _ = cancellation.cancelled() => return Err(anyhow!("operation cancelled")),
+            result = connect_socket(
+                &self.websocket_url,
+                &self.origin,
+                timeout,
+                &self.backend_hints,
+                self.sticky_cookie.as_deref(),
+            ) => result,
+        };
+        let (socket, backend, sticky_cookie) = connect_result?;
+        self.socket = socket;
+        if sticky_cookie.is_some() {
+            self.sticky_cookie = sticky_cookie;
+        }
+        if let Some(backend) = backend {
+            self.record
+                .diagnostics
+                .insert(format!("reconnect_backend_{}", self.reconnects), backend);
+        }
+        let token = self.token.clone();
+        self.send_cancellable(WSMessage::Token(token), cancellation)
+            .await?;
+        Ok(())
+    }
+
+    fn remember(&mut self, event: String) {
+        if self.recent_events.len() == RECENT_EVENT_LIMIT {
+            self.recent_events.pop_front();
+        }
+        self.recent_events.push_back(event);
+    }
+
+    fn fail(&mut self, phase: SessionPhase, message: impl Into<String>) {
+        let mut failure = SessionFailureRecord::new(phase, unix_time_ms(), message);
+        if let Some(game_id) = self.record.game_id {
+            failure = failure.with_context("game_id", game_id.to_string());
+        }
+        if !self.recent_events.is_empty() {
+            self.record.diagnostics.insert(
+                "recent_protocol_events".to_owned(),
+                self.recent_events
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<_>>()
+                    .join(","),
+            );
+        }
+        self.record.fail(failure);
+    }
+
+    fn into_record(mut self) -> SessionRecord {
+        if !self.recent_events.is_empty() {
+            self.record.diagnostics.insert(
+                "recent_protocol_events".to_owned(),
+                self.recent_events.into_iter().collect::<Vec<_>>().join(","),
+            );
+        }
+        self.record
+    }
+}
+
+async fn create_guest(
+    client: &Client,
+    api_origin: &Url,
+    nickname: &str,
+    timeout: Duration,
+) -> Result<GuestResponse> {
+    let endpoint = api_origin.join("/api/auth/guest")?;
+    let response = tokio::time::timeout(
+        timeout,
+        client
+            .post(endpoint.clone())
+            .json(&serde_json::json!({ "nickname": nickname }))
+            .send(),
+    )
+    .await
+    .map_err(|_| anyhow!("guest authentication timed out after {timeout:?}"))??;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        return Err(anyhow!(
+            "guest authentication at {endpoint} returned HTTP {status}: {}",
+            bounded(&body, 300)
+        ));
+    }
+    response
+        .json::<GuestResponse>()
+        .await
+        .context("decoding guest authentication response")
+}
+
+async fn connect_socket(
+    websocket_url: &Url,
+    origin: &str,
+    timeout: Duration,
+    backend_hints: &BackendHintRegistry,
+    sticky_cookie: Option<&str>,
+) -> Result<(Socket, Option<String>, Option<String>)> {
+    let request = websocket_request(websocket_url, origin, sticky_cookie)?;
+    let (socket, response) = tokio::time::timeout(timeout, connect_async(request))
+        .await
+        .map_err(|_| anyhow!("websocket connection timed out after {timeout:?}"))??;
+    let sticky_cookie = response
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(sticky_cookie_value)
+        .map(ToOwned::to_owned);
+    let backend = sticky_cookie
+        .as_deref()
+        .and_then(|raw| backend_hints.observe_sticky_value(raw))
+        .map(|hint| hint.identifier);
+    Ok((socket, backend, sticky_cookie))
+}
+
+fn websocket_request(
+    websocket_url: &Url,
+    origin: &str,
+    sticky_cookie: Option<&str>,
+) -> Result<Request<()>> {
+    let mut request = websocket_url
+        .as_str()
+        .into_client_request()
+        .context("building websocket handshake request")?;
+    request
+        .headers_mut()
+        .insert(ORIGIN, origin.parse().context("invalid Origin header")?);
+    apply_sticky_cookie(request.headers_mut(), sticky_cookie)?;
+    Ok(request)
+}
+
+fn apply_sticky_cookie(headers: &mut HeaderMap, sticky_cookie: Option<&str>) -> Result<()> {
+    if let Some(value) = sticky_cookie {
+        let cookie = format!("snaketron_sticky={value}");
+        headers.insert(
+            COOKIE,
+            cookie
+                .parse()
+                .context("sticky cookie was not a valid request header")?,
+        );
+    }
+    Ok(())
+}
+
+fn validate_group(
+    mut played: Vec<PlayedSession>,
+    expected_user_ids: &BTreeSet<u32>,
+    expected_game_count: usize,
+) -> MatchGroupResult {
+    let observed_game_ids: BTreeSet<u32> = played
+        .iter()
+        .filter_map(|session| session.record.game_id)
+        .collect();
+    if played
+        .iter()
+        .any(|session| session.record.outcome == SessionOutcome::Cancelled)
+    {
+        return MatchGroupResult {
+            sessions: played.into_iter().map(|session| session.record).collect(),
+            expected_game_count,
+            observed_game_ids,
+            pairing_violation: None,
+        };
+    }
+    let mut violations = Vec::new();
+    if observed_game_ids.len() != expected_game_count {
+        violations.push(format!(
+            "expected {expected_game_count} game ID, observed {} ({observed_game_ids:?})",
+            observed_game_ids.len()
+        ));
+    }
+    for session in &played {
+        if !session.snapshot_user_ids.is_empty() && &session.snapshot_user_ids != expected_user_ids
+        {
+            violations.push(format!(
+                "{} snapshot users {:?}, expected {:?}",
+                session.record.session_id, session.snapshot_user_ids, expected_user_ids
+            ));
+        }
+    }
+    violations.sort();
+    violations.dedup();
+    let pairing_violation = (!violations.is_empty()).then(|| violations.join("; "));
+    if let Some(message) = &pairing_violation {
+        for session in &mut played {
+            if session.record.failure.is_some() {
+                session
+                    .record
+                    .diagnostics
+                    .insert("pairing_validation_error".to_owned(), message.clone());
+            } else {
+                session.record.fail(
+                    SessionFailureRecord::new(
+                        SessionPhase::GameSnapshot,
+                        unix_time_ms(),
+                        format!("deterministic matchmaking validation failed: {message}"),
+                    )
+                    .with_context("expected_user_ids", format!("{expected_user_ids:?}"))
+                    .with_context("observed_game_ids", format!("{observed_game_ids:?}")),
+                )
+            }
+        }
+    }
+    MatchGroupResult {
+        sessions: played.into_iter().map(|session| session.record).collect(),
+        expected_game_count,
+        observed_game_ids,
+        pairing_violation,
+    }
+}
+
+async fn fail_and_close_all(
+    sessions: Vec<LiveSession>,
+    phase: SessionPhase,
+    message: &str,
+) -> Vec<SessionRecord> {
+    join_all(sessions.into_iter().map(|mut session| async move {
+        session.fail(phase, message);
+        let _ = session.socket.close(None).await;
+        session.into_record()
+    }))
+    .await
+}
+
+async fn cancel_and_close_all(sessions: Vec<LiveSession>, reason: &str) -> Vec<SessionRecord> {
+    join_all(sessions.into_iter().map(|mut session| async move {
+        session.record.cancel(unix_time_ms(), reason);
+        let _ = session.socket.close(None).await;
+        session.into_record()
+    }))
+    .await
+}
+
+async fn wait_at_wave_barrier(
+    barrier: &Barrier,
+    timeout: Duration,
+    cancellation: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        _ = cancellation.cancelled() => false,
+        result = tokio::time::timeout(timeout, barrier.wait()) => result.is_ok(),
+    }
+}
+
+fn fail_record(record: &mut SessionRecord, phase: SessionPhase, message: impl Into<String>) {
+    record.fail(SessionFailureRecord::new(phase, unix_time_ms(), message));
+}
+
+pub fn deterministic_username(run_id: &str, session_index: u64) -> String {
+    // Guest nicknames are capped at 20 characters. A stable FNV-1a suffix keeps
+    // names deterministic without leaking a potentially long run identifier.
+    let mut hash = 0xcbf29ce484222325_u64;
+    for byte in run_id.as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    format!(
+        "lt{:06x}{:08}",
+        hash & 0xff_ffff,
+        session_index % 100_000_000
+    )
+}
+
+fn sticky_cookie_value(header: &str) -> Option<&str> {
+    header.split(';').find_map(|part| {
+        let (name, value) = part.trim().split_once('=')?;
+        name.eq_ignore_ascii_case("snaketron_sticky")
+            .then_some(value)
+    })
+}
+
+fn message_kind(message: &WSMessage) -> &'static str {
+    match message {
+        WSMessage::Token(_) => "Token",
+        WSMessage::JoinGame(_) => "JoinGame",
+        WSMessage::LeaveGame => "LeaveGame",
+        WSMessage::GameCommand(_) => "GameCommand",
+        WSMessage::GameEvent(_) => "GameEvent",
+        WSMessage::Ping { .. } => "Ping",
+        WSMessage::Pong { .. } => "Pong",
+        WSMessage::QueueForMatch { .. } => "QueueForMatch",
+        WSMessage::QueueForMatchMulti { .. } => "QueueForMatchMulti",
+        WSMessage::LeaveQueue => "LeaveQueue",
+        WSMessage::MatchFound { .. } => "MatchFound",
+        WSMessage::QueueUpdate { .. } => "QueueUpdate",
+        WSMessage::QueueLeft => "QueueLeft",
+        WSMessage::AccessDenied { .. } => "AccessDenied",
+        WSMessage::GameLoadFailed { .. } => "GameLoadFailed",
+        WSMessage::Shutdown => "Shutdown",
+        WSMessage::ServerShutdown { .. } => "ServerShutdown",
+        WSMessage::CreateLobby => "CreateLobby",
+        WSMessage::LobbyCreated { .. } => "LobbyCreated",
+        WSMessage::JoinLobby { .. } => "JoinLobby",
+        WSMessage::JoinedLobby { .. } => "JoinedLobby",
+        WSMessage::LeaveLobby => "LeaveLobby",
+        WSMessage::LeftLobby => "LeftLobby",
+        WSMessage::LobbyUpdate { .. } => "LobbyUpdate",
+        WSMessage::UpdateLobbyPreferences { .. } => "UpdateLobbyPreferences",
+        _ => "Other",
+    }
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn bounded(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn duel_snapshot(user_ids: &[u32]) -> GameState {
+        let mut game_state = GameState::new(
+            60,
+            40,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Competitive,
+            None,
+            Utc::now().timestamp_millis() + 1_000,
+        );
+        for user_id in user_ids {
+            game_state
+                .add_player(*user_id, Some(format!("user-{user_id}")))
+                .expect("test player should fit in duel snapshot");
+        }
+        game_state
+    }
+
+    #[test]
+    fn deterministic_names_are_stable_valid_and_unique() {
+        let first = deterministic_username("autoscale-2026", 1);
+        let repeated = deterministic_username("autoscale-2026", 1);
+        let second = deterministic_username("autoscale-2026", 2);
+        assert_eq!(first, repeated);
+        assert_ne!(first, second);
+        assert!(first.len() <= 20);
+        assert!(
+            first
+                .chars()
+                .all(|character| character.is_ascii_alphanumeric())
+        );
+    }
+
+    #[test]
+    fn extracts_only_the_sticky_cookie() {
+        assert_eq!(
+            sticky_cookie_value("snaketron_sticky=backend-token; Path=/; Secure"),
+            Some("backend-token")
+        );
+        assert_eq!(sticky_cookie_value("other=value; Path=/"), None);
+    }
+
+    #[test]
+    fn untimed_games_use_the_configured_window_while_timed_games_keep_the_margin() {
+        let untimed = Duration::from_secs(37);
+        assert_eq!(configured_game_window(None, untimed), (untimed, true));
+        assert_eq!(
+            configured_game_window(Some(60_000), untimed),
+            (Duration::from_secs(60) + GAME_TIMEOUT_MARGIN, false)
+        );
+        assert_eq!(
+            duration_until_server_time(1_250, 1_000),
+            Duration::from_millis(250)
+        );
+        assert_eq!(duration_until_server_time(1_000, 1_250), Duration::ZERO);
+    }
+
+    #[tokio::test]
+    async fn timeboxed_leave_is_confirmed_by_an_ordered_ping() {
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::accept_async;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let websocket_url = Url::parse(&format!("ws://{address}/ws")).unwrap();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+            let leave = socket.next().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<WSMessage>(leave.to_text().unwrap()).unwrap(),
+                WSMessage::LeaveGame
+            ));
+            let ping = socket.next().await.unwrap().unwrap();
+            let client_time =
+                match serde_json::from_str::<WSMessage>(ping.to_text().unwrap()).unwrap() {
+                    WSMessage::Ping { client_time } => client_time,
+                    other => panic!("expected Ping after LeaveGame, received {other:?}"),
+                };
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&WSMessage::Pong {
+                        client_time,
+                        server_time: client_time,
+                    })
+                    .unwrap(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let (socket, _) = connect_async(websocket_url.as_str()).await.unwrap();
+        let (activity_sender, _activity_receiver) = mpsc::unbounded_channel();
+        let mut session = LiveSession {
+            record: SessionRecord::new("session-1", "test-user", 0, "group", 0),
+            user_id: 1,
+            token: "test-token".to_owned(),
+            socket,
+            websocket_url,
+            origin: "http://127.0.0.1".to_owned(),
+            backend_hints: BackendHintRegistry::default(),
+            sticky_cookie: None,
+            last_lobby_members: BTreeSet::new(),
+            recent_events: VecDeque::new(),
+            clock_offset_ms: 0,
+            reconnects: 0,
+            activity_lease: SessionActivityLease::new(1, activity_sender),
+        };
+
+        leave_game_and_confirm(
+            &mut session,
+            Some(Utc::now().timestamp_millis()),
+            Duration::from_secs(1),
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(session.record.metrics.messages_sent, 2);
+        assert_eq!(session.record.metrics.websocket_rtt_ms.len(), 1);
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn reconnect_request_replays_only_the_private_sticky_cookie() {
+        let url = Url::parse("wss://use1.snaketron.io/ws").unwrap();
+        let request =
+            websocket_request(&url, "https://snaketron.io", Some("opaque-backend-token")).unwrap();
+
+        assert_eq!(
+            request.headers().get(ORIGIN).unwrap(),
+            "https://snaketron.io"
+        );
+        assert_eq!(
+            request.headers().get(COOKIE).unwrap(),
+            "snaketron_sticky=opaque-backend-token"
+        );
+        assert!(
+            websocket_request(&url, "https://snaketron.io", None)
+                .unwrap()
+                .headers()
+                .get(COOKIE)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn activity_lease_emits_connected_once_and_terminal_on_drop() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        {
+            let mut lease = SessionActivityLease::new(17, sender);
+            lease.mark_connected();
+            lease.mark_connected();
+            assert_eq!(
+                receiver.try_recv().unwrap(),
+                SessionActivityEvent::Connected { session_index: 17 }
+            );
+            assert!(receiver.try_recv().is_err());
+        }
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            SessionActivityEvent::Terminal { session_index: 17 }
+        );
+        assert!(receiver.try_recv().is_err());
+    }
+
+    #[test]
+    fn activity_lease_reports_terminal_before_connection_too() {
+        let (sender, mut receiver) = mpsc::unbounded_channel();
+        drop(SessionActivityLease::new(23, sender));
+        assert_eq!(
+            receiver.try_recv().unwrap(),
+            SessionActivityEvent::Terminal { session_index: 23 }
+        );
+    }
+
+    #[test]
+    fn group_game_assignment_is_idempotent_and_rejects_conflicts() {
+        let (group_game_id, _) = watch::channel(None);
+        assert_eq!(share_group_game_id(&group_game_id, 42).unwrap(), 42);
+        assert_eq!(share_group_game_id(&group_game_id, 42).unwrap(), 42);
+
+        let error = share_group_game_id(&group_game_id, 99).unwrap_err();
+        assert!(error.to_string().contains("conflicting game IDs 42 and 99"));
+    }
+
+    #[test]
+    fn simultaneous_group_game_assignments_cannot_overwrite_each_other() {
+        use std::sync::{Arc, Barrier as ThreadBarrier};
+
+        let (group_game_id, _) = watch::channel(None);
+        let barrier = Arc::new(ThreadBarrier::new(2));
+        let assignments = [42, 99].map(|observed_game_id| {
+            let group_game_id = group_game_id.clone();
+            let barrier = barrier.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                share_group_game_id(&group_game_id, observed_game_id)
+            })
+        });
+        let results = assignments.map(|assignment| assignment.join().unwrap());
+
+        assert_eq!(results.iter().filter(|result| result.is_ok()).count(), 1);
+        assert_eq!(results.iter().filter(|result| result.is_err()).count(), 1);
+        let selected = (*group_game_id.borrow()).expect("one game ID must remain selected");
+        assert!(matches!(selected, 42 | 99));
+        assert_eq!(
+            results.iter().find_map(|result| result.as_ref().ok()),
+            Some(&selected)
+        );
+    }
+
+    #[tokio::test]
+    async fn matchmaking_disconnect_reauthenticates_rejoins_and_preserves_roster() {
+        use server::lobby_manager::LobbyMember;
+        use tokio::net::TcpListener;
+        use tokio_tungstenite::accept_async;
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let websocket_url = Url::parse(&format!("ws://{address}/ws")).unwrap();
+
+        let first_server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            accept_async(stream).await.unwrap()
+        });
+        let (socket, _) = connect_async(websocket_url.as_str()).await.unwrap();
+        let mut first_server = first_server.await.unwrap();
+        first_server.close(None).await.unwrap();
+
+        let listener = TcpListener::bind(address).await.unwrap();
+        let preferences = LobbyPreferences {
+            selected_modes: vec!["solo".to_owned()],
+            competitive: false,
+        };
+        let server_preferences = preferences.clone();
+        let recovery_server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut socket = accept_async(stream).await.unwrap();
+
+            let token = socket.next().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<WSMessage>(token.to_text().unwrap()).unwrap(),
+                WSMessage::Token(value) if value == "test-token"
+            ));
+            let join = socket.next().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<WSMessage>(join.to_text().unwrap()).unwrap(),
+                WSMessage::JoinLobby { lobby_code, .. } if lobby_code == "TEST-LOBBY"
+            ));
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&WSMessage::JoinedLobby {
+                        lobby_code: "TEST-LOBBY".to_owned(),
+                    })
+                    .unwrap(),
+                ))
+                .await
+                .unwrap();
+
+            let update_preferences = socket.next().await.unwrap().unwrap();
+            assert!(matches!(
+                serde_json::from_str::<WSMessage>(update_preferences.to_text().unwrap()).unwrap(),
+                WSMessage::UpdateLobbyPreferences { .. }
+            ));
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&WSMessage::LobbyUpdate {
+                        lobby_code: "TEST-LOBBY".to_owned(),
+                        members: vec![LobbyMember {
+                            user_id: 7,
+                            username: "test-user".to_owned(),
+                            ts: 0.0,
+                        }],
+                        host_user_id: 7,
+                        state: "queued".to_owned(),
+                        preferences: server_preferences,
+                    })
+                    .unwrap(),
+                ))
+                .await
+                .unwrap();
+            socket
+                .send(Message::Text(
+                    serde_json::to_string(&WSMessage::JoinGame(99)).unwrap(),
+                ))
+                .await
+                .unwrap();
+        });
+
+        let settings = SessionSettings {
+            api_origin: Url::parse("http://127.0.0.1/").unwrap(),
+            websocket_url,
+            origin: "http://127.0.0.1".to_owned(),
+            game_type: GameType::Solo,
+            queue_mode: QueueMode::Quickmatch,
+            selected_mode: "solo".to_owned(),
+            competitive: false,
+            connect_timeout: Duration::from_secs(1),
+            lobby_timeout: Duration::from_secs(1),
+            queue_timeout: Duration::from_secs(5),
+            untimed_play_duration: Duration::from_secs(1),
+            command_profile: CommandProfile::Realistic,
+            backend_hints: BackendHintRegistry::default(),
+        };
+        let (activity_sender, _activity_receiver) = mpsc::unbounded_channel();
+        let mut record = SessionRecord::new("session-7", "test-user", 0, "group", 0);
+        record.lobby_code = Some("TEST-LOBBY".to_owned());
+        let mut session = LiveSession {
+            record,
+            user_id: 7,
+            token: "test-token".to_owned(),
+            socket,
+            websocket_url: settings.websocket_url.clone(),
+            origin: settings.origin.clone(),
+            backend_hints: settings.backend_hints.clone(),
+            sticky_cookie: Some("opaque-backend-token".to_owned()),
+            last_lobby_members: BTreeSet::new(),
+            recent_events: VecDeque::new(),
+            clock_offset_ms: 0,
+            reconnects: 0,
+            activity_lease: SessionActivityLease::new(7, activity_sender),
+        };
+        let (group_game_id, _) = watch::channel(None);
+
+        let game_id = wait_for_match_with_recovery(
+            &mut session,
+            &settings,
+            &BTreeSet::from([7]),
+            &group_game_id,
+            settings.queue_timeout,
+            &CancellationToken::new(),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(game_id, 99);
+        assert_eq!(session.last_lobby_members, BTreeSet::from([7]));
+        assert_eq!(session.record.metrics.disconnects, 1);
+        assert_eq!(session.record.metrics.reconnects, 1);
+        recovery_server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn complete_reconnect_snapshot_is_terminal_and_replaces_membership() {
+        let initial = duel_snapshot(&[10, 11]);
+        let mut runtime = GameRuntime::from_snapshot(42, 10, initial, 0).unwrap();
+
+        let mut completed = duel_snapshot(&[10, 99]);
+        completed.status = GameStatus::Complete {
+            winning_snake_id: None,
+        };
+
+        assert!(runtime.apply_snapshot(42, 10, completed, 0).unwrap());
+        assert_eq!(runtime.snapshot_user_ids, BTreeSet::from([10, 99]));
+    }
+
+    #[test]
+    fn snapshot_identity_requires_the_local_player() {
+        let snapshot = duel_snapshot(&[20, 21]);
+        let error = snapshot_identity(7, 99, &snapshot).unwrap_err();
+        assert!(error.to_string().contains("omitted user 99"));
+    }
+
+    #[test]
+    fn validation_rejects_a_foreign_player_in_snapshot() {
+        let mut first = SessionRecord::new("s1", "u1", 0, "g1", 1);
+        first.game_id = Some(42);
+        first.complete(2);
+        let mut second = SessionRecord::new("s2", "u2", 0, "g1", 1);
+        second.game_id = Some(42);
+        second.complete(2);
+        let played = vec![
+            PlayedSession {
+                record: first,
+                snapshot_user_ids: BTreeSet::from([10, 99]),
+            },
+            PlayedSession {
+                record: second,
+                snapshot_user_ids: BTreeSet::from([10, 99]),
+            },
+        ];
+
+        let result = validate_group(played, &BTreeSet::from([10, 11]), 1);
+
+        assert!(result.pairing_violation.is_some());
+        assert!(result.sessions.iter().all(SessionRecord::is_failed));
+    }
+}

--- a/loadtest/src/target.rs
+++ b/loadtest/src/target.rs
@@ -1,0 +1,1063 @@
+//! Target discovery and preflight checks for the Snaketron load test.
+//!
+//! Production traffic enters through a public API origin and is then routed to
+//! a regional WebSocket origin.  This module keeps that routing knowledge out
+//! of the session runner.  It also deliberately owns construction of the HTTP
+//! client so certificate validation cannot accidentally be disabled by a
+//! caller.
+
+use reqwest::header::{HeaderMap, SET_COOKIE};
+use reqwest::{Client, StatusCode, Url};
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
+use std::error::Error;
+use std::fmt;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+const LOAD_TEST_USER_AGENT: &str = concat!("snaketron-loadtest/", env!("CARGO_PKG_VERSION"));
+const STICKY_COOKIE_NAME: &str = "snaketron_sticky";
+
+/// Inputs used to resolve and preflight a target.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TargetOptions {
+    /// Main site, API origin, or regional origin. A missing scheme implies HTTPS.
+    pub target: String,
+    /// Optional region ID. Matching is case-insensitive.
+    pub region: Option<String>,
+}
+
+impl TargetOptions {
+    pub fn new(target: impl Into<String>) -> Self {
+        Self {
+            target: target.into(),
+            region: None,
+        }
+    }
+
+    pub fn with_region(mut self, region: impl Into<String>) -> Self {
+        self.region = Some(region.into());
+        self
+    }
+}
+
+/// Region metadata returned by `GET /api/regions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegionMetadata {
+    pub id: String,
+    pub name: String,
+    pub origin: String,
+    #[serde(default)]
+    pub ws_url: String,
+}
+
+/// Why a region was selected for the run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RegionSelection {
+    Explicit,
+    LowestLatencyHealthy,
+}
+
+/// A non-sensitive, run-local alias for a load-balancer backend hint.
+///
+/// The cookie value is intentionally never stored here. Aliases only remain
+/// comparable while callers reuse the same [`BackendHintRegistry`].
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BackendHint {
+    pub source: String,
+    pub identifier: String,
+}
+
+/// Common measurements for a successful HTTP request.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EndpointObservation {
+    pub url: String,
+    pub status_code: u16,
+    pub latency_ms: u64,
+    pub observed_at_unix_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_hint: Option<BackendHint>,
+}
+
+/// Result of probing one regional health endpoint.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RegionHealthObservation {
+    pub region: RegionMetadata,
+    pub health_url: String,
+    pub healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status_code: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub latency_ms: Option<u64>,
+    pub observed_at_unix_ms: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend_hint: Option<BackendHint>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+impl RegionHealthObservation {
+    fn failure(region: RegionMetadata, health_url: String, error: impl Into<String>) -> Self {
+        Self {
+            region,
+            health_url,
+            healthy: false,
+            status_code: None,
+            latency_ms: None,
+            observed_at_unix_ms: unix_time_ms(),
+            backend_hint: None,
+            error: Some(error.into()),
+        }
+    }
+}
+
+/// One aggregate regional user-count sample.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UserCountObservation {
+    #[serde(flatten)]
+    pub endpoint: EndpointObservation,
+    pub counts: BTreeMap<String, u32>,
+}
+
+/// Active TTL-backed server-instance counts per region. The representation is
+/// intentionally identical to user counts, but the endpoint never returns raw
+/// server identifiers.
+pub type ServerCountObservation = UserCountObservation;
+
+/// Serializable outcome of resolving and preflighting the target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TargetPreflight {
+    pub requested_target: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requested_region: Option<String>,
+    pub api_origin: String,
+    pub regions_endpoint: EndpointObservation,
+    pub region_selection: RegionSelection,
+    pub selected_region: RegionMetadata,
+    pub selected_origin: String,
+    pub websocket_url: String,
+    pub selected_health: RegionHealthObservation,
+    pub region_health: Vec<RegionHealthObservation>,
+    pub initial_user_counts: UserCountObservation,
+    pub initial_server_counts: ServerCountObservation,
+    pub completed_at_unix_ms: u64,
+}
+
+impl TargetPreflight {
+    pub fn selected_region_user_count(&self) -> Option<u32> {
+        self.initial_user_counts
+            .counts
+            .get(&self.selected_region.id)
+            .copied()
+    }
+}
+
+/// Errors returned before any virtual-user sessions are launched.
+#[derive(Debug)]
+pub enum TargetError {
+    InvalidTarget {
+        target: String,
+        reason: String,
+    },
+    ClientBuild {
+        source: reqwest::Error,
+    },
+    Request {
+        operation: &'static str,
+        url: String,
+        source: reqwest::Error,
+    },
+    UnexpectedStatus {
+        operation: &'static str,
+        url: String,
+        status: StatusCode,
+    },
+    InvalidResponse {
+        operation: &'static str,
+        url: String,
+        source: reqwest::Error,
+    },
+    NoRegions {
+        url: String,
+    },
+    RegionNotFound {
+        requested: String,
+        available: Vec<String>,
+    },
+    RegionUnhealthy {
+        region: String,
+        reason: String,
+    },
+    NoHealthyRegions {
+        summary: String,
+    },
+}
+
+impl fmt::Display for TargetError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidTarget { target, reason } => {
+                write!(formatter, "invalid target '{target}': {reason}")
+            }
+            Self::ClientBuild { source } => {
+                write!(
+                    formatter,
+                    "failed to build strict-TLS HTTP client: {source}"
+                )
+            }
+            Self::Request {
+                operation,
+                url,
+                source,
+            } => write!(formatter, "{operation} request to {url} failed: {source}"),
+            Self::UnexpectedStatus {
+                operation,
+                url,
+                status,
+            } => write!(
+                formatter,
+                "{operation} request to {url} returned HTTP {}",
+                status.as_u16()
+            ),
+            Self::InvalidResponse {
+                operation,
+                url,
+                source,
+            } => write!(
+                formatter,
+                "{operation} response from {url} was invalid: {source}"
+            ),
+            Self::NoRegions { url } => {
+                write!(formatter, "region discovery at {url} returned no regions")
+            }
+            Self::RegionNotFound {
+                requested,
+                available,
+            } => write!(
+                formatter,
+                "requested region '{requested}' was not found (available: {})",
+                available.join(", ")
+            ),
+            Self::RegionUnhealthy { region, reason } => {
+                write!(
+                    formatter,
+                    "requested region '{region}' is not healthy: {reason}"
+                )
+            }
+            Self::NoHealthyRegions { summary } => {
+                write!(
+                    formatter,
+                    "no healthy Snaketron regions were found: {summary}"
+                )
+            }
+        }
+    }
+}
+
+impl Error for TargetError {
+    fn source(&self) -> Option<&(dyn Error + 'static)> {
+        match self {
+            Self::ClientBuild { source }
+            | Self::Request { source, .. }
+            | Self::InvalidResponse { source, .. } => Some(source),
+            _ => None,
+        }
+    }
+}
+
+/// Converts raw sticky-cookie values into harmless run-local aliases.
+///
+/// The custom `Debug` implementation only exposes the number of observed
+/// values, so accidentally logging the registry cannot reveal cookie contents.
+#[derive(Clone, Default)]
+pub struct BackendHintRegistry {
+    aliases: Arc<Mutex<HashMap<String, String>>>,
+}
+
+impl fmt::Debug for BackendHintRegistry {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("BackendHintRegistry")
+            .field("observed_backend_count", &self.observed_backend_count())
+            .finish()
+    }
+}
+
+impl BackendHintRegistry {
+    /// Inspect response headers and return a safe alias when Snaketron's sticky
+    /// backend cookie is present. Raw cookie values remain private to this map.
+    pub fn observe_headers(&self, headers: &HeaderMap) -> Option<BackendHint> {
+        let raw_value = sticky_cookie_value(headers)?;
+        self.observe_sticky_value(&raw_value)
+    }
+
+    /// Register a sticky-cookie value obtained from a non-reqwest handshake.
+    /// This keeps WebSocket clients on a different `http` crate version from
+    /// needing to pass their header map through reqwest's header types.
+    pub fn observe_sticky_value(&self, raw_value: &str) -> Option<BackendHint> {
+        let raw_value = raw_value.trim();
+        if raw_value.is_empty() {
+            return None;
+        }
+
+        let mut aliases = self.aliases.lock().unwrap_or_else(|lock| lock.into_inner());
+        let next_identifier = format!("backend-{:04}", aliases.len() + 1);
+        let identifier = aliases
+            .entry(raw_value.to_string())
+            .or_insert(next_identifier)
+            .clone();
+
+        Some(BackendHint {
+            source: format!("cookie:{STICKY_COOKIE_NAME}"),
+            identifier,
+        })
+    }
+
+    pub fn observed_backend_count(&self) -> usize {
+        self.aliases
+            .lock()
+            .unwrap_or_else(|lock| lock.into_inner())
+            .len()
+    }
+}
+
+/// Resolver that owns a certificate-validating reqwest client and backend
+/// alias registry. Reuse it for later user-count samples so aliases correlate.
+#[derive(Debug, Clone)]
+pub struct TargetResolver {
+    client: Client,
+    backend_hints: BackendHintRegistry,
+}
+
+impl TargetResolver {
+    pub fn new(request_timeout: Duration) -> Result<Self, TargetError> {
+        // reqwest validates hostnames and certificate chains by default. Do not
+        // add `danger_accept_invalid_certs` here, including for local testing.
+        let client = Client::builder()
+            .connect_timeout(request_timeout)
+            .timeout(request_timeout)
+            .redirect(reqwest::redirect::Policy::limited(5))
+            .user_agent(LOAD_TEST_USER_AGENT)
+            .build()
+            .map_err(|source| TargetError::ClientBuild { source })?;
+
+        Ok(Self {
+            client,
+            backend_hints: BackendHintRegistry::default(),
+        })
+    }
+
+    pub fn with_default_timeout() -> Result<Self, TargetError> {
+        Self::new(DEFAULT_REQUEST_TIMEOUT)
+    }
+
+    pub fn backend_hints(&self) -> BackendHintRegistry {
+        self.backend_hints.clone()
+    }
+
+    /// Clone the same strict-TLS client for guest-authentication requests.
+    pub fn http_client(&self) -> Client {
+        self.client.clone()
+    }
+
+    /// Resolve the API and regional origins, probe every region, select one,
+    /// and capture the initial aggregate user count.
+    pub async fn preflight(&self, options: &TargetOptions) -> Result<TargetPreflight, TargetError> {
+        let requested_target = normalize_target_url(&options.target)?;
+        let api_origin = derive_api_origin(&requested_target)?;
+        let (regions, regions_endpoint) = self.fetch_regions(&api_origin).await?;
+        if regions.is_empty() {
+            return Err(TargetError::NoRegions {
+                url: regions_endpoint.url,
+            });
+        }
+
+        // Probe serially. Each latency is measured around only its own request,
+        // so selection remains meaningful while avoiding another async runtime
+        // dependency in this low-volume preflight path.
+        let mut region_health = Vec::with_capacity(regions.len());
+        for region in regions {
+            region_health.push(self.probe_region(region).await);
+        }
+
+        let requested_region = options
+            .region
+            .as_deref()
+            .map(str::trim)
+            .filter(|region| !region.is_empty());
+        let selected = select_region(&region_health, requested_region)?.clone();
+        let region_selection = if requested_region.is_some() {
+            RegionSelection::Explicit
+        } else {
+            RegionSelection::LowestLatencyHealthy
+        };
+        let selected_origin = normalized_region_origin(&selected.region)?.to_string();
+        let websocket_url = websocket_url_for_region(&selected.region)?.to_string();
+        let initial_user_counts = self.sample_user_counts(&api_origin).await?;
+        let initial_server_counts = self.sample_server_counts(&api_origin).await?;
+
+        Ok(TargetPreflight {
+            requested_target: requested_target.to_string(),
+            requested_region: requested_region.map(ToOwned::to_owned),
+            api_origin: api_origin.to_string(),
+            regions_endpoint,
+            region_selection,
+            selected_region: selected.region.clone(),
+            selected_origin,
+            websocket_url,
+            selected_health: selected,
+            region_health,
+            initial_user_counts,
+            initial_server_counts,
+            completed_at_unix_ms: unix_time_ms(),
+        })
+    }
+
+    /// Capture another aggregate count sample during ramp-up, hold, or drain.
+    pub async fn sample_user_counts_from_origin(
+        &self,
+        api_origin: &str,
+    ) -> Result<UserCountObservation, TargetError> {
+        let api_origin = normalize_target_url(api_origin)?;
+        self.sample_user_counts(&api_origin).await
+    }
+
+    /// Capture active server-instance counts without exposing server IDs.
+    pub async fn sample_server_counts_from_origin(
+        &self,
+        api_origin: &str,
+    ) -> Result<ServerCountObservation, TargetError> {
+        let api_origin = normalize_target_url(api_origin)?;
+        self.sample_server_counts(&api_origin).await
+    }
+
+    async fn fetch_regions(
+        &self,
+        api_origin: &Url,
+    ) -> Result<(Vec<RegionMetadata>, EndpointObservation), TargetError> {
+        let url = endpoint_url(api_origin, "/api/regions")?;
+        let started = Instant::now();
+        let response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|source| TargetError::Request {
+                operation: "region discovery",
+                url: url.to_string(),
+                source,
+            })?;
+        let status = response.status();
+        let backend_hint = self.backend_hints.observe_headers(response.headers());
+        if !status.is_success() {
+            return Err(TargetError::UnexpectedStatus {
+                operation: "region discovery",
+                url: url.to_string(),
+                status,
+            });
+        }
+
+        let regions = response
+            .json::<Vec<RegionMetadata>>()
+            .await
+            .map_err(|source| TargetError::InvalidResponse {
+                operation: "region discovery",
+                url: url.to_string(),
+                source,
+            })?;
+        let endpoint = EndpointObservation {
+            url: url.to_string(),
+            status_code: status.as_u16(),
+            latency_ms: elapsed_ms(started),
+            observed_at_unix_ms: unix_time_ms(),
+            backend_hint,
+        };
+
+        Ok((regions, endpoint))
+    }
+
+    async fn probe_region(&self, region: RegionMetadata) -> RegionHealthObservation {
+        let origin = match normalized_region_origin(&region) {
+            Ok(origin) => origin,
+            Err(error) => {
+                return RegionHealthObservation::failure(region, String::new(), error.to_string());
+            }
+        };
+        let health_url = match endpoint_url(&origin, "/api/health") {
+            Ok(url) => url,
+            Err(error) => {
+                return RegionHealthObservation::failure(
+                    region,
+                    origin.to_string(),
+                    error.to_string(),
+                );
+            }
+        };
+        let started = Instant::now();
+        let response = match self.client.get(health_url.clone()).send().await {
+            Ok(response) => response,
+            Err(source) => {
+                return RegionHealthObservation {
+                    region,
+                    health_url: health_url.to_string(),
+                    healthy: false,
+                    status_code: None,
+                    latency_ms: Some(elapsed_ms(started)),
+                    observed_at_unix_ms: unix_time_ms(),
+                    backend_hint: None,
+                    error: Some(format!("health request failed: {source}")),
+                };
+            }
+        };
+
+        let status = response.status();
+        let backend_hint = self.backend_hints.observe_headers(response.headers());
+        let payload = if status.is_success() {
+            response.json::<HealthPayload>().await
+        } else {
+            // Consume the body so the connection can be reused, but never put
+            // an arbitrary proxy response body into the report.
+            let _ = response.bytes().await;
+            return RegionHealthObservation {
+                region,
+                health_url: health_url.to_string(),
+                healthy: false,
+                status_code: Some(status.as_u16()),
+                latency_ms: Some(elapsed_ms(started)),
+                observed_at_unix_ms: unix_time_ms(),
+                backend_hint,
+                error: Some(format!("health endpoint returned HTTP {}", status.as_u16())),
+            };
+        };
+
+        match payload {
+            Ok(payload) if payload.status.eq_ignore_ascii_case("ok") => RegionHealthObservation {
+                region,
+                health_url: health_url.to_string(),
+                healthy: true,
+                status_code: Some(status.as_u16()),
+                latency_ms: Some(elapsed_ms(started)),
+                observed_at_unix_ms: unix_time_ms(),
+                backend_hint,
+                error: None,
+            },
+            Ok(payload) => RegionHealthObservation {
+                region,
+                health_url: health_url.to_string(),
+                healthy: false,
+                status_code: Some(status.as_u16()),
+                latency_ms: Some(elapsed_ms(started)),
+                observed_at_unix_ms: unix_time_ms(),
+                backend_hint,
+                error: Some(format!(
+                    "health payload reported unexpected status '{}'",
+                    payload.status
+                )),
+            },
+            Err(source) => RegionHealthObservation {
+                region,
+                health_url: health_url.to_string(),
+                healthy: false,
+                status_code: Some(status.as_u16()),
+                latency_ms: Some(elapsed_ms(started)),
+                observed_at_unix_ms: unix_time_ms(),
+                backend_hint,
+                error: Some(format!("health response was not valid JSON: {source}")),
+            },
+        }
+    }
+
+    async fn sample_user_counts(
+        &self,
+        api_origin: &Url,
+    ) -> Result<UserCountObservation, TargetError> {
+        self.sample_regional_counts(
+            api_origin,
+            "/api/regions/user-counts",
+            "regional user-count sample",
+        )
+        .await
+    }
+
+    async fn sample_server_counts(
+        &self,
+        api_origin: &Url,
+    ) -> Result<ServerCountObservation, TargetError> {
+        self.sample_regional_counts(
+            api_origin,
+            "/api/regions/server-counts",
+            "regional server-count sample",
+        )
+        .await
+    }
+
+    async fn sample_regional_counts(
+        &self,
+        api_origin: &Url,
+        path: &'static str,
+        operation: &'static str,
+    ) -> Result<UserCountObservation, TargetError> {
+        let url = endpoint_url(api_origin, path)?;
+        let started = Instant::now();
+        let response = self
+            .client
+            .get(url.clone())
+            .send()
+            .await
+            .map_err(|source| TargetError::Request {
+                operation,
+                url: url.to_string(),
+                source,
+            })?;
+        let status = response.status();
+        let backend_hint = self.backend_hints.observe_headers(response.headers());
+        if !status.is_success() {
+            return Err(TargetError::UnexpectedStatus {
+                operation,
+                url: url.to_string(),
+                status,
+            });
+        }
+
+        let counts = response
+            .json::<BTreeMap<String, u32>>()
+            .await
+            .map_err(|source| TargetError::InvalidResponse {
+                operation,
+                url: url.to_string(),
+                source,
+            })?;
+
+        Ok(UserCountObservation {
+            endpoint: EndpointObservation {
+                url: url.to_string(),
+                status_code: status.as_u16(),
+                latency_ms: elapsed_ms(started),
+                observed_at_unix_ms: unix_time_ms(),
+                backend_hint,
+            },
+            counts,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct HealthPayload {
+    status: String,
+}
+
+/// Convenience entry point for callers that only need one preflight.
+pub async fn preflight_target(options: &TargetOptions) -> Result<TargetPreflight, TargetError> {
+    TargetResolver::with_default_timeout()?
+        .preflight(options)
+        .await
+}
+
+/// Parse a target into a normalized HTTP(S) origin.
+pub fn normalize_target_url(raw: &str) -> Result<Url, TargetError> {
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return Err(TargetError::InvalidTarget {
+            target: raw.to_string(),
+            reason: "target cannot be empty".to_string(),
+        });
+    }
+
+    let candidate = if raw.contains("://") {
+        raw.to_string()
+    } else {
+        format!("https://{raw}")
+    };
+    let mut url = Url::parse(&candidate).map_err(|error| TargetError::InvalidTarget {
+        target: raw.to_string(),
+        reason: error.to_string(),
+    })?;
+    validate_http_origin(&url, raw)?;
+    url.set_path("/");
+    url.set_query(None);
+    url.set_fragment(None);
+    Ok(url)
+}
+
+/// Resolve the API origin. Public snaketron.io site/region hosts share the
+/// dedicated `api.snaketron.io` origin; local and custom targets are same-origin.
+pub fn derive_api_origin(target: &Url) -> Result<Url, TargetError> {
+    validate_http_origin(target, target.as_str())?;
+    let mut api_origin = target.clone();
+    if target.host_str().is_some_and(|host| {
+        host.eq_ignore_ascii_case("snaketron.io")
+            || host.to_ascii_lowercase().ends_with(".snaketron.io")
+    }) {
+        api_origin
+            .set_host(Some("api.snaketron.io"))
+            .map_err(|_| TargetError::InvalidTarget {
+                target: target.to_string(),
+                reason: "could not derive the Snaketron API host".to_string(),
+            })?;
+        api_origin
+            .set_port(None)
+            .map_err(|_| TargetError::InvalidTarget {
+                target: target.to_string(),
+                reason: "could not clear the API port".to_string(),
+            })?;
+        api_origin
+            .set_scheme("https")
+            .map_err(|_| TargetError::InvalidTarget {
+                target: target.to_string(),
+                reason: "could not require HTTPS for the production API".to_string(),
+            })?;
+    }
+    api_origin.set_path("/");
+    api_origin.set_query(None);
+    api_origin.set_fragment(None);
+    Ok(api_origin)
+}
+
+/// Return the configured regional WebSocket URL or derive `/ws` from origin.
+pub fn websocket_url_for_region(region: &RegionMetadata) -> Result<Url, TargetError> {
+    let origin = normalized_region_origin(region)?;
+    let mut ws_url = if region.ws_url.trim().is_empty() {
+        origin.clone()
+    } else {
+        Url::parse(region.ws_url.trim()).map_err(|error| TargetError::InvalidTarget {
+            target: region.ws_url.clone(),
+            reason: format!(
+                "region '{}' has an invalid WebSocket URL: {error}",
+                region.id
+            ),
+        })?
+    };
+
+    let desired_scheme = match ws_url.scheme() {
+        "http" => "ws",
+        "https" => "wss",
+        "ws" => "ws",
+        "wss" => "wss",
+        scheme => {
+            return Err(TargetError::InvalidTarget {
+                target: ws_url.to_string(),
+                reason: format!(
+                    "region '{}' WebSocket URL uses unsupported scheme '{scheme}'",
+                    region.id
+                ),
+            });
+        }
+    };
+    ws_url
+        .set_scheme(desired_scheme)
+        .map_err(|_| TargetError::InvalidTarget {
+            target: ws_url.to_string(),
+            reason: "could not set WebSocket scheme".to_string(),
+        })?;
+    if ws_url.host_str().is_none() || !ws_url.username().is_empty() || ws_url.password().is_some() {
+        return Err(TargetError::InvalidTarget {
+            target: ws_url.to_string(),
+            reason: "WebSocket URL must have a host and cannot contain credentials".to_string(),
+        });
+    }
+    if origin.scheme() == "https" && ws_url.scheme() != "wss" {
+        return Err(TargetError::InvalidTarget {
+            target: ws_url.to_string(),
+            reason: format!(
+                "region '{}' cannot downgrade an HTTPS origin to an insecure WebSocket",
+                region.id
+            ),
+        });
+    }
+    ws_url.set_path("/ws");
+    ws_url.set_query(None);
+    ws_url.set_fragment(None);
+    Ok(ws_url)
+}
+
+/// Select an explicit healthy region, or the lowest-latency healthy region.
+/// Latency ties are broken by region ID for deterministic reports.
+pub fn select_region<'a>(
+    observations: &'a [RegionHealthObservation],
+    requested_region: Option<&str>,
+) -> Result<&'a RegionHealthObservation, TargetError> {
+    if let Some(requested) = requested_region
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+    {
+        let observation = observations
+            .iter()
+            .find(|observation| observation.region.id.eq_ignore_ascii_case(requested))
+            .ok_or_else(|| TargetError::RegionNotFound {
+                requested: requested.to_string(),
+                available: observations
+                    .iter()
+                    .map(|observation| observation.region.id.clone())
+                    .collect(),
+            })?;
+        if !observation.healthy {
+            return Err(TargetError::RegionUnhealthy {
+                region: observation.region.id.clone(),
+                reason: observation
+                    .error
+                    .clone()
+                    .unwrap_or_else(|| "health check failed".to_string()),
+            });
+        }
+        return Ok(observation);
+    }
+
+    observations
+        .iter()
+        .filter(|observation| observation.healthy && observation.latency_ms.is_some())
+        .min_by(|left, right| {
+            left.latency_ms
+                .cmp(&right.latency_ms)
+                .then_with(|| left.region.id.cmp(&right.region.id))
+        })
+        .ok_or_else(|| TargetError::NoHealthyRegions {
+            summary: observations
+                .iter()
+                .map(|observation| {
+                    format!(
+                        "{}: {}",
+                        observation.region.id,
+                        observation.error.as_deref().unwrap_or("unhealthy")
+                    )
+                })
+                .collect::<Vec<_>>()
+                .join("; "),
+        })
+}
+
+fn normalized_region_origin(region: &RegionMetadata) -> Result<Url, TargetError> {
+    let origin =
+        normalize_target_url(&region.origin).map_err(|error| TargetError::InvalidTarget {
+            target: region.origin.clone(),
+            reason: format!("region '{}' has an invalid origin: {error}", region.id),
+        })?;
+    Ok(origin)
+}
+
+fn endpoint_url(origin: &Url, path: &str) -> Result<Url, TargetError> {
+    origin
+        .join(path)
+        .map_err(|error| TargetError::InvalidTarget {
+            target: origin.to_string(),
+            reason: format!("could not construct endpoint '{path}': {error}"),
+        })
+}
+
+fn validate_http_origin(url: &Url, original: &str) -> Result<(), TargetError> {
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(TargetError::InvalidTarget {
+            target: original.to_string(),
+            reason: format!(
+                "unsupported scheme '{}'; expected http or https",
+                url.scheme()
+            ),
+        });
+    }
+    if url.host_str().is_none() {
+        return Err(TargetError::InvalidTarget {
+            target: original.to_string(),
+            reason: "URL must include a host".to_string(),
+        });
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(TargetError::InvalidTarget {
+            target: original.to_string(),
+            reason: "URL cannot contain credentials".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn sticky_cookie_value(headers: &HeaderMap) -> Option<String> {
+    for header in headers.get_all(SET_COOKIE).iter() {
+        let Ok(header) = header.to_str() else {
+            continue;
+        };
+        let Some(cookie_pair) = header.split(';').next() else {
+            continue;
+        };
+        let Some((name, value)) = cookie_pair.split_once('=') else {
+            continue;
+        };
+        if name.trim().eq_ignore_ascii_case(STICKY_COOKIE_NAME) && !value.trim().is_empty() {
+            return Some(value.trim().to_string());
+        }
+    }
+    None
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().try_into().unwrap_or(u64::MAX)
+}
+
+fn unix_time_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis()
+        .try_into()
+        .unwrap_or(u64::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::header::HeaderValue;
+
+    fn region(id: &str, origin: &str, ws_url: &str) -> RegionMetadata {
+        RegionMetadata {
+            id: id.to_string(),
+            name: id.to_uppercase(),
+            origin: origin.to_string(),
+            ws_url: ws_url.to_string(),
+        }
+    }
+
+    fn health(id: &str, healthy: bool, latency_ms: Option<u64>) -> RegionHealthObservation {
+        RegionHealthObservation {
+            region: region(id, &format!("https://{id}.example.com"), ""),
+            health_url: format!("https://{id}.example.com/api/health"),
+            healthy,
+            status_code: healthy.then_some(200),
+            latency_ms,
+            observed_at_unix_ms: 1,
+            backend_hint: None,
+            error: (!healthy).then(|| "unavailable".to_string()),
+        }
+    }
+
+    #[test]
+    fn normalizes_target_to_an_origin_and_defaults_to_https() {
+        let url = normalize_target_url("snaketron.io/play?mode=duel#top").unwrap();
+        assert_eq!(url.as_str(), "https://snaketron.io/");
+    }
+
+    #[test]
+    fn rejects_non_http_target_schemes_and_credentials() {
+        assert!(normalize_target_url("wss://use1.snaketron.io/ws").is_err());
+        assert!(normalize_target_url("https://user:secret@example.com").is_err());
+    }
+
+    #[test]
+    fn maps_public_hosts_to_the_api_origin_but_keeps_local_targets() {
+        let public = normalize_target_url("https://use1.snaketron.io/play").unwrap();
+        assert_eq!(
+            derive_api_origin(&public).unwrap().as_str(),
+            "https://api.snaketron.io/"
+        );
+
+        let local = normalize_target_url("http://localhost:8080/anything").unwrap();
+        assert_eq!(
+            derive_api_origin(&local).unwrap().as_str(),
+            "http://localhost:8080/"
+        );
+    }
+
+    #[test]
+    fn uses_or_derives_a_secure_websocket_url() {
+        let configured = region(
+            "use1",
+            "https://use1.snaketron.io",
+            "wss://games.snaketron.io/ignored?token=none",
+        );
+        assert_eq!(
+            websocket_url_for_region(&configured).unwrap().as_str(),
+            "wss://games.snaketron.io/ws"
+        );
+
+        let derived = region("local", "http://localhost:8080", "");
+        assert_eq!(
+            websocket_url_for_region(&derived).unwrap().as_str(),
+            "ws://localhost:8080/ws"
+        );
+    }
+
+    #[test]
+    fn rejects_a_websocket_security_downgrade() {
+        let insecure = region(
+            "use1",
+            "https://use1.snaketron.io",
+            "ws://use1.snaketron.io/ws",
+        );
+        assert!(websocket_url_for_region(&insecure).is_err());
+    }
+
+    #[test]
+    fn explicit_selection_is_case_insensitive_and_does_not_fall_back() {
+        let observations = vec![
+            health("use1", true, Some(30)),
+            health("euw1", false, Some(10)),
+        ];
+        assert_eq!(
+            select_region(&observations, Some("USE1"))
+                .unwrap()
+                .region
+                .id,
+            "use1"
+        );
+        assert!(matches!(
+            select_region(&observations, Some("euw1")),
+            Err(TargetError::RegionUnhealthy { .. })
+        ));
+        assert!(matches!(
+            select_region(&observations, Some("ap1")),
+            Err(TargetError::RegionNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn automatic_selection_uses_latency_then_region_id() {
+        let observations = vec![
+            health("use2", true, Some(12)),
+            health("use1", true, Some(12)),
+            health("euw1", false, Some(1)),
+        ];
+        assert_eq!(
+            select_region(&observations, None).unwrap().region.id,
+            "use1"
+        );
+    }
+
+    #[test]
+    fn automatic_selection_requires_a_healthy_latency_sample() {
+        let observations = vec![health("use1", false, Some(2)), health("euw1", true, None)];
+        assert!(matches!(
+            select_region(&observations, None),
+            Err(TargetError::NoHealthyRegions { .. })
+        ));
+    }
+
+    #[test]
+    fn sticky_backend_values_become_run_local_aliases() {
+        let registry = BackendHintRegistry::default();
+        let mut first_headers = HeaderMap::new();
+        first_headers.append(
+            SET_COOKIE,
+            HeaderValue::from_static("session=secret; Path=/; HttpOnly"),
+        );
+        first_headers.append(
+            SET_COOKIE,
+            HeaderValue::from_static(
+                "snaketron_sticky=raw-backend-value-one; Path=/; HttpOnly; Secure",
+            ),
+        );
+        let first = registry.observe_headers(&first_headers).unwrap();
+        assert_eq!(first.identifier, "backend-0001");
+        assert!(!format!("{first:?}").contains("raw-backend-value-one"));
+        assert!(!format!("{registry:?}").contains("raw-backend-value-one"));
+
+        let same = registry.observe_headers(&first_headers).unwrap();
+        assert_eq!(same.identifier, first.identifier);
+
+        let mut second_headers = HeaderMap::new();
+        second_headers.insert(
+            SET_COOKIE,
+            HeaderValue::from_static("snaketron_sticky=raw-backend-value-two; Path=/"),
+        );
+        let second = registry.observe_headers(&second_headers).unwrap();
+        assert_eq!(second.identifier, "backend-0002");
+        assert_eq!(registry.observed_backend_count(), 2);
+    }
+}

--- a/server/src/api/regions.rs
+++ b/server/src/api/regions.rs
@@ -1,9 +1,11 @@
-use axum::{Json, extract::State};
+use axum::{Json, extract::State, http::StatusCode};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use tracing::error;
+use std::collections::{HashMap, HashSet};
+use tracing::{error, warn};
 
 use crate::http_server::HttpServerState;
+
+const ACTIVE_SERVER_USER_COUNT_PATTERN: &str = "server:*:user_count";
 
 /// Region metadata returned by /api/regions endpoint
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -33,13 +35,14 @@ pub async fn list_regions(State(state): State<HttpServerState>) -> Json<Vec<Regi
 /// Redis schema:
 /// - Key: server:{server_id}:user_count -> Value: <count>
 /// - Key: server:{server_id}:region -> Value: <region_id>
-pub async fn get_user_counts(State(state): State<HttpServerState>) -> Json<HashMap<String, u32>> {
-    // Create Redis client
+pub async fn get_user_counts(
+    State(state): State<HttpServerState>,
+) -> Result<Json<HashMap<String, u32>>, StatusCode> {
     let redis_client = match redis::Client::open(state.redis_url.as_str()) {
         Ok(client) => client,
         Err(e) => {
             error!("Failed to open Redis client: {}", e);
-            return Json(HashMap::new());
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
     };
 
@@ -47,20 +50,15 @@ pub async fn get_user_counts(State(state): State<HttpServerState>) -> Json<HashM
         Ok(conn) => conn,
         Err(e) => {
             error!("Failed to get Redis connection: {}", e);
-            return Json(HashMap::new());
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
     };
 
-    // Query all server user count keys
-    let server_keys: Vec<String> = match redis::cmd("KEYS")
-        .arg("server:*:user_count")
-        .query_async(&mut conn)
-        .await
-    {
+    let server_keys = match scan_active_server_keys(&mut conn).await {
         Ok(keys) => keys,
         Err(e) => {
-            error!("Failed to query Redis keys: {}", e);
-            return Json(HashMap::new());
+            error!("Failed to query active server metric keys: {}", e);
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
         }
     };
 
@@ -68,42 +66,146 @@ pub async fn get_user_counts(State(state): State<HttpServerState>) -> Json<HashM
 
     for key in server_keys {
         // Get user count for this server
-        let count: u32 = match redis::cmd("GET").arg(&key).query_async(&mut conn).await {
+        let count: Option<u32> = match redis::cmd("GET").arg(&key).query_async(&mut conn).await {
             Ok(count) => count,
             Err(e) => {
-                error!("Failed to get user count for {}: {}", key, e);
-                continue;
+                error!("Failed to read an active server's user count: {}", e);
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
             }
         };
-
-        // Extract server_id from key "server:{server_id}:user_count"
-        let server_id = match key.split(':').nth(1) {
-            Some(id) => id,
-            None => {
-                error!("Invalid key format: {}", key);
-                continue;
-            }
+        let Some(count) = count else {
+            // The TTL-backed key can legitimately expire after SCAN.
+            continue;
         };
 
-        // Get region for this server
-        let region_key = format!("server:{}:region", server_id);
-        let region: String = match redis::cmd("GET")
+        let Some(region_key) = region_key_for_active_server(&key) else {
+            error!("Redis returned a malformed active server metric key");
+            continue;
+        };
+
+        let region: Option<String> = match redis::cmd("GET")
             .arg(&region_key)
             .query_async(&mut conn)
             .await
         {
             Ok(region) => region,
-            Err(_) => {
-                // If no region is set, default to "us"
-                "us".to_string()
+            Err(e) => {
+                error!("Failed to resolve an active server's region: {}", e);
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
             }
+        };
+        let Some(region) = region.filter(|region| !region.trim().is_empty()) else {
+            warn!("Ignoring an active server metric without region metadata");
+            continue;
         };
 
         // Aggregate counts by region
-        *region_counts.entry(region).or_insert(0) += count;
+        let regional_count = region_counts.entry(region).or_insert(0_u32);
+        *regional_count = regional_count.saturating_add(count);
     }
 
-    Json(region_counts)
+    Ok(Json(region_counts))
+}
+
+/// Get active server-instance counts per region from Redis.
+///
+/// A server is considered active while its TTL-backed
+/// `server:{server_id}:user_count` key exists. Persistent region metadata is
+/// consulted only for those active keys, and server identifiers are never
+/// included in the response.
+pub async fn get_server_counts(
+    State(state): State<HttpServerState>,
+) -> Result<Json<HashMap<String, u32>>, StatusCode> {
+    let redis_client = match redis::Client::open(state.redis_url.as_str()) {
+        Ok(client) => client,
+        Err(e) => {
+            error!("Failed to open Redis client: {}", e);
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    let mut conn = match redis_client.get_multiplexed_async_connection().await {
+        Ok(conn) => conn,
+        Err(e) => {
+            error!("Failed to get Redis connection: {}", e);
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    let active_server_keys = match scan_active_server_keys(&mut conn).await {
+        Ok(keys) => keys,
+        Err(e) => {
+            error!("Failed to query active server metric keys: {}", e);
+            return Err(StatusCode::SERVICE_UNAVAILABLE);
+        }
+    };
+
+    let mut region_counts = HashMap::new();
+    for active_server_key in active_server_keys {
+        let Some(region_key) = region_key_for_active_server(&active_server_key) else {
+            error!("Redis returned a malformed active server metric key");
+            continue;
+        };
+        let region: Option<String> = match redis::cmd("GET")
+            .arg(region_key)
+            .query_async(&mut conn)
+            .await
+        {
+            Ok(region) => region,
+            Err(e) => {
+                error!("Failed to resolve an active server's region: {}", e);
+                return Err(StatusCode::SERVICE_UNAVAILABLE);
+            }
+        };
+        let Some(region) = region.filter(|region| !region.trim().is_empty()) else {
+            warn!("Ignoring an active server metric without region metadata");
+            continue;
+        };
+
+        record_active_server(&mut region_counts, region);
+    }
+
+    Ok(Json(region_counts))
+}
+
+async fn scan_active_server_keys(
+    conn: &mut redis::aio::MultiplexedConnection,
+) -> redis::RedisResult<Vec<String>> {
+    let mut cursor = 0_u64;
+    let mut keys = HashSet::new();
+
+    loop {
+        let (next_cursor, batch): (u64, Vec<String>) = redis::cmd("SCAN")
+            .arg(cursor)
+            .arg("MATCH")
+            .arg(ACTIVE_SERVER_USER_COUNT_PATTERN)
+            .arg("COUNT")
+            .arg(100_u32)
+            .query_async(conn)
+            .await?;
+        keys.extend(batch);
+        cursor = next_cursor;
+        if cursor == 0 {
+            break;
+        }
+    }
+
+    Ok(keys.into_iter().collect())
+}
+
+fn record_active_server(region_counts: &mut HashMap<String, u32>, region: String) {
+    let count = region_counts.entry(region).or_insert(0);
+    *count = count.saturating_add(1);
+}
+
+fn region_key_for_active_server(user_count_key: &str) -> Option<String> {
+    let mut parts = user_count_key.split(':');
+    match (parts.next(), parts.next(), parts.next(), parts.next()) {
+        (Some("server"), Some(server_id), Some("user_count"), None) if !server_id.is_empty() => {
+            Some(format!("server:{server_id}:region"))
+        }
+        _ => None,
+    }
 }
 
 /// Simple health check endpoint for client-side ping measurement
@@ -112,4 +214,43 @@ pub async fn health_check_json() -> Json<HealthResponse> {
     Json(HealthResponse {
         status: "ok".to_string(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{record_active_server, region_key_for_active_server};
+    use std::collections::HashMap;
+
+    #[test]
+    fn counts_instances_by_region() {
+        let mut counts = HashMap::new();
+        record_active_server(&mut counts, "use1".to_string());
+        record_active_server(&mut counts, "use1".to_string());
+        record_active_server(&mut counts, "euw1".to_string());
+
+        assert_eq!(counts.get("use1"), Some(&2));
+        assert_eq!(counts.get("euw1"), Some(&1));
+        assert_eq!(counts.len(), 2);
+    }
+
+    #[test]
+    fn derives_region_key_from_an_active_server_metric() {
+        assert_eq!(
+            region_key_for_active_server("server:instance-123:user_count").as_deref(),
+            Some("server:instance-123:region")
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_active_server_metrics() {
+        for key in [
+            "",
+            "server::user_count",
+            "server:instance-123",
+            "server:instance-123:connections",
+            "server:instance-123:user_count:extra",
+        ] {
+            assert_eq!(region_key_for_active_server(key), None, "accepted {key}");
+        }
+    }
 }

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -150,6 +150,10 @@ pub async fn run_http_server(
     let region_routes = Router::new()
         .route("/api/regions", get(regions::list_regions))
         .route("/api/regions/user-counts", get(regions::get_user_counts))
+        .route(
+            "/api/regions/server-counts",
+            get(regions::get_server_counts),
+        )
         .with_state(state.clone());
 
     // Debug/observability routes: clients upload their sync trace (flight

--- a/server/src/matchmaking.rs
+++ b/server/src/matchmaking.rs
@@ -578,6 +578,22 @@ fn find_ffa_combination(
         }
     }
 
+    // Keep a complete party intact even when older partial lobbies are also
+    // waiting. Without this fast path, the include-first backtracking below can
+    // fill the first slots from a partial lobby and turn members of the complete
+    // lobby into spectators.
+    if let Some((lobby_idx, _)) = lobbies
+        .iter()
+        .enumerate()
+        .find(|(_, lobby)| lobby.members.len() == max_players)
+    {
+        return Some(build_ffa_combination_from_selection(
+            lobbies,
+            &[lobby_idx],
+            max_players,
+        ));
+    }
+
     // Fast path: single-lobby decision based on wait thresholds
     if lobbies.len() == 1 {
         let lobby = &lobbies[0];
@@ -1347,10 +1363,54 @@ mod tests {
     use crate::matchmaking_manager::QueuedLobby;
     use common::{QueueMode, TeamId};
 
+    fn ffa_lobby(code: &str, user_ids: &[u32], queued_at: i64) -> QueuedLobby {
+        QueuedLobby {
+            lobby_code: code.to_string(),
+            members: user_ids
+                .iter()
+                .map(|user_id| LobbyMember {
+                    user_id: *user_id,
+                    username: format!("player_{user_id}"),
+                    ts: queued_at as f64,
+                })
+                .collect(),
+            avg_mmr: 1000,
+            game_types: vec![GameType::FreeForAll { max_players: 4 }],
+            queue_mode: QueueMode::Quickmatch,
+            queued_at,
+            requesting_user_id: user_ids[0],
+        }
+    }
+
     #[tokio::test]
     async fn test_match_creation_logic() {
         // Test the match creation logic
         // This would require mocking Redis and PubSub
+    }
+
+    #[test]
+    fn one_player_lobby_forms_a_solo_match() {
+        let lobby = QueuedLobby {
+            lobby_code: "SOLO1".to_string(),
+            members: vec![LobbyMember {
+                user_id: 5,
+                username: "solo_player".to_string(),
+                ts: 100.0,
+            }],
+            avg_mmr: 1000,
+            game_types: vec![GameType::Solo],
+            queue_mode: QueueMode::Quickmatch,
+            queued_at: 0,
+            requesting_user_id: 5,
+        };
+
+        let combo = find_best_lobby_combination(&[lobby], &GameType::Solo)
+            .expect("a one-player lobby should form one solo match");
+
+        assert_eq!(combo.total_players, 1);
+        assert_eq!(combo.lobbies.len(), 1);
+        assert!(combo.team_assignments.is_empty());
+        assert!(combo.spectators.is_empty());
     }
 
     #[test]
@@ -1396,5 +1456,67 @@ mod tests {
 
         assert_eq!(team_a_indices, vec![0]);
         assert_eq!(team_b_indices, vec![1]);
+    }
+
+    #[test]
+    fn four_player_lobby_splits_into_two_v_two_without_spectators() {
+        let lobby = QueuedLobby {
+            lobby_code: "TEAM4".to_string(),
+            members: (20..24)
+                .map(|user_id| LobbyMember {
+                    user_id,
+                    username: format!("player_{user_id}"),
+                    ts: f64::from(user_id),
+                })
+                .collect(),
+            avg_mmr: 1200,
+            game_types: vec![GameType::TeamMatch { per_team: 2 }],
+            queue_mode: QueueMode::Quickmatch,
+            queued_at: 0,
+            requesting_user_id: 20,
+        };
+
+        let combo = find_best_lobby_combination(&[lobby], &GameType::TeamMatch { per_team: 2 })
+            .expect("a four-player lobby should form one 2v2 match");
+
+        assert_eq!(combo.total_players, 4);
+        assert_eq!(combo.lobbies.len(), 1);
+        assert!(combo.spectators.is_empty());
+        assert_eq!(combo.team_assignments.len(), 2);
+        assert!(
+            combo
+                .team_assignments
+                .iter()
+                .all(|assignment| assignment.member_indices.len() == 2)
+        );
+    }
+
+    #[test]
+    fn ffa_prefers_full_lobby_over_older_partial_lobby() {
+        let now = Utc::now().timestamp_millis();
+        let partial = ffa_lobby("PARTIAL", &[1], now - 1_000);
+        let full = ffa_lobby("FULL", &[10, 11, 12, 13], now);
+
+        let combo = find_ffa_combination(&[partial, full], 4)
+            .expect("a complete four-player FFA lobby should match");
+
+        assert_eq!(combo.total_players, 4);
+        assert_eq!(combo.lobbies.len(), 1);
+        assert_eq!(combo.lobbies[0].lobby_code, "FULL");
+        assert!(combo.spectators.is_empty());
+    }
+
+    #[test]
+    fn ffa_still_combines_partial_lobbies_when_no_full_lobby_exists() {
+        let now = Utc::now().timestamp_millis();
+        let first = ffa_lobby("FIRST", &[1, 2], now);
+        let second = ffa_lobby("SECOND", &[3, 4], now);
+
+        let combo = find_ffa_combination(&[first, second], 4)
+            .expect("two fresh two-player lobbies should form a four-player FFA");
+
+        assert_eq!(combo.total_players, 4);
+        assert_eq!(combo.lobbies.len(), 2);
+        assert!(combo.spectators.is_empty());
     }
 }


### PR DESCRIPTION
## Summary
- add a native coordinated load-test runner that reuses the shared game engine, AI, and WebSocket protocol
- support deterministic Solo, Duel, 2v2, and FFA sessions with full-party multiplayer lobbies
- gradually ramp and maintain concurrency while observing regional users and active server counts
- emit aggregate HTML and JSON reports plus detailed artifacts for failed, cancelled, or incomplete sessions
- add production safeguards, reconnect recovery, pairing validation, and authoritative versus timeboxed completion reporting
- prefer complete FFA parties during matchmaking and expose active server counts by region

## Validation
- cargo test -p loadtest: 58 passed
- cargo test -p server --lib: 44 passed
- cargo check -p loadtest
- cargo clippy -p loadtest --all-targets --no-deps -- -D warnings
- cargo fmt --all -- --check
- git diff --check

No production load was executed.