### PR TITLE
Add comprehensive Snaketron operational telemetry

### DIFF
--- a/run_autoscaling_resilience_tests.sh
+++ b/run_autoscaling_resilience_tests.sh
@@ -4066,58 +4066,58 @@ collect_cloudwatch_evidence() {
   mkdir -p "$cloudwatch_dir"
 
   cloudwatch_metric "$cloudwatch_dir/ready-tasks.json" \
-    Snaketron/Resilience ReadyTasks Minimum \
+    Snaketron/OperationalDev ReadyTasks Minimum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/regional-collection-failures.json" \
-    Snaketron/Resilience RegionalCollectionFailures Sum \
+    Snaketron/OperationalDev RegionalCollectionFailures Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/fingerprint-divergences.json" \
-    Snaketron/Resilience RecoveryFingerprintDivergences Sum \
+    Snaketron/OperationalDev RecoveryFingerprintDivergences Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/owner-mismatches.json" \
-    Snaketron/Resilience PartitionOwnerMismatches Maximum \
+    Snaketron/OperationalDev PartitionOwnerMismatches Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/active-index-mismatches.json" \
-    Snaketron/Resilience ActiveGameIndexMismatches Maximum \
+    Snaketron/OperationalDev ActiveGameIndexMismatches Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/planned-drain-failures.json" \
-    Snaketron/Resilience PlannedDrainFailures Sum \
+    Snaketron/OperationalDev PlannedDrainFailures Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/partition-unowned-ms.json" \
-    Snaketron/Resilience PartitionUnownedMs Maximum \
+    Snaketron/OperationalDev PartitionUnownedMs Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/assignment-imbalance.json" \
-    Snaketron/Resilience AssignmentImbalance Maximum \
+    Snaketron/OperationalDev AssignmentImbalance Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/oldest-pending-command-ms.json" \
-    Snaketron/Resilience OldestPendingCommandMs Maximum \
+    Snaketron/OperationalDev OldestPendingCommandMs Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/pending-commands.json" \
-    Snaketron/Resilience PendingCommands Maximum \
+    Snaketron/OperationalDev PendingCommands Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/pending-completions.json" \
-    Snaketron/Resilience PendingCompletions Maximum \
+    Snaketron/OperationalDev PendingCompletions Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/checkpoint-age-ms.json" \
-    Snaketron/Resilience CheckpointAgeMs Maximum \
+    Snaketron/OperationalDev CheckpointAgeMs Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/checkpoint-bytes.json" \
-    Snaketron/Resilience CheckpointBytes Maximum \
+    Snaketron/OperationalDev CheckpointBytes Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/checkpoint-writes.json" \
-    Snaketron/Resilience CheckpointWrites Sum \
+    Snaketron/OperationalDev CheckpointWrites Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/checkpoint-failures.json" \
-    Snaketron/Resilience CheckpointFailures Sum \
+    Snaketron/OperationalDev CheckpointFailures Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/fenced-write-rejections.json" \
-    Snaketron/Resilience FencedWriteRejections Sum \
+    Snaketron/OperationalDev FencedWriteRejections Sum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/quarantined-commands.json" \
-    Snaketron/Resilience QuarantinedCommands Maximum \
+    Snaketron/OperationalDev QuarantinedCommands Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
   cloudwatch_metric "$cloudwatch_dir/active-websockets.json" \
-    Snaketron/Resilience ActiveWebSockets Maximum \
+    Snaketron/OperationalDev ActiveWebSockets Maximum \
     Name=Environment,Value="$SNAKETRON_STAGING_ENVIRONMENT"
 
   cloudwatch_metric "$cloudwatch_dir/ecs-cpu.json" \

--- a/server/src/game_executor_v2.rs
+++ b/server/src/game_executor_v2.rs
@@ -1366,7 +1366,8 @@ impl GameActor {
             .clone()
             .context("terminal game has no materialized completion record")?;
         let covered = self.pending_stream_ids.clone();
-        self.bus
+        let newly_committed = self
+            .bus
             .commit_completion_record_fenced(
                 &self.guard,
                 &self.envelope(),
@@ -1375,6 +1376,19 @@ impl GameActor {
                 self.config.retention,
             )
             .await?;
+        if newly_committed {
+            let duration_ms = u64::try_from(
+                record
+                    .ended_at_ms
+                    .saturating_sub(record.final_state.start_ms)
+                    .max(0),
+            )
+            .unwrap_or(u64::MAX);
+            crate::resilience_metrics::record_game_completed(
+                duration_ms,
+                record.final_state.players.len(),
+            );
+        }
         self.pending_stream_ids.clear();
         // The immutable record and pending-effect index are now authoritative.
         // DynamoDB is deliberately decoupled from this actor: the partition

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -9,6 +9,7 @@ use axum::{
     routing::{get, options, post},
 };
 use std::sync::{Arc, RwLock};
+use std::time::Instant;
 use tokio::net::TcpListener;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
@@ -314,11 +315,22 @@ pub async fn install_http_application(
         // Nest API routes
         .nest("/", api_routes)
         .layer(cors)
+        .layer(middleware::from_fn(observe_application_request))
         .with_state(state);
 
     deferred.install(app)?;
     info!("HTTP API and WebSocket routes installed");
     Ok(())
+}
+
+async fn observe_application_request(request: Request<Body>, next: middleware::Next) -> Response {
+    let started_at = Instant::now();
+    let response = next.run(request).await;
+    crate::resilience_metrics::record_http_request(
+        response.status().as_u16(),
+        started_at.elapsed(),
+    );
+    response
 }
 
 #[derive(serde::Deserialize)]
@@ -388,6 +400,7 @@ async fn websocket_handler(
     State(state): State<HttpServerState>,
 ) -> axum::response::Response {
     if !state.lifecycle.is_ready() {
+        crate::resilience_metrics::record_websocket_rejected_upgrade(1);
         return (
             StatusCode::SERVICE_UNAVAILABLE,
             [(axum::http::header::RETRY_AFTER, "1")],
@@ -405,9 +418,11 @@ async fn websocket_handler(
         // after the 101 response is prepared but before Axum runs this future.
         let count = connection_count.fetch_add(1, Ordering::Relaxed) + 1;
         lifecycle.websocket_opened();
+        crate::resilience_metrics::record_websocket_opened(1);
         tracing::debug!("WebSocket connection opened, total connections: {}", count);
 
         // Handle the WebSocket connection
+        let session_started_at = Instant::now();
         handle_websocket(
             socket,
             state.db,
@@ -426,10 +441,12 @@ async fn websocket_handler(
             state.cluster_namespace,
         )
         .await;
+        crate::resilience_metrics::record_websocket_session(session_started_at.elapsed());
 
         // Decrement connection count when connection closes
         let count = connection_count.fetch_sub(1, Ordering::Relaxed) - 1;
         lifecycle.websocket_closed();
+        crate::resilience_metrics::record_websocket_closed(1);
         tracing::debug!("WebSocket connection closed, total connections: {}", count);
     })
     .into_response()

--- a/server/src/matchmaking.rs
+++ b/server/src/matchmaking.rs
@@ -17,8 +17,8 @@ use crate::game_executor::PARTITION_COUNT;
 use crate::game_executor::StreamEvent;
 use crate::lobby_manager::LobbyManager;
 use crate::matchmaking_manager::{
-    ActiveMatch, GameCreatedOutboxRecord, MatchCommitOutcome, MatchStatus, MatchmakingManager,
-    QueuedPlayer,
+    ActiveMatch, GameCreatedOutboxRecord, MATCHMAKING_GAME_TYPES, MatchCommitOutcome, MatchStatus,
+    MatchmakingManager, QueuedPlayer,
 };
 
 // --- Configuration Constants ---
@@ -73,6 +73,7 @@ async fn deliver_game_created_outbox_record(
 ) {
     let game_id = delivery.record.game_id;
     if let Err(error) = game_bus.publish_game_created_once(&delivery.record).await {
+        crate::resilience_metrics::record_game_created_outbox_delivery_error(1);
         warn!(game_id, %error, "game-created outbox delivery failed; retrying");
         return;
     }
@@ -82,10 +83,12 @@ async fn deliver_game_created_outbox_record(
     {
         Ok(_) => {
             if let Err(error) = game_bus.expire_game_created_delivery_marker(game_id).await {
+                crate::resilience_metrics::record_game_created_outbox_delivery_error(1);
                 warn!(game_id, %error, "failed to expire acknowledged game-created marker");
             }
         }
         Err(error) => {
+            crate::resilience_metrics::record_game_created_outbox_delivery_error(1);
             warn!(game_id, %error, "game-created outbox acknowledgement failed; retrying");
         }
     }
@@ -159,6 +162,7 @@ pub async fn run_game_created_outbox_loop(
             let (next_cursor, records) = match scan_result {
                 Ok(batch) => batch,
                 Err(error) => {
+                    crate::resilience_metrics::record_game_created_outbox_delivery_error(1);
                     warn!(%error, "game-created outbox scan failed; retrying");
                     cursor = 0;
                     continue;
@@ -924,20 +928,9 @@ pub async fn run_matchmaking_loop(
             }
         }
 
-        // Get distinct game types from Redis
-        // For now, we'll check a few common game types
-        // In production, we'd maintain a set of active game types
-        let game_types = vec![
-            GameType::Solo,
-            GameType::FreeForAll { max_players: 2 },
-            GameType::FreeForAll { max_players: 4 },
-            GameType::TeamMatch { per_team: 1 },
-            GameType::TeamMatch { per_team: 2 },
-        ];
-
         let mut total_games_created = 0;
 
-        for game_type in &game_types {
+        for game_type in &MATCHMAKING_GAME_TYPES {
             // Try lobby-based matchmaking for quickmatch
             match create_lobby_matches(
                 &mut matchmaking_manager,

--- a/server/src/matchmaking_manager.rs
+++ b/server/src/matchmaking_manager.rs
@@ -11,6 +11,20 @@ use std::time::Duration;
 use tokio::time::sleep;
 use tracing::{error, info, warn};
 
+/// Fixed queue families consumed by the production matchmaking loop. Metrics
+/// aggregate these ten queues without adding game-type or mode dimensions.
+pub const MATCHMAKING_GAME_TYPES: [GameType; 5] = [
+    GameType::Solo,
+    GameType::FreeForAll { max_players: 2 },
+    GameType::FreeForAll { max_players: 4 },
+    GameType::TeamMatch { per_team: 1 },
+    GameType::TeamMatch { per_team: 2 },
+];
+pub const MATCHMAKING_QUEUE_MODES: [common::QueueMode; 2] = [
+    common::QueueMode::Quickmatch,
+    common::QueueMode::Competitive,
+];
+
 // Data structures for Redis storage
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct QueuedPlayer {
@@ -57,6 +71,24 @@ pub enum MatchCommitOutcome {
     Conflict { reason: String },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AtomicMatchmakingOutcome {
+    IntegrityError,
+    Applied,
+    Idempotent,
+    ExpectedConflict,
+}
+
+fn classify_atomic_matchmaking_outcome(code: i64) -> Option<AtomicMatchmakingOutcome> {
+    match code {
+        0 => Some(AtomicMatchmakingOutcome::IntegrityError),
+        1 => Some(AtomicMatchmakingOutcome::Applied),
+        2 => Some(AtomicMatchmakingOutcome::Idempotent),
+        3 => Some(AtomicMatchmakingOutcome::ExpectedConflict),
+        _ => None,
+    }
+}
+
 #[derive(Serialize)]
 struct MatchCommitQueuePair {
     queue_key: String,
@@ -85,7 +117,9 @@ struct MatchCommitUser {
 struct MatchCommitPlan {
     active_matches_key: String,
     outbox_key: String,
+    outbox_age_key: String,
     outbox_payload: String,
+    created_at_ms: i64,
     game_id: String,
     active_match_json: String,
     lobbies: Vec<MatchCommitLobby>,
@@ -179,17 +213,21 @@ if lobby_mapping_type ~= 'none' and lobby_mapping_type ~= 'string' then
     return {0, 'lobby-mapping-wrong-type'}
 end
 if redis.call('GET', plan.lobby_active_game_key) then
-    return {0, 'lobby-already-matched'}
+    return {3, 'lobby-already-matched'}
 end
-if key_type(plan.lobby_metadata_key) ~= 'hash' then
-    return {0, 'lobby-metadata-missing-or-wrong-type'}
+local lobby_metadata_type = key_type(plan.lobby_metadata_key)
+if lobby_metadata_type == 'none' then
+    return {3, 'lobby-metadata-missing'}
+end
+if lobby_metadata_type ~= 'hash' then
+    return {0, 'lobby-metadata-wrong-type'}
 end
 for _, key in ipairs(plan.user_active_game_keys) do
     local mapping_type = key_type(key)
     if mapping_type ~= 'none' and mapping_type ~= 'string' then
         return {0, 'user-mapping-wrong-type'}
     end
-    if redis.call('GET', key) then return {0, 'user-already-matched'} end
+    if redis.call('GET', key) then return {3, 'user-already-matched'} end
 end
 
 local identity_type = key_type(plan.queue_identity_key)
@@ -209,7 +247,7 @@ for _, claim in ipairs(plan.user_queue_claims) do
     end
     local existing_claim = redis.call('GET', claim.key)
     if existing_claim and existing_claim ~= claim.value then
-        return {0, 'user-already-queued'}
+        return {3, 'user-already-queued'}
     end
 end
 
@@ -328,12 +366,24 @@ if outbox_type ~= 'none' and outbox_type ~= 'hash' then
     return {0, 'game-created-outbox-wrong-type'}
 end
 
+local outbox_age_type = key_type(plan.outbox_age_key)
+if outbox_age_type ~= 'none' and outbox_age_type ~= 'zset' then
+    return {0, 'game-created-outbox-age-wrong-type'}
+end
+
 local existing = redis.call('HGET', plan.active_matches_key, plan.game_id)
 if existing then
-    if existing == plan.active_match_json then
-        return {2, 'already-committed'}
+    if existing ~= plan.active_match_json then
+        return {0, 'game-id-already-committed'}
     end
-    return {0, 'game-id-already-committed'}
+    local existing_outbox = redis.call('HGET', plan.outbox_key, plan.game_id)
+    if existing_outbox and existing_outbox ~= plan.outbox_payload then
+        return {0, 'game-created-outbox-conflict'}
+    end
+    if existing_outbox then
+        redis.call('ZADD', plan.outbox_age_key, plan.created_at_ms, plan.game_id)
+    end
+    return {2, 'already-committed'}
 end
 
 local existing_outbox = redis.call('HGET', plan.outbox_key, plan.game_id)
@@ -347,25 +397,34 @@ for _, lobby in ipairs(plan.lobbies) do
         return {0, 'lobby-mapping-wrong-type:' .. lobby.lobby_code}
     end
     if redis.call('GET', lobby.active_game_key) then
-        return {0, 'lobby-already-matched:' .. lobby.lobby_code}
+        return {3, 'lobby-already-matched:' .. lobby.lobby_code}
     end
 
-    if key_type(lobby.queue_identity_key) ~= 'string' then
-        return {0, 'queue-identity-missing-or-wrong-type:' .. lobby.lobby_code}
+    local queue_identity_type = key_type(lobby.queue_identity_key)
+    if queue_identity_type == 'none' then
+        return {3, 'queue-identity-missing:' .. lobby.lobby_code}
+    end
+    if queue_identity_type ~= 'string' then
+        return {0, 'queue-identity-wrong-type:' .. lobby.lobby_code}
     end
     if redis.call('GET', lobby.queue_identity_key) ~= lobby.member_json then
-        return {0, 'queue-entry-changed:' .. lobby.lobby_code}
+        return {3, 'queue-entry-changed:' .. lobby.lobby_code}
     end
 
     for _, pair in ipairs(lobby.queue_pairs) do
-        if key_type(pair.queue_key) ~= 'zset' or key_type(pair.mmr_key) ~= 'zset' then
-            return {0, 'queue-missing-or-wrong-type:' .. lobby.lobby_code}
+        local queue_type = key_type(pair.queue_key)
+        local mmr_type = key_type(pair.mmr_key)
+        if queue_type == 'none' or mmr_type == 'none' then
+            return {3, 'queue-missing:' .. lobby.lobby_code}
+        end
+        if queue_type ~= 'zset' or mmr_type ~= 'zset' then
+            return {0, 'queue-wrong-type:' .. lobby.lobby_code}
         end
         if not redis.call('ZSCORE', pair.queue_key, lobby.member_json) then
-            return {0, 'queue-entry-changed:' .. lobby.lobby_code}
+            return {3, 'queue-entry-changed:' .. lobby.lobby_code}
         end
         if not redis.call('ZSCORE', pair.mmr_key, lobby.member_json) then
-            return {0, 'mmr-entry-changed:' .. lobby.lobby_code}
+            return {3, 'mmr-entry-changed:' .. lobby.lobby_code}
         end
     end
 end
@@ -376,13 +435,17 @@ for _, user in ipairs(plan.users) do
         return {0, 'user-mapping-wrong-type'}
     end
     if redis.call('GET', user.active_game_key) then
-        return {0, 'user-already-matched'}
+        return {3, 'user-already-matched'}
     end
-    if key_type(user.queue_identity_key) ~= 'string' then
-        return {0, 'user-queue-identity-missing-or-wrong-type'}
+    local user_queue_identity_type = key_type(user.queue_identity_key)
+    if user_queue_identity_type == 'none' then
+        return {3, 'user-queue-identity-missing'}
+    end
+    if user_queue_identity_type ~= 'string' then
+        return {0, 'user-queue-identity-wrong-type'}
     end
     if redis.call('GET', user.queue_identity_key) ~= user.queue_identity_value then
-        return {0, 'user-queue-entry-changed'}
+        return {3, 'user-queue-entry-changed'}
     end
 end
 
@@ -408,6 +471,7 @@ for _, user in ipairs(plan.users) do
 end
 
 redis.call('HSET', plan.outbox_key, plan.game_id, plan.outbox_payload)
+redis.call('ZADD', plan.outbox_age_key, plan.created_at_ms, plan.game_id)
 for _, notification in ipairs(plan.notifications) do
     redis.call('PUBLISH', notification.channel, notification.payload)
 end
@@ -457,7 +521,11 @@ impl LobbyRemovalPlan {
 
 impl MatchCommitPlan {
     fn redis_keys(&self) -> Vec<&str> {
-        let mut keys = vec![self.active_matches_key.as_str(), self.outbox_key.as_str()];
+        let mut keys = vec![
+            self.active_matches_key.as_str(),
+            self.outbox_key.as_str(),
+            self.outbox_age_key.as_str(),
+        ];
         for lobby in &self.lobbies {
             keys.push(&lobby.active_game_key);
             keys.push(&lobby.metadata_key);
@@ -590,12 +658,14 @@ impl MatchmakingManager {
                         "Failed to add lobby to queue after {} attempts",
                         self.max_retries
                     );
+                    crate::resilience_metrics::record_matchmaking_error(1);
                     return Err(anyhow!("Failed to add lobby to queue: {}", e));
                 }
             }
         };
-        match code {
-            1 => {
+        match classify_atomic_matchmaking_outcome(code) {
+            Some(AtomicMatchmakingOutcome::Applied) => {
+                crate::resilience_metrics::record_matchmaking_admission(1);
                 info!(
                     "Added lobby {} to matchmaking queue for {:?} with {} members and avg MMR {}",
                     lobby_code,
@@ -604,16 +674,27 @@ impl MatchmakingManager {
                     avg_mmr
                 );
             }
-            2 => {
+            Some(AtomicMatchmakingOutcome::Idempotent) => {
+                crate::resilience_metrics::record_matchmaking_admission_deduplication(1);
                 info!(
                     lobby_code,
                     "Lobby already had an admitted queue identity; kept the first request"
                 );
             }
-            0 => return Err(anyhow!("Lobby admission was rejected: {detail}")),
-            other => {
+            Some(AtomicMatchmakingOutcome::ExpectedConflict) => {
+                crate::resilience_metrics::record_matchmaking_admission_rejection(1);
+                return Err(anyhow!("Lobby admission was rejected: {detail}"));
+            }
+            Some(AtomicMatchmakingOutcome::IntegrityError) => {
+                crate::resilience_metrics::record_matchmaking_error(1);
+                crate::resilience_metrics::record_matchmaking_integrity_error(1);
+                return Err(anyhow!("Lobby admission integrity failure: {detail}"));
+            }
+            None => {
+                crate::resilience_metrics::record_matchmaking_error(1);
+                crate::resilience_metrics::record_matchmaking_integrity_error(1);
                 return Err(anyhow!(
-                    "Lobby admission returned unknown status {other}: {detail}"
+                    "Lobby admission returned unknown status {code}: {detail}"
                 ));
             }
         }
@@ -936,7 +1017,9 @@ impl MatchmakingManager {
         let plan = MatchCommitPlan {
             active_matches_key: RedisKeys::matchmaking_active_matches(),
             outbox_key: RedisKeys::matchmaking_game_created_outbox(),
+            outbox_age_key: RedisKeys::matchmaking_game_created_outbox_age(),
             outbox_payload: serde_json::to_string(&outbox_record)?,
+            created_at_ms: match_info.created_at,
             game_id: game_id.to_string(),
             active_match_json: active_match_json.clone(),
             lobbies: commit_lobbies,
@@ -944,6 +1027,14 @@ impl MatchmakingManager {
             notifications,
         };
         let plan_json = serde_json::to_string(&plan)?;
+        let matched_players = match_info.players.len();
+        let matched_lobbies = lobbies.len();
+        let committed_at_ms = Utc::now().timestamp_millis();
+        let wait_ms = lobbies
+            .iter()
+            .map(|lobby| committed_at_ms.saturating_sub(lobby.queued_at).max(0) as u64)
+            .max()
+            .unwrap_or(0);
         let script = redis::Script::new(COMMIT_MATCH_SCRIPT);
         let mut attempts = 0;
         let mut delay = self.retry_delay;
@@ -982,23 +1073,40 @@ impl MatchmakingManager {
                     if matches!(existing, Ok(Some(ref value)) if value == &active_match_json) {
                         return Ok(MatchCommitOutcome::AlreadyCommitted);
                     }
+                    crate::resilience_metrics::record_matchmaking_error(1);
                     return Err(error).context("Failed to atomically commit matchmaking claim");
                 }
             }
         };
 
-        match code {
-            1 => Ok(MatchCommitOutcome::Committed { outbox_id: detail }),
-            2 => Ok(MatchCommitOutcome::AlreadyCommitted),
-            0 => {
+        match classify_atomic_matchmaking_outcome(code) {
+            Some(AtomicMatchmakingOutcome::Applied) => {
+                crate::resilience_metrics::record_matchmaking_commit(
+                    wait_ms,
+                    matched_players,
+                    matched_lobbies,
+                );
+                Ok(MatchCommitOutcome::Committed { outbox_id: detail })
+            }
+            Some(AtomicMatchmakingOutcome::Idempotent) => Ok(MatchCommitOutcome::AlreadyCommitted),
+            Some(AtomicMatchmakingOutcome::ExpectedConflict) => {
                 crate::resilience_metrics::record_match_claim_conflicts(1);
                 Ok(MatchCommitOutcome::Conflict { reason: detail })
             }
-            other => Err(anyhow!(
-                "Atomic matchmaking script returned unknown status {} ({})",
-                other,
-                detail
-            )),
+            Some(AtomicMatchmakingOutcome::IntegrityError) => {
+                crate::resilience_metrics::record_matchmaking_error(1);
+                crate::resilience_metrics::record_matchmaking_integrity_error(1);
+                Err(anyhow!("Atomic matchmaking integrity failure: {detail}"))
+            }
+            None => {
+                crate::resilience_metrics::record_matchmaking_error(1);
+                crate::resilience_metrics::record_matchmaking_integrity_error(1);
+                Err(anyhow!(
+                    "Atomic matchmaking script returned unknown status {} ({})",
+                    code,
+                    detail
+                ))
+            }
         }
     }
 
@@ -1035,13 +1143,28 @@ impl MatchmakingManager {
     ) -> Result<bool> {
         let result: i32 = redis::Script::new(
             r#"
+            local function key_type(key)
+                local response = redis.call('TYPE', key)
+                if type(response) == 'table' then return response['ok'] end
+                return response
+            end
+            local outbox_type = key_type(KEYS[1])
+            if outbox_type ~= 'none' and outbox_type ~= 'hash' then return -2 end
+            local age_type = key_type(KEYS[2])
+            if age_type ~= 'none' and age_type ~= 'zset' then return -3 end
             local current = redis.call('HGET', KEYS[1], ARGV[1])
-            if not current then return 0 end
+            if not current then
+                redis.call('ZREM', KEYS[2], ARGV[1])
+                return 0
+            end
             if current ~= ARGV[2] then return -1 end
-            return redis.call('HDEL', KEYS[1], ARGV[1])
+            redis.call('HDEL', KEYS[1], ARGV[1])
+            redis.call('ZREM', KEYS[2], ARGV[1])
+            return 1
             "#,
         )
         .key(RedisKeys::matchmaking_game_created_outbox())
+        .key(RedisKeys::matchmaking_game_created_outbox_age())
         .arg(game_id)
         .arg(expected_payload)
         .invoke_async(&mut self.redis)
@@ -1052,6 +1175,10 @@ impl MatchmakingManager {
             0 => Ok(false),
             -1 => Err(anyhow!(
                 "game-created outbox payload changed before acknowledgement"
+            )),
+            -2 => Err(anyhow!("game-created outbox has the wrong Redis type")),
+            -3 => Err(anyhow!(
+                "game-created outbox age index has the wrong Redis type"
             )),
             other => Err(anyhow!(
                 "game-created outbox acknowledgement returned {other}"
@@ -1091,6 +1218,27 @@ mod tests {
     use super::*;
     use crate::redis_utils;
     use redis::Client;
+
+    #[test]
+    fn atomic_script_codes_separate_expected_conflicts_from_integrity_errors() {
+        assert_eq!(
+            classify_atomic_matchmaking_outcome(0),
+            Some(AtomicMatchmakingOutcome::IntegrityError)
+        );
+        assert_eq!(
+            classify_atomic_matchmaking_outcome(1),
+            Some(AtomicMatchmakingOutcome::Applied)
+        );
+        assert_eq!(
+            classify_atomic_matchmaking_outcome(2),
+            Some(AtomicMatchmakingOutcome::Idempotent)
+        );
+        assert_eq!(
+            classify_atomic_matchmaking_outcome(3),
+            Some(AtomicMatchmakingOutcome::ExpectedConflict)
+        );
+        assert_eq!(classify_atomic_matchmaking_outcome(4), None);
+    }
 
     #[tokio::test]
     async fn test_redis_connection() {

--- a/server/src/redis_keys.rs
+++ b/server/src/redis_keys.rs
@@ -90,6 +90,16 @@ impl RedisKeys {
         )
     }
 
+    /// Creation-time index for exact oldest-age observation of the durable
+    /// GameCreated outbox. It shares the outbox hash slot so commit and
+    /// acknowledgement can maintain both structures atomically.
+    pub fn matchmaking_game_created_outbox_age() -> String {
+        format!(
+            "matchmaking:{{{}}}:game-created-outbox-age:v1",
+            Self::MATCHMAKING_TAG
+        )
+    }
+
     /// Partition-local idempotency marker for one outbox delivery.
     pub fn matchmaking_game_created_delivery(game_id: u32) -> String {
         let partition = Self::game_partition(game_id);
@@ -429,6 +439,7 @@ mod tests {
         assert_same_slot(&[
             RedisKeys::matchmaking_active_matches(),
             RedisKeys::matchmaking_game_created_outbox(),
+            RedisKeys::matchmaking_game_created_outbox_age(),
             RedisKeys::matchmaking_user_status(1),
             RedisKeys::matchmaking_user_active_game(1),
             RedisKeys::matchmaking_user_queue_identity(1),

--- a/server/src/redis_utils.rs
+++ b/server/src/redis_utils.rs
@@ -3,7 +3,7 @@ use redis::aio::{ConnectionLike, ConnectionManager, ConnectionManagerConfig};
 use redis::cluster::ClusterClient;
 use redis::cluster_async::ClusterConnection;
 use redis::{Client, PushInfo, RedisFuture, Value};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
@@ -118,18 +118,20 @@ impl RedisClient {
                 push_sender,
             } => {
                 let config = standalone_manager_config(push_sender.clone());
-                Ok(RedisConnection::StandaloneManaged(
-                    ConnectionManager::new_with_config(client.clone(), config)
-                        .await
-                        .context("failed to create standalone Redis connection manager")?,
+                Ok(RedisConnection::new(
+                    RedisConnectionInner::StandaloneManaged(
+                        ConnectionManager::new_with_config(client.clone(), config)
+                            .await
+                            .context("failed to create standalone Redis connection manager")?,
+                    ),
                 ))
             }
-            Self::Cluster(client) => Ok(RedisConnection::Cluster(
+            Self::Cluster(client) => Ok(RedisConnection::new(RedisConnectionInner::Cluster(
                 client
                     .get_async_connection()
                     .await
                     .context("failed to create Redis Cluster connection")?,
-            )),
+            ))),
         }
     }
 
@@ -138,18 +140,20 @@ impl RedisClient {
     /// the application's shared publisher connection.
     pub async fn get_dedicated_connection(&self) -> Result<RedisConnection> {
         match self {
-            Self::Standalone { client, .. } => Ok(RedisConnection::StandaloneMultiplexed(
-                client
-                    .get_multiplexed_async_connection()
-                    .await
-                    .context("failed to create dedicated standalone Redis connection")?,
+            Self::Standalone { client, .. } => Ok(RedisConnection::new(
+                RedisConnectionInner::StandaloneMultiplexed(
+                    client
+                        .get_multiplexed_async_connection()
+                        .await
+                        .context("failed to create dedicated standalone Redis connection")?,
+                ),
             )),
-            Self::Cluster(client) => Ok(RedisConnection::Cluster(
+            Self::Cluster(client) => Ok(RedisConnection::new(RedisConnectionInner::Cluster(
                 client
                     .get_async_connection()
                     .await
                     .context("failed to create dedicated Redis Cluster connection")?,
-            )),
+            ))),
         }
     }
 }
@@ -167,40 +171,118 @@ impl From<Client> for RedisClient {
 /// redis-rs' connection trait preserves `AsyncCommands`, `Script`, pipelines,
 /// and existing call sites while cluster routing stays encapsulated here.
 #[derive(Clone)]
-pub enum RedisConnection {
+enum RedisConnectionInner {
     StandaloneManaged(ConnectionManager),
     StandaloneMultiplexed(redis::aio::MultiplexedConnection),
     Cluster(ClusterConnection),
 }
 
+#[derive(Clone)]
+pub struct RedisConnection {
+    inner: RedisConnectionInner,
+    record_application_metrics: bool,
+}
+
+struct RedisRequestMeasurement {
+    started_at: Instant,
+    enabled: bool,
+    recorded: bool,
+}
+
+impl RedisRequestMeasurement {
+    fn new(enabled: bool) -> Self {
+        Self {
+            started_at: Instant::now(),
+            enabled,
+            recorded: false,
+        }
+    }
+
+    fn complete(&mut self, failed: bool) {
+        if self.enabled {
+            crate::resilience_metrics::record_redis_request(self.started_at.elapsed(), failed);
+        }
+        self.recorded = true;
+    }
+}
+
+impl Drop for RedisRequestMeasurement {
+    fn drop(&mut self) {
+        if self.enabled && !self.recorded {
+            // A caller-side timeout or cancellation drops the redis-rs future
+            // before it yields a RedisError. Treat that abandoned request as
+            // failed and retain the elapsed time observed by the application.
+            crate::resilience_metrics::record_redis_request(self.started_at.elapsed(), true);
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn drop_redis_request_measurement_for_test(enabled: bool) {
+    drop(RedisRequestMeasurement::new(enabled));
+}
+
 impl From<ConnectionManager> for RedisConnection {
     fn from(connection: ConnectionManager) -> Self {
-        Self::StandaloneManaged(connection)
+        Self {
+            inner: RedisConnectionInner::StandaloneManaged(connection),
+            record_application_metrics: true,
+        }
     }
 }
 
 impl RedisConnection {
+    fn new(inner: RedisConnectionInner) -> Self {
+        Self {
+            inner,
+            record_application_metrics: true,
+        }
+    }
+
+    /// Clone-derived connection dedicated to telemetry/control-plane reads.
+    /// Its commands remain functional but cannot recursively inflate the
+    /// application/cache Redis workload metrics they are collecting.
+    pub(crate) fn without_application_metrics(mut self) -> Self {
+        self.record_application_metrics = false;
+        self
+    }
+
     pub async fn subscribe(&mut self, channel: &str) -> redis::RedisResult<()> {
-        match self {
-            Self::StandaloneManaged(connection) => connection.subscribe(channel).await,
-            Self::Cluster(connection) => connection.subscribe(channel).await,
-            Self::StandaloneMultiplexed(connection) => {
+        let mut measurement = RedisRequestMeasurement::new(self.record_application_metrics);
+        let result = match &mut self.inner {
+            RedisConnectionInner::StandaloneManaged(connection) => {
+                connection.subscribe(channel).await
+            }
+            RedisConnectionInner::Cluster(connection) => connection.subscribe(channel).await,
+            RedisConnectionInner::StandaloneMultiplexed(connection) => {
                 redis::cmd("SUBSCRIBE")
                     .arg(channel)
                     .query_async(connection)
                     .await
             }
-        }
+        };
+        measurement.complete(result.is_err());
+        result
     }
 }
 
 impl ConnectionLike for RedisConnection {
     fn req_packed_command<'a>(&'a mut self, cmd: &'a redis::Cmd) -> RedisFuture<'a, Value> {
-        match self {
-            Self::StandaloneManaged(connection) => connection.req_packed_command(cmd),
-            Self::StandaloneMultiplexed(connection) => connection.req_packed_command(cmd),
-            Self::Cluster(connection) => connection.req_packed_command(cmd),
-        }
+        let mut measurement = RedisRequestMeasurement::new(self.record_application_metrics);
+        let request = match &mut self.inner {
+            RedisConnectionInner::StandaloneManaged(connection) => {
+                connection.req_packed_command(cmd)
+            }
+            RedisConnectionInner::StandaloneMultiplexed(connection) => {
+                connection.req_packed_command(cmd)
+            }
+            RedisConnectionInner::Cluster(connection) => connection.req_packed_command(cmd),
+        };
+        Box::pin(async move {
+            let result = request.await;
+            measurement.complete(result.is_err());
+            result
+        })
     }
 
     fn req_packed_commands<'a>(
@@ -209,22 +291,30 @@ impl ConnectionLike for RedisConnection {
         offset: usize,
         count: usize,
     ) -> RedisFuture<'a, Vec<Value>> {
-        match self {
-            Self::StandaloneManaged(connection) => {
+        let mut measurement = RedisRequestMeasurement::new(self.record_application_metrics);
+        let request = match &mut self.inner {
+            RedisConnectionInner::StandaloneManaged(connection) => {
                 connection.req_packed_commands(cmd, offset, count)
             }
-            Self::StandaloneMultiplexed(connection) => {
+            RedisConnectionInner::StandaloneMultiplexed(connection) => {
                 connection.req_packed_commands(cmd, offset, count)
             }
-            Self::Cluster(connection) => connection.req_packed_commands(cmd, offset, count),
-        }
+            RedisConnectionInner::Cluster(connection) => {
+                connection.req_packed_commands(cmd, offset, count)
+            }
+        };
+        Box::pin(async move {
+            let result = request.await;
+            measurement.complete(result.is_err());
+            result
+        })
     }
 
     fn get_db(&self) -> i64 {
-        match self {
-            Self::StandaloneManaged(connection) => connection.get_db(),
-            Self::StandaloneMultiplexed(connection) => connection.get_db(),
-            Self::Cluster(connection) => connection.get_db(),
+        match &self.inner {
+            RedisConnectionInner::StandaloneManaged(connection) => connection.get_db(),
+            RedisConnectionInner::StandaloneMultiplexed(connection) => connection.get_db(),
+            RedisConnectionInner::Cluster(connection) => connection.get_db(),
         }
     }
 }

--- a/server/src/resilience_metrics.rs
+++ b/server/src/resilience_metrics.rs
@@ -3,6 +3,10 @@
 //! Correctness must not depend on metrics. Collection therefore uses its own
 //! best-effort loop and never changes liveness or lease state when CloudWatch,
 //! Valkey, or stdout is unavailable.
+//!
+//! Count/sum/max components use independent atomics. A request concurrent with
+//! the interval snapshot can split those components across adjacent windows,
+//! so dashboard averages derived from them are approximate over short windows.
 
 use crate::cluster_membership::{
     ClusterNamespace, EXECUTOR_PROTOCOL_VERSION, MembershipStore, TaskLifecycle,
@@ -19,11 +23,13 @@ use serde_json::{Map, Value, json};
 use std::array;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 use tracing::warn;
 
-const EMF_NAMESPACE: &str = "Snaketron/Resilience";
+const PRODUCTION_EMF_NAMESPACE: &str = "Snaketron/Operational";
+const NON_PRODUCTION_EMF_NAMESPACE: &str = "Snaketron/OperationalDev";
 const DEFAULT_EMIT_INTERVAL_SECS: u64 = 15;
 const OWNERSHIP_SAMPLE_INTERVAL_MS: i64 = 500;
 // The exact regional scan performs roughly sixty independently routed cluster
@@ -34,6 +40,8 @@ const RECOVERY_METADATA_BATCH_SIZE: usize = 32;
 const RECOVERY_TAIL_SAMPLE_BYTES: i64 = 512;
 const CHECKPOINTED_AT_MARKER: &[u8] = b"\"checkpointed_at_ms\":";
 const SOURCE_LEASE_TOKEN_MARKER: &[u8] = b"\"source_lease_token\":\"";
+const MATCHMAKING_QUEUE_COUNT: usize = crate::matchmaking_manager::MATCHMAKING_GAME_TYPES.len()
+    * crate::matchmaking_manager::MATCHMAKING_QUEUE_MODES.len();
 
 #[derive(Default)]
 struct Counters {
@@ -51,6 +59,46 @@ struct Counters {
     recovery_replays: AtomicU64,
     match_claim_conflicts: AtomicU64,
     duplicate_completion_effects_prevented: AtomicU64,
+    http_requests: AtomicU64,
+    http_responses_4xx: AtomicU64,
+    http_responses_5xx: AtomicU64,
+    http_request_latency_ms_sum: AtomicU64,
+    http_request_latency_ms_max: AtomicU64,
+    websocket_opens: AtomicU64,
+    websocket_closes: AtomicU64,
+    websocket_rejected_upgrades: AtomicU64,
+    websocket_inbound_messages: AtomicU64,
+    websocket_inbound_bytes: AtomicU64,
+    websocket_outbound_messages: AtomicU64,
+    websocket_outbound_bytes: AtomicU64,
+    websocket_malformed_messages: AtomicU64,
+    websocket_process_errors: AtomicU64,
+    websocket_send_errors: AtomicU64,
+    websocket_transport_errors: AtomicU64,
+    websocket_session_duration_ms_sum: AtomicU64,
+    websocket_session_duration_ms_max: AtomicU64,
+    websocket_resync_requests: AtomicU64,
+    websocket_resync_accepted: AtomicU64,
+    websocket_resync_rejected: AtomicU64,
+    matchmaking_admissions: AtomicU64,
+    matchmaking_admission_deduplications: AtomicU64,
+    matchmaking_admission_rejections: AtomicU64,
+    matchmaking_commits: AtomicU64,
+    matchmaking_wait_ms_sum: AtomicU64,
+    matchmaking_wait_ms_max: AtomicU64,
+    matchmaking_matched_players: AtomicU64,
+    matchmaking_matched_lobbies: AtomicU64,
+    matchmaking_errors: AtomicU64,
+    matchmaking_integrity_errors: AtomicU64,
+    game_created_outbox_delivery_errors: AtomicU64,
+    games_completed: AtomicU64,
+    game_duration_ms_sum: AtomicU64,
+    game_duration_ms_max: AtomicU64,
+    completed_game_players: AtomicU64,
+    redis_requests: AtomicU64,
+    redis_errors: AtomicU64,
+    redis_request_latency_ms_sum: AtomicU64,
+    redis_request_latency_ms_max: AtomicU64,
 }
 
 static COUNTERS: OnceLock<Counters> = OnceLock::new();
@@ -88,6 +136,147 @@ counter_fn!(
     duplicate_completion_effects_prevented
 );
 
+counter_fn!(record_websocket_opened, websocket_opens);
+counter_fn!(record_websocket_closed, websocket_closes);
+counter_fn!(
+    record_websocket_rejected_upgrade,
+    websocket_rejected_upgrades
+);
+counter_fn!(
+    record_websocket_malformed_message,
+    websocket_malformed_messages
+);
+counter_fn!(record_websocket_process_error, websocket_process_errors);
+counter_fn!(record_websocket_send_error, websocket_send_errors);
+counter_fn!(record_websocket_transport_error, websocket_transport_errors);
+counter_fn!(record_websocket_resync_requested, websocket_resync_requests);
+counter_fn!(record_websocket_resync_accepted, websocket_resync_accepted);
+counter_fn!(record_websocket_resync_rejected, websocket_resync_rejected);
+counter_fn!(record_matchmaking_admission, matchmaking_admissions);
+counter_fn!(
+    record_matchmaking_admission_deduplication,
+    matchmaking_admission_deduplications
+);
+counter_fn!(
+    record_matchmaking_admission_rejection,
+    matchmaking_admission_rejections
+);
+counter_fn!(record_matchmaking_error, matchmaking_errors);
+counter_fn!(
+    record_matchmaking_integrity_error,
+    matchmaking_integrity_errors
+);
+counter_fn!(
+    record_game_created_outbox_delivery_error,
+    game_created_outbox_delivery_errors
+);
+
+fn saturating_u64(value: usize) -> u64 {
+    u64::try_from(value).unwrap_or(u64::MAX)
+}
+
+fn duration_ms(duration: Duration) -> u64 {
+    u64::try_from(duration.as_millis()).unwrap_or(u64::MAX)
+}
+
+fn record_sum_and_max(sum: &AtomicU64, max: &AtomicU64, value: u64) {
+    sum.fetch_add(value, Ordering::Relaxed);
+    max.fetch_max(value, Ordering::Relaxed);
+}
+
+pub fn record_http_request(status_code: u16, latency: Duration) {
+    let counters = counters();
+    counters.http_requests.fetch_add(1, Ordering::Relaxed);
+    if (400..500).contains(&status_code) {
+        counters.http_responses_4xx.fetch_add(1, Ordering::Relaxed);
+    } else if status_code >= 500 {
+        counters.http_responses_5xx.fetch_add(1, Ordering::Relaxed);
+    }
+    record_sum_and_max(
+        &counters.http_request_latency_ms_sum,
+        &counters.http_request_latency_ms_max,
+        duration_ms(latency),
+    );
+}
+
+pub fn record_websocket_inbound_message(bytes: usize) {
+    let counters = counters();
+    counters
+        .websocket_inbound_messages
+        .fetch_add(1, Ordering::Relaxed);
+    counters
+        .websocket_inbound_bytes
+        .fetch_add(saturating_u64(bytes), Ordering::Relaxed);
+}
+
+pub fn record_websocket_outbound_message(bytes: usize) {
+    let counters = counters();
+    counters
+        .websocket_outbound_messages
+        .fetch_add(1, Ordering::Relaxed);
+    counters
+        .websocket_outbound_bytes
+        .fetch_add(saturating_u64(bytes), Ordering::Relaxed);
+}
+
+pub fn record_websocket_session(duration: Duration) {
+    let counters = counters();
+    record_sum_and_max(
+        &counters.websocket_session_duration_ms_sum,
+        &counters.websocket_session_duration_ms_max,
+        duration_ms(duration),
+    );
+}
+
+pub fn record_matchmaking_commit(wait_ms: u64, players: usize, lobbies: usize) {
+    // Only a newly committed response observed by this process reaches here.
+    // An ambiguous success recovered as AlreadyCommitted is omitted rather
+    // than risking double-counting the match and its players.
+    let counters = counters();
+    counters.matchmaking_commits.fetch_add(1, Ordering::Relaxed);
+    counters
+        .matchmaking_matched_players
+        .fetch_add(saturating_u64(players), Ordering::Relaxed);
+    counters
+        .matchmaking_matched_lobbies
+        .fetch_add(saturating_u64(lobbies), Ordering::Relaxed);
+    record_sum_and_max(
+        &counters.matchmaking_wait_ms_sum,
+        &counters.matchmaking_wait_ms_max,
+        wait_ms,
+    );
+}
+
+pub fn record_game_completed(duration_ms: u64, players: usize) {
+    // Only a newly committed response observed by this process reaches here.
+    // Recovery of an ambiguous success remains uncounted because completion
+    // does not carry a durable telemetry marker.
+    let counters = counters();
+    counters.games_completed.fetch_add(1, Ordering::Relaxed);
+    counters
+        .completed_game_players
+        .fetch_add(saturating_u64(players), Ordering::Relaxed);
+    record_sum_and_max(
+        &counters.game_duration_ms_sum,
+        &counters.game_duration_ms_max,
+        duration_ms,
+    );
+}
+
+pub fn record_redis_request(latency: Duration, failed: bool) {
+    let counters = counters();
+    counters.redis_requests.fetch_add(1, Ordering::Relaxed);
+    if failed {
+        counters.redis_errors.fetch_add(1, Ordering::Relaxed);
+    }
+    record_sum_and_max(
+        &counters.redis_request_latency_ms_sum,
+        &counters.redis_request_latency_ms_max,
+        duration_ms(latency),
+    );
+}
+
+#[derive(Default)]
 struct CounterSnapshot {
     fenced_write_rejections: u64,
     recovery_fingerprint_divergences: u64,
@@ -103,6 +292,46 @@ struct CounterSnapshot {
     recovery_replays: u64,
     match_claim_conflicts: u64,
     duplicate_completion_effects_prevented: u64,
+    http_requests: u64,
+    http_responses_4xx: u64,
+    http_responses_5xx: u64,
+    http_request_latency_ms_sum: u64,
+    http_request_latency_ms_max: u64,
+    websocket_opens: u64,
+    websocket_closes: u64,
+    websocket_rejected_upgrades: u64,
+    websocket_inbound_messages: u64,
+    websocket_inbound_bytes: u64,
+    websocket_outbound_messages: u64,
+    websocket_outbound_bytes: u64,
+    websocket_malformed_messages: u64,
+    websocket_process_errors: u64,
+    websocket_send_errors: u64,
+    websocket_transport_errors: u64,
+    websocket_session_duration_ms_sum: u64,
+    websocket_session_duration_ms_max: u64,
+    websocket_resync_requests: u64,
+    websocket_resync_accepted: u64,
+    websocket_resync_rejected: u64,
+    matchmaking_admissions: u64,
+    matchmaking_admission_deduplications: u64,
+    matchmaking_admission_rejections: u64,
+    matchmaking_commits: u64,
+    matchmaking_wait_ms_sum: u64,
+    matchmaking_wait_ms_max: u64,
+    matchmaking_matched_players: u64,
+    matchmaking_matched_lobbies: u64,
+    matchmaking_errors: u64,
+    matchmaking_integrity_errors: u64,
+    game_created_outbox_delivery_errors: u64,
+    games_completed: u64,
+    game_duration_ms_sum: u64,
+    game_duration_ms_max: u64,
+    completed_game_players: u64,
+    redis_requests: u64,
+    redis_errors: u64,
+    redis_request_latency_ms_sum: u64,
+    redis_request_latency_ms_max: u64,
 }
 
 fn take_counter_snapshot() -> CounterSnapshot {
@@ -125,6 +354,86 @@ fn take_counter_snapshot() -> CounterSnapshot {
         match_claim_conflicts: counters.match_claim_conflicts.swap(0, Ordering::Relaxed),
         duplicate_completion_effects_prevented: counters
             .duplicate_completion_effects_prevented
+            .swap(0, Ordering::Relaxed),
+        http_requests: counters.http_requests.swap(0, Ordering::Relaxed),
+        http_responses_4xx: counters.http_responses_4xx.swap(0, Ordering::Relaxed),
+        http_responses_5xx: counters.http_responses_5xx.swap(0, Ordering::Relaxed),
+        http_request_latency_ms_sum: counters
+            .http_request_latency_ms_sum
+            .swap(0, Ordering::Relaxed),
+        http_request_latency_ms_max: counters
+            .http_request_latency_ms_max
+            .swap(0, Ordering::Relaxed),
+        websocket_opens: counters.websocket_opens.swap(0, Ordering::Relaxed),
+        websocket_closes: counters.websocket_closes.swap(0, Ordering::Relaxed),
+        websocket_rejected_upgrades: counters
+            .websocket_rejected_upgrades
+            .swap(0, Ordering::Relaxed),
+        websocket_inbound_messages: counters
+            .websocket_inbound_messages
+            .swap(0, Ordering::Relaxed),
+        websocket_inbound_bytes: counters.websocket_inbound_bytes.swap(0, Ordering::Relaxed),
+        websocket_outbound_messages: counters
+            .websocket_outbound_messages
+            .swap(0, Ordering::Relaxed),
+        websocket_outbound_bytes: counters.websocket_outbound_bytes.swap(0, Ordering::Relaxed),
+        websocket_malformed_messages: counters
+            .websocket_malformed_messages
+            .swap(0, Ordering::Relaxed),
+        websocket_process_errors: counters.websocket_process_errors.swap(0, Ordering::Relaxed),
+        websocket_send_errors: counters.websocket_send_errors.swap(0, Ordering::Relaxed),
+        websocket_transport_errors: counters
+            .websocket_transport_errors
+            .swap(0, Ordering::Relaxed),
+        websocket_session_duration_ms_sum: counters
+            .websocket_session_duration_ms_sum
+            .swap(0, Ordering::Relaxed),
+        websocket_session_duration_ms_max: counters
+            .websocket_session_duration_ms_max
+            .swap(0, Ordering::Relaxed),
+        websocket_resync_requests: counters
+            .websocket_resync_requests
+            .swap(0, Ordering::Relaxed),
+        websocket_resync_accepted: counters
+            .websocket_resync_accepted
+            .swap(0, Ordering::Relaxed),
+        websocket_resync_rejected: counters
+            .websocket_resync_rejected
+            .swap(0, Ordering::Relaxed),
+        matchmaking_admissions: counters.matchmaking_admissions.swap(0, Ordering::Relaxed),
+        matchmaking_admission_deduplications: counters
+            .matchmaking_admission_deduplications
+            .swap(0, Ordering::Relaxed),
+        matchmaking_admission_rejections: counters
+            .matchmaking_admission_rejections
+            .swap(0, Ordering::Relaxed),
+        matchmaking_commits: counters.matchmaking_commits.swap(0, Ordering::Relaxed),
+        matchmaking_wait_ms_sum: counters.matchmaking_wait_ms_sum.swap(0, Ordering::Relaxed),
+        matchmaking_wait_ms_max: counters.matchmaking_wait_ms_max.swap(0, Ordering::Relaxed),
+        matchmaking_matched_players: counters
+            .matchmaking_matched_players
+            .swap(0, Ordering::Relaxed),
+        matchmaking_matched_lobbies: counters
+            .matchmaking_matched_lobbies
+            .swap(0, Ordering::Relaxed),
+        matchmaking_errors: counters.matchmaking_errors.swap(0, Ordering::Relaxed),
+        matchmaking_integrity_errors: counters
+            .matchmaking_integrity_errors
+            .swap(0, Ordering::Relaxed),
+        game_created_outbox_delivery_errors: counters
+            .game_created_outbox_delivery_errors
+            .swap(0, Ordering::Relaxed),
+        games_completed: counters.games_completed.swap(0, Ordering::Relaxed),
+        game_duration_ms_sum: counters.game_duration_ms_sum.swap(0, Ordering::Relaxed),
+        game_duration_ms_max: counters.game_duration_ms_max.swap(0, Ordering::Relaxed),
+        completed_game_players: counters.completed_game_players.swap(0, Ordering::Relaxed),
+        redis_requests: counters.redis_requests.swap(0, Ordering::Relaxed),
+        redis_errors: counters.redis_errors.swap(0, Ordering::Relaxed),
+        redis_request_latency_ms_sum: counters
+            .redis_request_latency_ms_sum
+            .swap(0, Ordering::Relaxed),
+        redis_request_latency_ms_max: counters
+            .redis_request_latency_ms_max
             .swap(0, Ordering::Relaxed),
     }
 }
@@ -151,6 +460,109 @@ struct RegionalGauges {
     checkpoint_bytes: u64,
     active_games: u64,
     active_game_index_mismatches: u64,
+    matchmaking_queue_entries: u64,
+    matchmaking_oldest_queued_lobby_ms: u64,
+    game_created_outbox_backlog: u64,
+    game_created_outbox_oldest_age_ms: u64,
+    game_created_outbox_age_index_cardinality_delta: u64,
+}
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct MatchmakingBacklogGauges {
+    queue_entries: u64,
+    oldest_queued_lobby_ms: u64,
+    outbox_backlog: u64,
+    outbox_oldest_age_ms: u64,
+    outbox_age_index_cardinality_delta: u64,
+}
+
+fn summarize_matchmaking_backlogs(values: &[i64], now_ms: i64) -> Result<MatchmakingBacklogGauges> {
+    let expected_values = MATCHMAKING_QUEUE_COUNT * 2 + 3;
+    if values.len() != expected_values {
+        anyhow::bail!(
+            "matchmaking backlog summary returned {} values, expected {expected_values}",
+            values.len()
+        );
+    }
+    let mut summary = MatchmakingBacklogGauges::default();
+    for queue in values[..MATCHMAKING_QUEUE_COUNT * 2].chunks_exact(2) {
+        let entries = u64::try_from(queue[0]).context("negative matchmaking queue depth")?;
+        summary.queue_entries = summary.queue_entries.saturating_add(entries);
+        if queue[1] > 0 {
+            summary.oldest_queued_lobby_ms = summary
+                .oldest_queued_lobby_ms
+                .max(now_ms.saturating_sub(queue[1]).max(0) as u64);
+        }
+    }
+    let tail = &values[MATCHMAKING_QUEUE_COUNT * 2..];
+    let outbox_backlog = u64::try_from(tail[0]).context("negative GameCreated outbox depth")?;
+    let indexed_outbox = u64::try_from(tail[1]).context("negative outbox age-index depth")?;
+    summary.outbox_backlog = outbox_backlog;
+    summary.outbox_age_index_cardinality_delta = outbox_backlog.abs_diff(indexed_outbox);
+    if tail[2] > 0 {
+        summary.outbox_oldest_age_ms = now_ms.saturating_sub(tail[2]).max(0) as u64;
+    }
+    Ok(summary)
+}
+
+async fn collect_matchmaking_backlog_gauges(
+    redis: &mut RedisConnection,
+    now_ms: i64,
+) -> Result<MatchmakingBacklogGauges> {
+    // Every key shares the fixed matchmaking hash tag, so this bounded script
+    // is one routed operation regardless of queue depth. Queue counts are
+    // entry counts: one lobby intentionally appears in each selected game-mode
+    // queue and may therefore contribute more than once.
+    let script = redis::Script::new(
+        r#"
+        local function key_type(key)
+            local response = redis.call('TYPE', key)
+            if type(response) == 'table' then return response['ok'] end
+            return response
+        end
+        local result = {}
+        for index = 1, #KEYS - 2 do
+            local queue_type = key_type(KEYS[index])
+            if queue_type ~= 'none' and queue_type ~= 'zset' then
+                return redis.error_reply('matchmaking queue has wrong type')
+            end
+            table.insert(result, redis.call('ZCARD', KEYS[index]))
+            local oldest = redis.call('ZRANGE', KEYS[index], 0, 0, 'WITHSCORES')
+            table.insert(result, #oldest == 0 and 0 or tonumber(oldest[2]))
+        end
+        local outbox_key = KEYS[#KEYS - 1]
+        local age_key = KEYS[#KEYS]
+        local outbox_type = key_type(outbox_key)
+        if outbox_type ~= 'none' and outbox_type ~= 'hash' then
+            return redis.error_reply('GameCreated outbox has wrong type')
+        end
+        local age_type = key_type(age_key)
+        if age_type ~= 'none' and age_type ~= 'zset' then
+            return redis.error_reply('GameCreated outbox age index has wrong type')
+        end
+        table.insert(result, redis.call('HLEN', outbox_key))
+        table.insert(result, redis.call('ZCARD', age_key))
+        local oldest_outbox = redis.call('ZRANGE', age_key, 0, 0, 'WITHSCORES')
+        table.insert(result, #oldest_outbox == 0 and 0 or tonumber(oldest_outbox[2]))
+        return result
+        "#,
+    );
+    let mut invocation = script.prepare_invoke();
+    for game_type in &crate::matchmaking_manager::MATCHMAKING_GAME_TYPES {
+        for queue_mode in &crate::matchmaking_manager::MATCHMAKING_QUEUE_MODES {
+            invocation.key(crate::redis_keys::RedisKeys::matchmaking_lobby_queue(
+                game_type, queue_mode,
+            ));
+        }
+    }
+    invocation
+        .key(crate::redis_keys::RedisKeys::matchmaking_game_created_outbox())
+        .key(crate::redis_keys::RedisKeys::matchmaking_game_created_outbox_age());
+    let values: Vec<i64> = invocation
+        .invoke_async(redis)
+        .await
+        .context("failed to collect matchmaking backlog gauges")?;
+    summarize_matchmaking_backlogs(&values, now_ms)
 }
 
 fn expected_recovery_prefix(partition: u32, game_id: u32) -> String {
@@ -281,7 +693,11 @@ impl PartitionOutageTracker {
 
 /// Starts a best-effort collector. One deterministic live task reports the
 /// regional gauges while every task reports local health and counters, so
-/// CloudWatch uses `Maximum` for regional gauges and `Sum` for counters.
+/// CloudWatch uses `Maximum` for regional gauges and `Sum` for counters. The
+/// active-WebSocket gauge is emitted separately per task so dashboards can
+/// sum per-task `Average` for minute-average fleet concurrency. Summed
+/// per-task `Maximum` is only a conservative upper bound because task peaks
+/// need not occur simultaneously.
 /// Dimensions deliberately exclude partitions, users, and games.
 pub fn spawn_resilience_metrics(
     redis: RedisConnection,
@@ -290,6 +706,10 @@ pub fn spawn_resilience_metrics(
     server_id: u64,
     cancellation: CancellationToken,
 ) -> JoinHandle<()> {
+    // Every clone derived below is collector-only. Excluding these reads keeps
+    // RedisRequests/RedisErrors/latency representative of application and
+    // gameplay cache work instead of recursively measuring the sampler.
+    let redis = redis.without_application_metrics();
     let environment =
         std::env::var("SNAKETRON_ENVIRONMENT").unwrap_or_else(|_| "development".to_string());
     let task_boot_id = lifecycle.task_boot_id().to_string();
@@ -519,6 +939,14 @@ async fn collect_regional_gauges(
         return Ok(gauges);
     }
 
+    let matchmaking = collect_matchmaking_backlog_gauges(&mut redis, now_ms).await?;
+    gauges.matchmaking_queue_entries = matchmaking.queue_entries;
+    gauges.matchmaking_oldest_queued_lobby_ms = matchmaking.oldest_queued_lobby_ms;
+    gauges.game_created_outbox_backlog = matchmaking.outbox_backlog;
+    gauges.game_created_outbox_oldest_age_ms = matchmaking.outbox_oldest_age_ms;
+    gauges.game_created_outbox_age_index_cardinality_delta =
+        matchmaking.outbox_age_index_cardinality_delta;
+
     let assignment = assignment_store.load().await?;
     if let Some(assignment) = &assignment {
         gauges.assignment_version = assignment.version;
@@ -698,17 +1126,25 @@ fn metric(name: &str, unit: &str) -> Value {
     json!({ "Name": name, "Unit": unit })
 }
 
+fn emf_namespace(environment: &str) -> &'static str {
+    if environment == "prod" {
+        PRODUCTION_EMF_NAMESPACE
+    } else {
+        NON_PRODUCTION_EMF_NAMESPACE
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
-fn emit_emf(
+fn emf_document(
     environment: &str,
     region: &str,
     task_boot_id: &str,
     local_ready: bool,
-    active_websockets: u64,
     gauges: RegionalGauges,
     counters: CounterSnapshot,
     now_ms: i64,
-) {
+) -> Value {
+    let namespace = emf_namespace(environment);
     let values = [
         (
             "RegionalCollectionFailures",
@@ -759,6 +1195,31 @@ fn emit_emf(
             "Count",
         ),
         (
+            "MatchmakingQueueEntries",
+            gauges.matchmaking_queue_entries,
+            "Count",
+        ),
+        (
+            "MatchmakingOldestQueuedLobbyMs",
+            gauges.matchmaking_oldest_queued_lobby_ms,
+            "Milliseconds",
+        ),
+        (
+            "GameCreatedOutboxBacklog",
+            gauges.game_created_outbox_backlog,
+            "Count",
+        ),
+        (
+            "GameCreatedOutboxOldestAgeMs",
+            gauges.game_created_outbox_oldest_age_ms,
+            "Milliseconds",
+        ),
+        (
+            "GameCreatedOutboxAgeIndexCardinalityDelta",
+            gauges.game_created_outbox_age_index_cardinality_delta,
+            "Count",
+        ),
+        (
             "FencedWriteRejections",
             counters.fenced_write_rejections,
             "Count",
@@ -796,8 +1257,167 @@ fn emit_emf(
             counters.duplicate_completion_effects_prevented,
             "Count",
         ),
+        ("HttpRequests", counters.http_requests, "Count"),
+        ("Http4xxResponses", counters.http_responses_4xx, "Count"),
+        ("Http5xxResponses", counters.http_responses_5xx, "Count"),
+        (
+            "HttpRequestLatencyMsSum",
+            counters.http_request_latency_ms_sum,
+            "Milliseconds",
+        ),
+        (
+            "HttpRequestLatencyMsMax",
+            counters.http_request_latency_ms_max,
+            "Milliseconds",
+        ),
+        ("WebSocketOpens", counters.websocket_opens, "Count"),
+        ("WebSocketCloses", counters.websocket_closes, "Count"),
+        (
+            "WebSocketRejectedUpgrades",
+            counters.websocket_rejected_upgrades,
+            "Count",
+        ),
+        (
+            "WebSocketInboundMessages",
+            counters.websocket_inbound_messages,
+            "Count",
+        ),
+        (
+            "WebSocketInboundBytes",
+            counters.websocket_inbound_bytes,
+            "Bytes",
+        ),
+        (
+            "WebSocketOutboundMessages",
+            counters.websocket_outbound_messages,
+            "Count",
+        ),
+        (
+            "WebSocketOutboundBytes",
+            counters.websocket_outbound_bytes,
+            "Bytes",
+        ),
+        (
+            "WebSocketMalformedMessages",
+            counters.websocket_malformed_messages,
+            "Count",
+        ),
+        (
+            "WebSocketProcessErrors",
+            counters.websocket_process_errors,
+            "Count",
+        ),
+        (
+            "WebSocketSendErrors",
+            counters.websocket_send_errors,
+            "Count",
+        ),
+        (
+            "WebSocketTransportErrors",
+            counters.websocket_transport_errors,
+            "Count",
+        ),
+        (
+            "WebSocketSessionDurationMsSum",
+            counters.websocket_session_duration_ms_sum,
+            "Milliseconds",
+        ),
+        (
+            "WebSocketSessionDurationMsMax",
+            counters.websocket_session_duration_ms_max,
+            "Milliseconds",
+        ),
+        (
+            "WebSocketResyncRequests",
+            counters.websocket_resync_requests,
+            "Count",
+        ),
+        (
+            "WebSocketResyncAccepted",
+            counters.websocket_resync_accepted,
+            "Count",
+        ),
+        (
+            "WebSocketResyncRejected",
+            counters.websocket_resync_rejected,
+            "Count",
+        ),
+        (
+            "MatchmakingAdmissions",
+            counters.matchmaking_admissions,
+            "Count",
+        ),
+        (
+            "MatchmakingAdmissionDeduplications",
+            counters.matchmaking_admission_deduplications,
+            "Count",
+        ),
+        (
+            "MatchmakingAdmissionRejections",
+            counters.matchmaking_admission_rejections,
+            "Count",
+        ),
+        ("MatchmakingCommits", counters.matchmaking_commits, "Count"),
+        (
+            "MatchmakingWaitMsSum",
+            counters.matchmaking_wait_ms_sum,
+            "Milliseconds",
+        ),
+        (
+            "MatchmakingWaitMsMax",
+            counters.matchmaking_wait_ms_max,
+            "Milliseconds",
+        ),
+        (
+            "MatchmakingMatchedPlayers",
+            counters.matchmaking_matched_players,
+            "Count",
+        ),
+        (
+            "MatchmakingMatchedLobbies",
+            counters.matchmaking_matched_lobbies,
+            "Count",
+        ),
+        ("MatchmakingErrors", counters.matchmaking_errors, "Count"),
+        (
+            "MatchmakingIntegrityErrors",
+            counters.matchmaking_integrity_errors,
+            "Count",
+        ),
+        (
+            "GameCreatedOutboxDeliveryErrors",
+            counters.game_created_outbox_delivery_errors,
+            "Count",
+        ),
+        ("GamesCompleted", counters.games_completed, "Count"),
+        (
+            "GameDurationMsSum",
+            counters.game_duration_ms_sum,
+            "Milliseconds",
+        ),
+        (
+            "GameDurationMsMax",
+            counters.game_duration_ms_max,
+            "Milliseconds",
+        ),
+        (
+            "CompletedGamePlayers",
+            counters.completed_game_players,
+            "Count",
+        ),
+        ("RedisRequests", counters.redis_requests, "Count"),
+        ("RedisErrors", counters.redis_errors, "Count"),
+        (
+            "RedisRequestLatencyMsSum",
+            counters.redis_request_latency_ms_sum,
+            "Milliseconds",
+        ),
+        (
+            "RedisRequestLatencyMsMax",
+            counters.redis_request_latency_ms_max,
+            "Milliseconds",
+        ),
         ("LocalReady", u64::from(local_ready), "Count"),
-        ("ActiveWebSockets", active_websockets, "Count"),
     ];
     let definitions: Vec<Value> = values
         .iter()
@@ -815,16 +1435,75 @@ fn emit_emf(
         json!({
             "Timestamp": now_ms,
             "CloudWatchMetrics": [{
-                "Namespace": EMF_NAMESPACE,
+                "Namespace": namespace,
                 "Dimensions": [
                     ["Environment"],
-                    ["Environment", "Region", "TaskBootId"]
+                    ["Environment", "Region"]
                 ],
                 "Metrics": definitions
             }]
         }),
     );
-    println!("{}", Value::Object(document));
+    Value::Object(document)
+}
+
+fn active_websockets_emf_document(
+    environment: &str,
+    region: &str,
+    task_boot_id: &str,
+    active_websockets: u64,
+    now_ms: i64,
+) -> Value {
+    let namespace = emf_namespace(environment);
+    json!({
+        "Environment": environment,
+        "Region": region,
+        "TaskBootId": task_boot_id,
+        "ActiveWebSockets": active_websockets,
+        "_aws": {
+            "Timestamp": now_ms,
+            "CloudWatchMetrics": [{
+                "Namespace": namespace,
+                "Dimensions": [["Environment", "Region", "TaskBootId"]],
+                "Metrics": [metric("ActiveWebSockets", "Count")]
+            }]
+        }
+    })
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_emf(
+    environment: &str,
+    region: &str,
+    task_boot_id: &str,
+    local_ready: bool,
+    active_websockets: u64,
+    gauges: RegionalGauges,
+    counters: CounterSnapshot,
+    now_ms: i64,
+) {
+    println!(
+        "{}",
+        emf_document(
+            environment,
+            region,
+            task_boot_id,
+            local_ready,
+            gauges,
+            counters,
+            now_ms,
+        )
+    );
+    println!(
+        "{}",
+        active_websockets_emf_document(
+            environment,
+            region,
+            task_boot_id,
+            active_websockets,
+            now_ms,
+        )
+    );
 }
 
 #[cfg(test)]
@@ -844,10 +1523,153 @@ mod tests {
         let _ = take_counter_snapshot();
         record_fenced_write_rejection(1);
         record_checkpoint_writes(2);
+        record_http_request(204, Duration::from_millis(7));
+        record_http_request(404, Duration::from_millis(11));
+        record_http_request(503, Duration::from_millis(17));
+        record_websocket_opened(1);
+        record_websocket_closed(1);
+        record_websocket_rejected_upgrade(1);
+        record_websocket_inbound_message(12);
+        record_websocket_outbound_message(34);
+        record_websocket_malformed_message(1);
+        record_websocket_process_error(1);
+        record_websocket_send_error(1);
+        record_websocket_transport_error(1);
+        record_websocket_session(Duration::from_millis(19));
+        record_websocket_resync_requested(2);
+        record_websocket_resync_accepted(1);
+        record_websocket_resync_rejected(1);
+        record_matchmaking_admission(1);
+        record_matchmaking_admission_deduplication(1);
+        record_matchmaking_admission_rejection(1);
+        record_matchmaking_commit(250, 4, 2);
+        record_matchmaking_error(1);
+        record_matchmaking_integrity_error(1);
+        record_game_created_outbox_delivery_error(1);
+        record_game_completed(3_000, 4);
+        record_redis_request(Duration::from_millis(9), true);
+        crate::redis_utils::drop_redis_request_measurement_for_test(true);
+        crate::redis_utils::drop_redis_request_measurement_for_test(false);
         let snapshot = take_counter_snapshot();
         assert_eq!(snapshot.fenced_write_rejections, 1);
         assert_eq!(snapshot.checkpoint_writes, 2);
+        assert!(snapshot.http_requests >= 3);
+        assert!(snapshot.http_responses_4xx >= 1);
+        assert!(snapshot.http_responses_5xx >= 1);
+        assert!(snapshot.http_request_latency_ms_sum >= 35);
+        assert!(snapshot.http_request_latency_ms_max >= 17);
+        assert!(snapshot.websocket_opens >= 1);
+        assert!(snapshot.websocket_closes >= 1);
+        assert!(snapshot.websocket_rejected_upgrades >= 1);
+        assert!(snapshot.websocket_inbound_messages >= 1);
+        assert!(snapshot.websocket_inbound_bytes >= 12);
+        assert!(snapshot.websocket_outbound_messages >= 1);
+        assert!(snapshot.websocket_outbound_bytes >= 34);
+        assert!(snapshot.websocket_malformed_messages >= 1);
+        assert!(snapshot.websocket_process_errors >= 1);
+        assert!(snapshot.websocket_send_errors >= 1);
+        assert!(snapshot.websocket_transport_errors >= 1);
+        assert!(snapshot.websocket_session_duration_ms_sum >= 19);
+        assert!(snapshot.websocket_session_duration_ms_max >= 19);
+        assert!(snapshot.websocket_resync_requests >= 2);
+        assert!(snapshot.websocket_resync_accepted >= 1);
+        assert!(snapshot.websocket_resync_rejected >= 1);
+        assert!(snapshot.matchmaking_admissions >= 1);
+        assert!(snapshot.matchmaking_admission_deduplications >= 1);
+        assert!(snapshot.matchmaking_admission_rejections >= 1);
+        assert!(snapshot.matchmaking_commits >= 1);
+        assert!(snapshot.matchmaking_wait_ms_sum >= 250);
+        assert!(snapshot.matchmaking_wait_ms_max >= 250);
+        assert!(snapshot.matchmaking_matched_players >= 4);
+        assert!(snapshot.matchmaking_matched_lobbies >= 2);
+        assert!(snapshot.matchmaking_errors >= 1);
+        assert!(snapshot.matchmaking_integrity_errors >= 1);
+        assert!(snapshot.game_created_outbox_delivery_errors >= 1);
+        assert!(snapshot.games_completed >= 1);
+        assert!(snapshot.game_duration_ms_sum >= 3_000);
+        assert!(snapshot.game_duration_ms_max >= 3_000);
+        assert!(snapshot.completed_game_players >= 4);
+        assert!(snapshot.redis_requests >= 2);
+        assert!(snapshot.redis_errors >= 2);
+        assert!(snapshot.redis_request_latency_ms_sum >= 9);
+        assert!(snapshot.redis_request_latency_ms_max >= 9);
         assert_eq!(take_counter_snapshot().checkpoint_writes, 0);
+    }
+
+    #[test]
+    fn matchmaking_backlog_summary_aggregates_fixed_queues_and_exact_ages() -> Result<()> {
+        let now_ms = 10_000_i64;
+        let mut values = Vec::with_capacity(MATCHMAKING_QUEUE_COUNT * 2 + 3);
+        for index in 0..MATCHMAKING_QUEUE_COUNT {
+            values.push(i64::try_from(index + 1)?);
+            values.push(now_ms - i64::try_from((index + 1) * 100)?);
+        }
+        values.extend([3, 2, now_ms - 2_000]);
+
+        assert_eq!(
+            summarize_matchmaking_backlogs(&values, now_ms)?,
+            MatchmakingBacklogGauges {
+                queue_entries: 55,
+                oldest_queued_lobby_ms: 1_000,
+                outbox_backlog: 3,
+                outbox_oldest_age_ms: 2_000,
+                outbox_age_index_cardinality_delta: 1,
+            }
+        );
+        assert!(summarize_matchmaking_backlogs(&values[..values.len() - 1], now_ms).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn emf_dimensions_keep_only_websocket_gauge_per_task() {
+        let main = emf_document(
+            "test",
+            "us-test-1",
+            "boot-id",
+            true,
+            RegionalGauges::default(),
+            CounterSnapshot::default(),
+            123,
+        );
+        assert_eq!(
+            main.pointer("/_aws/CloudWatchMetrics/0/Dimensions"),
+            Some(&json!([["Environment"], ["Environment", "Region"]])),
+        );
+        assert_eq!(
+            main.pointer("/_aws/CloudWatchMetrics/0/Namespace"),
+            Some(&json!("Snaketron/OperationalDev")),
+        );
+        let main_metrics = main
+            .pointer("/_aws/CloudWatchMetrics/0/Metrics")
+            .and_then(Value::as_array)
+            .expect("main EMF metric definitions");
+        assert!(main_metrics.len() <= 100);
+        assert!(
+            main_metrics
+                .iter()
+                .all(|definition| definition["Name"] != "ActiveWebSockets")
+        );
+
+        let sockets = active_websockets_emf_document("test", "us-test-1", "boot-id", 7, 123);
+        assert_eq!(
+            sockets.pointer("/_aws/CloudWatchMetrics/0/Dimensions"),
+            Some(&json!([["Environment", "Region", "TaskBootId"]])),
+        );
+        assert_eq!(
+            sockets.pointer("/_aws/CloudWatchMetrics/0/Namespace"),
+            Some(&json!("Snaketron/OperationalDev")),
+        );
+        assert_eq!(sockets["ActiveWebSockets"], 7);
+        assert_eq!(
+            sockets.pointer("/_aws/CloudWatchMetrics/0/Metrics/0/Name"),
+            Some(&json!("ActiveWebSockets")),
+        );
+
+        let production = active_websockets_emf_document("prod", "use1", "boot-id", 1, 123);
+        assert_eq!(
+            production.pointer("/_aws/CloudWatchMetrics/0/Namespace"),
+            Some(&json!("Snaketron/Operational")),
+        );
     }
 
     #[test]

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -532,7 +532,33 @@ pub async fn handle_websocket(
     )
     .await
     {
+        crate::resilience_metrics::record_websocket_process_error(1);
         error!("WebSocket connection error: {}", e);
+    }
+}
+
+fn tungstenite_message_bytes(message: &Message) -> usize {
+    match message {
+        Message::Text(text) => text.len(),
+        Message::Binary(data) | Message::Ping(data) | Message::Pong(data) => data.len(),
+        Message::Close(frame) => frame
+            .as_ref()
+            .map(|frame| frame.reason.len().saturating_add(2))
+            .unwrap_or(0),
+        _ => 0,
+    }
+}
+
+fn axum_message_bytes(message: &axum::extract::ws::Message) -> usize {
+    match message {
+        axum::extract::ws::Message::Text(text) => text.len(),
+        axum::extract::ws::Message::Binary(data)
+        | axum::extract::ws::Message::Ping(data)
+        | axum::extract::ws::Message::Pong(data) => data.len(),
+        axum::extract::ws::Message::Close(frame) => frame
+            .as_ref()
+            .map(|frame| frame.reason.len().saturating_add(2))
+            .unwrap_or(0),
     }
 }
 
@@ -617,6 +643,7 @@ async fn handle_websocket_connection(
         )
         .await
         {
+            let outbound_bytes = tungstenite_message_bytes(&msg);
             // Convert to Axum WebSocket message
             let axum_msg = match msg {
                 Message::Text(text) => axum::extract::ws::Message::Text(text.to_string()),
@@ -634,9 +661,11 @@ async fn handle_websocket_connection(
             };
 
             if let Err(e) = ws_sink.send(axum_msg).await {
+                crate::resilience_metrics::record_websocket_send_error(1);
                 error!("Failed to send message to WebSocket: {}", e);
                 break;
             }
+            crate::resilience_metrics::record_websocket_outbound_message(outbound_bytes);
         }
     });
 
@@ -718,6 +747,9 @@ async fn handle_websocket_connection(
             Some(result) = ws_stream.next() => {
                 match result {
                     Ok(msg) => {
+                        crate::resilience_metrics::record_websocket_inbound_message(
+                            axum_message_bytes(&msg),
+                        );
                         // Convert Axum message to tokio-tungstenite message for processing
                         let tungstenite_msg = match msg {
                             axum::extract::ws::Message::Text(text) => Message::Text(text.into()),
@@ -734,6 +766,7 @@ async fn handle_websocket_connection(
                         if let Message::Text(text) = tungstenite_msg {
                             match serde_json::from_str::<WSMessage>(&text) {
                                 Ok(WSMessage::RequestResync { game_id: resync_game_id }) => {
+                                    crate::resilience_metrics::record_websocket_resync_requested(1);
                                     // The client detected loss or divergence (stream
                                     // gap, repeated fingerprint mismatch, or a dead
                                     // feed). Restart its event forwarder — which
@@ -750,6 +783,7 @@ async fn handle_websocket_connection(
                                         .map(|t| now.duration_since(t) >= Duration::from_millis(500))
                                         .unwrap_or(true);
                                     if in_this_game && allowed {
+                                        crate::resilience_metrics::record_websocket_resync_accepted(1);
                                         last_resync_at = Some(now);
                                         if let ConnectionState::Authenticated { metadata, .. } = &state {
                                             let user_id = metadata.user_id as u32;
@@ -778,11 +812,14 @@ async fn handle_websocket_connection(
                                                 ).await;
                                             }));
                                         }
-                                    } else if !in_this_game {
-                                        debug!(
-                                            "Ignoring resync request for game {} from connection not in that game",
-                                            resync_game_id
-                                        );
+                                    } else {
+                                        crate::resilience_metrics::record_websocket_resync_rejected(1);
+                                        if !in_this_game {
+                                            debug!(
+                                                "Ignoring resync request for game {} from connection not in that game",
+                                                resync_game_id
+                                            );
+                                        }
                                     }
                                 }
                                 Ok(ws_message) => {
@@ -1131,6 +1168,7 @@ async fn handle_websocket_connection(
                                             state = new_state;
                                         }
                                         Err(e) => {
+                                            crate::resilience_metrics::record_websocket_process_error(1);
                                             error!("Error processing message: {}", e);
                                             // State was consumed, need to reset
                                             state = ConnectionState::Unauthenticated;
@@ -1139,12 +1177,14 @@ async fn handle_websocket_connection(
                                     }
                                 }
                                 Err(e) => {
+                                    crate::resilience_metrics::record_websocket_malformed_message(1);
                                     error!("Failed to parse WebSocket message: {}", e);
                                 }
                             }
                         }
                     }
                     Err(e) => {
+                        crate::resilience_metrics::record_websocket_transport_error(1);
                         error!("WebSocket error: {}", e);
                         break;
                     }

--- a/server/tests/lobby_matchmaking_tests.rs
+++ b/server/tests/lobby_matchmaking_tests.rs
@@ -173,6 +173,44 @@ async fn repeated_and_concurrent_lobby_admission_keeps_one_queue_identity() -> R
 }
 
 #[tokio::test]
+async fn admission_wrong_type_is_reported_as_integrity_failure() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    setup_test_redis().await?;
+    seed_lobby_metadata(&["CORRUPT1"]).await?;
+
+    let game_type = GameType::FreeForAll { max_players: 2 };
+    let queue_mode = QueueMode::Quickmatch;
+    let mut redis = Client::open(test_redis_url())?
+        .get_multiplexed_async_connection()
+        .await?;
+    let _: usize = redis
+        .rpush(
+            RedisKeys::matchmaking_lobby_queue(&game_type, &queue_mode),
+            "wrong-type",
+        )
+        .await?;
+
+    let mut manager = create_test_matchmaking_manager().await?;
+    let error = manager
+        .add_lobby_to_queue(
+            "CORRUPT1",
+            vec![make_lobby_member(92, "corrupt-player")],
+            1_000,
+            vec![game_type],
+            queue_mode,
+            92,
+        )
+        .await
+        .expect_err("wrong-type queue must not look like an expected claim race");
+    assert!(
+        error
+            .to_string()
+            .contains("integrity failure: queue-wrong-type")
+    );
+    Ok(())
+}
+
+#[tokio::test]
 async fn one_user_cannot_be_admitted_through_two_lobbies() -> Result<()> {
     let _guard = TEST_LOCK.lock().await;
     setup_test_redis().await?;
@@ -738,6 +776,16 @@ async fn concurrent_atomic_claims_commit_exactly_one_match() -> Result<()> {
     assert_eq!(outbox.len(), 1);
     let (outbox_game_id, outbox_payload) = outbox.pop().expect("one committed outbox record");
     assert_eq!(outbox_game_id, winner_id.to_string());
+    let outbox_age_key = RedisKeys::matchmaking_game_created_outbox_age();
+    let indexed_at_ms: Option<i64> = redis.zscore(&outbox_age_key, winner_id).await?;
+    assert!(indexed_at_ms.is_some());
+    assert_eq!(redis.zcard::<_, usize>(&outbox_age_key).await?, 1);
+    assert_eq!(
+        redis
+            .zscore::<_, _, Option<i64>>(&outbox_age_key, loser_id)
+            .await?,
+        None
+    );
     let outbox_record: GameCreatedOutboxRecord = serde_json::from_str(&outbox_payload)?;
     let redis_client = Client::open(test_redis_url())?;
     let (pubsub_tx, _rx) = broadcast::channel::<PushInfo>(128);
@@ -768,6 +816,12 @@ async fn concurrent_atomic_claims_commit_exactly_one_match() -> Result<()> {
     assert!(
         left.acknowledge_game_created_outbox(winner_id, &outbox_payload)
             .await?
+    );
+    assert_eq!(
+        redis
+            .zscore::<_, _, Option<i64>>(&outbox_age_key, winner_id)
+            .await?,
+        None
     );
     game_bus
         .expire_game_created_delivery_marker(winner_id)


### PR DESCRIPTION
## Summary

- Expand the EMF publisher into bounded-cardinality production and non-production operational namespaces covering cluster membership, partition ownership, recovery, game execution, HTTP, WebSockets, matchmaking, outbox health, and Redis operations.
- Instrument request, socket, matchmaking, game-completion, and Redis paths with counts, errors, traffic volumes, durations, and latency components for the Grafana dashboard suite.
- Add exact matchmaking queue and game-created outbox backlog and age observation, distinguish expected atomic claim conflicts from data-integrity failures, and prevent telemetry Redis reads from recursively inflating workload metrics.
- Update resilience certification queries for the non-production namespace and add regression coverage for metric documents, matchmaking integrity handling, and outbox age-index maintenance.

## Verification

- cargo fmt --all -- --check
- cargo check -p server
- cargo test -p server resilience_metrics -- --nocapture
- cargo test -p server --test lobby_matchmaking_tests admission_wrong_type_is_reported_as_integrity_failure -- --nocapture
- cargo test -p server --test lobby_matchmaking_tests concurrent_atomic_claims_commit_exactly_one_match -- --nocapture