### PR TITLE
Fix Start Game connection race

### DIFF
--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -37,6 +37,7 @@ interface GameStartFormProps {
   isLobbyQueued?: boolean;
   lobbyPreferences: LobbyPreferences | null;
   onPreferencesChange?: (preferences: LobbyPreferences) => void;
+  errorMessage?: string | null;
 }
 
 export const GameStartForm: React.FC<GameStartFormProps> = ({
@@ -47,6 +48,7 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
   isLobbyQueued = false,
   lobbyPreferences,
   onPreferencesChange,
+  errorMessage = null,
 }) => {
   const [nickname, setNickname] = useState(currentUsername || '');
   const [hasAutoSetNickname, setHasAutoSetNickname] = useState(false);
@@ -362,6 +364,13 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
         >
           {startButtonLabel}
         </button>
+        <div className="min-h-5 mt-3" aria-live="polite">
+          {errorMessage && (
+            <p className="text-sm text-red-600 text-center" role="alert">
+              {errorMessage}
+            </p>
+          )}
+        </div>
       </div>
     </form>
   );

--- a/client/web/components/LobbyInvitePage.tsx
+++ b/client/web/components/LobbyInvitePage.tsx
@@ -15,7 +15,7 @@ const LobbyInvitePage: React.FC = () => {
   const lobbyCode = (rawCode ?? '').toUpperCase();
   const navigate = useNavigate();
   const { user, createGuest, loading: authLoading, getToken } = useAuth();
-  const { isConnected, joinLobby, sendMessage } = useWebSocket();
+  const { isConnected, joinLobby, waitForSessionReady } = useWebSocket();
 
   const inFlightRef = useRef(false);
   const hasSucceededRef = useRef(false);
@@ -28,8 +28,6 @@ const LobbyInvitePage: React.FC = () => {
   useEffect(() => {
     latestUserRef.current = user;
   }, [user]);
-
-  const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
   const ensureAuthenticatedSession = useCallback(async () => {
     let activeUser = latestUserRef.current;
@@ -49,9 +47,8 @@ const LobbyInvitePage: React.FC = () => {
       throw new Error('Missing authentication token');
     }
 
-    sendMessage({ Token: token });
-    await delay(50);
-  }, [createGuest, getToken, lobbyCode, sendMessage]);
+    await waitForSessionReady();
+  }, [createGuest, getToken, lobbyCode, waitForSessionReady]);
 
   useEffect(() => {
     if (hasSucceededRef.current) {

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -21,7 +21,7 @@ export const NewHome: React.FC = () => {
   const {
     connectToRegion,
     isConnected,
-    isSessionAuthenticated,
+    waitForSessionReady,
     onMessage,
     currentRegionUrl,
     currentLobby,
@@ -33,30 +33,12 @@ export const NewHome: React.FC = () => {
     lobbyPreferences,
     updateLobbyPreferences,
   } = useWebSocket();
-  const { currentGameId, queueForMatch, queueForMatchMulti } = useGameWebSocket();
+  const { currentGameId, isQueued, queueForMatch, queueForMatchMulti } = useGameWebSocket();
   const [isLoading, setIsLoading] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   const [showJoinModal, setShowJoinModal] = useState(false);
   const [isCreatingInvite, setIsCreatingInvite] = useState(false);
-
-  const waitForConnection = async (timeoutMs = 5000) => {
-    const start = Date.now();
-    // Trigger a reconnect if we have region data but no active socket
-    if (!isConnected) {
-      const target = selectedRegion ?? regions[0];
-      if (target && currentRegionUrl !== target.wsUrl) {
-        connectToRegion(target.wsUrl, { regionId: target.id, origin: target.origin });
-      }
-    }
-
-    while (Date.now() - start < timeoutMs) {
-      if (isConnected && (!user || isSessionAuthenticated)) {
-        return true;
-      }
-      await new Promise(resolve => setTimeout(resolve, 200));
-    }
-    return false;
-  };
+  const [startError, setStartError] = useState<string | null>(null);
 
   // Use regions hook for live data
   const {
@@ -70,7 +52,7 @@ export const NewHome: React.FC = () => {
     onMessage,
   });
   const currentRegionId = selectedRegion?.id ?? regions[0]?.id ?? '';
-  const isLobbyQueued = currentLobby?.state === 'queued';
+  const isLobbyQueued = isQueued || currentLobby?.state === 'queued';
 
   // Connect to selected region when it changes
   useEffect(() => {
@@ -125,19 +107,16 @@ export const NewHome: React.FC = () => {
     }
 
     setIsLoading(true);
+    setStartError(null);
     try {
       // If not logged in, create guest user
       if (!user) {
-        try {
-          await createGuest(nickname);
-        } catch (error) {
-          console.error('Guest creation failed:', error);
-          return;
-        }
+        await createGuest(nickname);
       }
 
-      // Wait for auth to propagate
-      await new Promise(resolve => setTimeout(resolve, 500));
+      // Wait for the active regional socket to acknowledge this exact session
+      // before issuing lobby or matchmaking commands.
+      await waitForSessionReady();
 
       if (!currentLobby) {
         await createLobby();
@@ -147,9 +126,6 @@ export const NewHome: React.FC = () => {
         selectedModes: gameModes,
         competitive: isCompetitive,
       });
-
-      // Give the WebSocket a moment to broadcast lobby preferences before queuing
-      await new Promise(resolve => setTimeout(resolve, 100));
 
       // Convert game modes to GameType format
       const gameTypes = gameModes.map(mode => {
@@ -173,6 +149,13 @@ export const NewHome: React.FC = () => {
       }
     } catch (error) {
       console.error('Failed to start game:', error);
+      const message =
+        error instanceof Error
+          ? error.message
+          : typeof (error as any)?.message === 'string'
+            ? (error as any).message
+            : 'Failed to start matchmaking. Please try again.';
+      setStartError(message);
     } finally {
       setIsLoading(false);
     }
@@ -196,15 +179,9 @@ export const NewHome: React.FC = () => {
           console.error('Guest creation failed for lobby invite:', error);
           return;
         }
-
-        await new Promise(resolve => setTimeout(resolve, 500));
       }
 
-      const connected = await waitForConnection();
-      if (!connected) {
-        console.error('Could not establish WebSocket connection for lobby invite');
-        return;
-      }
+      await waitForSessionReady();
 
       if (!currentLobby) {
         await createLobby();
@@ -292,6 +269,7 @@ export const NewHome: React.FC = () => {
               isLobbyQueued={isLobbyQueued}
               lobbyPreferences={lobbyPreferences}
               onPreferencesChange={updateLobbyPreferences}
+              errorMessage={startError}
             />
             <SocialFooter />
           </div>

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -9,6 +9,7 @@ import {
   LobbyGameMode,
   LobbyState,
   User,
+  MatchmakingStatus,
 } from '../types';
 import { clockSync } from '../utils/clockSync';
 import { record as recordTrace } from '../utils/syncTrace';
@@ -208,7 +209,7 @@ const normalizeLobbyPreferences = (payload: any): LobbyPreferences => {
 
 interface StoredLobbyInfo {
   code: string;
-  id?: number;
+  id?: number | null;
 }
 
 interface PendingMatchmakingIntent {
@@ -235,6 +236,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const [lobbyChatMessages, setLobbyChatMessages] = useState<ChatMessage[]>([]);
   const [gameChatMessages, setGameChatMessages] = useState<ChatMessage[]>([]);
   const [lobbyPreferences, setLobbyPreferences] = useState<LobbyPreferences | null>(storedPreferences);
+  const [matchmakingStatus, setMatchmakingStatus] = useState<MatchmakingStatus>('idle');
   const [isSessionAuthenticated, setIsSessionAuthenticated] = useState(false);
   const [serverCapabilities, setServerCapabilities] = useState<ReadonlySet<string>>(new Set());
   const currentLobbyRef = useRef<Lobby | null>(null);
@@ -391,7 +393,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     }
   }, []);
 
-  const persistLobby = useCallback((lobby: { id: number; code: string }) => {
+  const persistLobby = useCallback((lobby: { id: number | null; code: string }) => {
     storedLobbyRef.current = { id: lobby.id, code: lobby.code.toUpperCase() };
 
     if (typeof window === 'undefined') {
@@ -424,6 +426,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
 
   const resetLobbyState = useCallback(() => {
     pendingMatchmakingIntentRef.current = null;
+    setMatchmakingStatus('idle');
     setCurrentLobby(null);
     currentLobbyRef.current = null;
     setLobbyMembers([]);
@@ -1336,17 +1339,18 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     }
     setIsConnected(false);
     setAuthHandshakeState(false);
+    lastAuthTokenRef.current = null;
     setServerCapabilities(new Set());
     plannedHandoffStartedAtRef.current = null;
     recoveryStartedAtRef.current = null;
     usableGapStartedAtRef.current = null;
   }, [setAuthHandshakeState]);
 
-  const connectToRegion = useCallback((wsUrl: string, options?: { regionId?: string; origin?: string }) => {
+  const connectToRegion = useCallback((
+    wsUrl: string,
+    options?: { regionId?: string; origin?: string; forceReconnect?: boolean },
+  ) => {
     console.log('Switching to region:', wsUrl);
-    disconnect();
-    reconnectEnabledRef.current = true;
-    reconnectAttemptRef.current = 0;
     if (options?.regionId) {
       saveRegionPreference({
         regionId: options.regionId,
@@ -1355,11 +1359,28 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         timestamp: Date.now(),
       });
     }
+
+    const active = activeSlotRef.current;
+    const isSameActiveRegion = Boolean(
+      active &&
+      active.role === 'active' &&
+      active.url === wsUrl &&
+      (active.socket.readyState === WebSocket.OPEN ||
+        active.socket.readyState === WebSocket.CONNECTING),
+    );
+    if (isSameActiveRegion && !options?.forceReconnect) {
+      return;
+    }
+
+    disconnect();
+    reconnectEnabledRef.current = true;
+    reconnectAttemptRef.current = 0;
     connect(wsUrl, onConnectCallback.current || undefined);
   }, [connect, disconnect]);
 
   const sendMessage = useCallback((message: any) => {
-    if (isMatchmakingQueueIntent(message)) {
+    const isQueueIntent = isMatchmakingQueueIntent(message);
+    if (isQueueIntent) {
       const authToken = getToken();
       const lobbyCode = (
         currentLobbyRef.current?.code ?? storedLobbyRef.current?.code ?? ''
@@ -1375,50 +1396,129 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       pendingMatchmakingIntentRef.current = null;
     }
     const target = activeSlotRef.current;
-    const doSend = () => {
+    const targetCanSend = () => Boolean(
+      target &&
+      isCommandOwner(
+        activeSlotRef.current?.generation ?? null,
+        target.generation,
+        target.role,
+        target.socket.readyState,
+      ) &&
+      (!isQueueIntent || (
+        target.authenticated &&
+        target.authTokenSent === pendingMatchmakingIntentRef.current?.authToken
+      ))
+    );
+    const doSend = (): boolean => {
       if (
         target &&
-        isCommandOwner(
-          activeSlotRef.current?.generation ?? null,
-          target.generation,
-          target.role,
-          target.socket.readyState,
-        )
+        targetCanSend()
       ) {
-        target.socket.send(JSON.stringify(message));
-        console.log('WebSocket message sent:', message, 'generation:', target.generation);
+        try {
+          target.socket.send(JSON.stringify(message));
+          console.log('WebSocket message sent:', message, 'generation:', target.generation);
+          return true;
+        } catch (error) {
+          console.error('Failed to send WebSocket message:', error);
+          return false;
+        }
       } else {
         console.error('WebSocket is not connected');
+        return false;
       }
     };
     if (latencySettings.enabled && latencySettings.sendDelayMs > 0) {
       setTimeout(doSend, latencySettings.sendDelayMs);
+      // Queue admission is a retained logical intent. A transport transition
+      // after readiness may defer the physical frame, but restoration will
+      // replay it against the same authenticated lobby identity.
+      return isQueueIntent || targetCanSend();
     } else {
-      doSend();
+      return doSend() || isQueueIntent;
     }
   }, [getToken, latencySettings]);
 
   const authenticateConnection = useCallback(() => {
     const slot = activeSlotRef.current;
-    if (!slot || slot.socket.readyState !== WebSocket.OPEN) {
+    if (
+      !slot ||
+      slot.role !== 'active' ||
+      slot.socket.readyState !== WebSocket.OPEN
+    ) {
       return false;
     }
     const token = getToken();
     if (!token) {
       return false;
     }
-    if (slot.authenticated && slot.authTokenSent === token) {
-      setAuthHandshakeState(true);
-      return true;
+    if (slot.authenticated) {
+      if (slot.authTokenSent === token) {
+        setAuthHandshakeState(true);
+        return true;
+      }
+
+      // Token is only valid during the initial server handshake. The auth
+      // effect will replace this wrong-identity socket; never send a second
+      // Token frame on an already authenticated connection.
+      return false;
     }
     if (slot.authTokenSent !== token) {
+      // A different identity is already being authenticated on this socket.
+      // Let the token-change effect replace it before sending any command.
+      if (slot.authTokenSent !== null) {
+        return false;
+      }
       slot.authStartedAtMs = Date.now();
       slot.authTokenSent = token;
-      slot.socket.send(JSON.stringify({ Token: token }));
+      try {
+        slot.socket.send(JSON.stringify({ Token: token }));
+      } catch (error) {
+        slot.authStartedAtMs = null;
+        slot.authTokenSent = null;
+        console.error('Failed to authenticate WebSocket connection:', error);
+        return false;
+      }
       lastAuthTokenRef.current = token;
     }
     return slot.authenticated;
   }, [getToken, setAuthHandshakeState]);
+
+  const waitForSessionReady = useCallback(async (timeoutMs = 10_000): Promise<void> => {
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const token = getToken();
+      const slot = activeSlotRef.current;
+      if (
+        token &&
+        slot &&
+        slot.role === 'active' &&
+        slot.socket.readyState === WebSocket.OPEN &&
+        slot.authenticated &&
+        slot.authTokenSent === token
+      ) {
+        return;
+      }
+
+      if (
+        token &&
+        slot &&
+        slot.role === 'active' &&
+        slot.socket.readyState === WebSocket.OPEN &&
+        !slot.authenticated &&
+        (slot.authTokenSent === null || slot.authTokenSent === token)
+      ) {
+        authenticateConnection();
+      }
+
+      await new Promise<void>((resolve) => setTimeout(resolve, 50));
+    }
+
+    if (!getToken()) {
+      throw new Error('Your player session is not ready. Please try again.');
+    }
+    throw new Error('Could not connect to the game server. Please try again.');
+  }, [authenticateConnection, getToken]);
 
   const sendChatMessage = useCallback((scope: ChatScope, message: string) => {
     const trimmed = message.trim();
@@ -1490,10 +1590,27 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       pendingMatchmakingIntentRef.current.authToken !== token
     ) {
       pendingMatchmakingIntentRef.current = null;
+      setMatchmakingStatus('idle');
     }
     if (!token) {
+      const active = activeSlotRef.current;
+      const reconnectUrl = active?.url ?? currentRegionUrl;
+      const carriedAuthenticatedIdentity = Boolean(
+        active &&
+        active.role === 'active' &&
+        (active.authenticated || active.authTokenSent !== null),
+      );
+
+      previousUserRef.current = user;
+      setMatchmakingStatus('idle');
       setAuthHandshakeState(false);
       lastAuthTokenRef.current = null;
+      // Logging out must retire the server-side identity as well as clearing
+      // React state. Reconnect anonymously so a later guest cannot issue
+      // commands through the previous user's authenticated transport.
+      if (carriedAuthenticatedIdentity && reconnectUrl) {
+        connectToRegion(reconnectUrl, { forceReconnect: true });
+      }
       return;
     }
 
@@ -1543,6 +1660,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     isSessionAuthenticated,
     currentRegionUrl,
     connect,
+    connectToRegion,
     disconnect,
     getToken,
     authenticateConnection,
@@ -1643,6 +1761,14 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
 
   // Lobby methods
   const createLobby = useCallback(async () => {
+    await waitForSessionReady();
+
+    // Re-read the mutable lobby source after awaiting auth. A stored-lobby
+    // restoration or another request may have completed since this render.
+    if (currentLobbyRef.current) {
+      return;
+    }
+
     const requestedInitialPreferences = buildInitialLobbyPreferences();
     const initialPreferencesClone: LobbyPreferences = {
       selectedModes: [...requestedInitialPreferences.selectedModes],
@@ -1659,16 +1785,38 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       let settled = false;
       let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
+      let cleanupCreated = () => {};
+      let cleanupDenied = () => {};
+      const cleanupHandlers = () => {
+        cleanupCreated();
+        cleanupDenied();
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+      };
+
       // Set up one-time handler for LobbyCreated message
-      const cleanup = onMessage('LobbyCreated', (message: any) => {
+      cleanupCreated = onMessage('LobbyCreated', (message: any) => {
         if (settled) {
           return;
         }
 
-        const { lobby_id, lobby_code } = message.data;
+        const { lobby_id, lobby_code } = message.data ?? {};
+        if (typeof lobby_code !== 'string' || !lobby_code.trim()) {
+          settled = true;
+          cleanupHandlers();
+          finishRequest();
+          reject(new Error('Game server returned an invalid lobby response'));
+          return;
+        }
+
         const normalizedCode = lobby_code.toUpperCase();
+        const lobbyId = typeof lobby_id === 'number' && Number.isFinite(lobby_id)
+          ? lobby_id
+          : null;
         const newLobby: Lobby = {
-          id: lobby_id,
+          id: lobbyId,
           code: normalizedCode,
           hostUserId: user?.id ?? 0, // Optimistically assume creator is host
           region: '', // Will be set by LobbyUpdate
@@ -1678,7 +1826,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         setCurrentLobby(newLobby);
         // console.log('setLobbyPreferences', DEFAULT_LOBBY_PREFERENCES);
         // setLobbyPreferences(DEFAULT_LOBBY_PREFERENCES);
-        persistLobby({ id: lobby_id, code: normalizedCode });
+        persistLobby({ id: lobbyId, code: normalizedCode });
 
         if (initialPreferencesClone.selectedModes.length > 0) {
           desiredLobbyPreferencesRef.current = initialPreferencesClone;
@@ -1692,22 +1840,31 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         }
 
         settled = true;
-        cleanup();
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
+        cleanupHandlers();
         finishRequest();
         resolve();
       });
 
-      // Send CreateLobby message
-      try {
-        sendMessage('CreateLobby');
-      } catch (error) {
+      cleanupDenied = onMessage('AccessDenied', (message: any) => {
+        if (settled) {
+          return;
+        }
+        const reason =
+          typeof message?.data?.reason === 'string' && message.data.reason.trim()
+            ? message.data.reason.trim()
+            : 'Lobby creation was denied';
         settled = true;
-        cleanup();
+        cleanupHandlers();
         finishRequest();
-        reject(error);
+        reject(new Error(reason));
+      });
+
+      // Send CreateLobby message
+      if (!sendMessage('CreateLobby')) {
+        settled = true;
+        cleanupHandlers();
+        finishRequest();
+        reject(new Error('Connection was lost before the lobby could be created'));
         return;
       }
 
@@ -1717,7 +1874,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
           return;
         }
         settled = true;
-        cleanup();
+        cleanupHandlers();
         finishRequest();
         reject(new Error('Timeout waiting for lobby creation'));
       }, 5000);
@@ -1729,9 +1886,12 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     persistLobby,
     user?.id,
     buildInitialLobbyPreferences,
+    waitForSessionReady,
   ]);
 
   const joinLobby = useCallback(async (lobbyCode: string) => {
+    await waitForSessionReady();
+
     const normalizedCode = lobbyCode.trim().toUpperCase();
     const joinPreferences = buildInitialLobbyPreferences();
     return new Promise<void>((resolve, reject) => {
@@ -1755,7 +1915,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         }
       };
 
-      const handleSuccess = (lobbyId: number, hostUserId?: number) => {
+      const handleSuccess = (lobbyId: number | null, hostUserId?: number) => {
         if (settled) {
           return;
         }
@@ -1787,8 +1947,11 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         if (settled) {
           return;
         }
-        const { lobby_id } = message.data;
-        handleSuccess(lobby_id);
+        const { lobby_id } = message.data ?? {};
+        const lobbyId = typeof lobby_id === 'number' && Number.isFinite(lobby_id)
+          ? lobby_id
+          : null;
+        handleSuccess(lobbyId);
       });
 
       cleanupDenied = onMessage('AccessDenied', (message: any) => {
@@ -1833,8 +1996,11 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         if (settled) {
           return;
         }
-        const { lobby_id, host_user_id } = message.data;
-        handleSuccess(lobby_id, host_user_id);
+        const { lobby_id, host_user_id } = message.data ?? {};
+        const lobbyId = typeof lobby_id === 'number' && Number.isFinite(lobby_id)
+          ? lobby_id
+          : null;
+        handleSuccess(lobbyId, host_user_id);
       });
 
       // Timeout after 5 seconds
@@ -1848,21 +2014,19 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         reject(new Error('Timeout waiting to join lobby'));
       }, 5000);
 
-      try {
-        sendMessage({
-          JoinLobby: {
-            lobby_code: normalizedCode,
-            preferences: {
-              selected_modes: joinPreferences.selectedModes,
-              competitive: joinPreferences.competitive,
-            },
+      if (!sendMessage({
+        JoinLobby: {
+          lobby_code: normalizedCode,
+          preferences: {
+            selected_modes: joinPreferences.selectedModes,
+            competitive: joinPreferences.competitive,
           },
-        });
-      } catch (error) {
+        },
+      })) {
         settled = true;
         cleanupHandlers();
         finishRequest();
-        reject(error);
+        reject(new Error('Connection was lost before the lobby could be joined'));
       }
     });
   }, [
@@ -1874,6 +2038,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     resetLobbyState,
     isLobbyMissingReason,
     buildInitialLobbyPreferences,
+    waitForSessionReady,
   ]);
 
   const leaveLobby = useCallback(async () => {
@@ -2463,6 +2628,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     isSessionAuthenticated,
     serverCapabilities,
     sendMessage,
+    waitForSessionReady,
     onMessage,
     connect,
     disconnect,
@@ -2474,6 +2640,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     lobbyChatMessages,
     gameChatMessages,
     lobbyPreferences,
+    matchmakingStatus,
+    setMatchmakingStatus,
     createLobby,
     joinLobby,
     leaveLobby,

--- a/client/web/hooks/useGameWebSocket.ts
+++ b/client/web/hooks/useGameWebSocket.ts
@@ -56,6 +56,8 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     isConnected,
     isSessionAuthenticated,
     serverCapabilities,
+    matchmakingStatus,
+    setMatchmakingStatus,
     sendMessage,
     onMessage,
   } = useWebSocket();
@@ -75,8 +77,8 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
   const [gameLoadFailure, setGameLoadFailure] = useState<GameLoadFailure | null>(null);
   const [awaitingGameSnapshotForId, setAwaitingGameSnapshotForId] = useState<string | null>(null);
   const [isGameSnapshotSynchronized, setIsGameSnapshotSynchronized] = useState(false);
-  const [isQueued, setIsQueued] = useState(false);
-  const [isJoiningGame, setIsJoiningGame] = useState(false);
+  const isQueued = matchmakingStatus === 'queued';
+  const isJoiningGame = matchmakingStatus === 'joining';
   const requestedGameRef = useRef<{ routeGameId: string; gameId: number } | null>(null);
   const serverAssignedGameRef = useRef<number | null>(null);
   const awaitingGameSnapshotRef = useRef<string | null>(null);
@@ -151,8 +153,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
           'Snapshot' in event
         ) {
           serverAssignedGameRef.current = null;
-          setIsQueued(false);
-          setIsJoiningGame(false);
+          setMatchmakingStatus('idle');
         }
 
         const requestedGame = requestedGameRef.current;
@@ -231,7 +232,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     // A game may have existed but no longer have a loadable live or persisted snapshot.
     unsubscribers.push(
       onMessage('GameLoadFailed', (message: any) => {
-        const payload = message?.data;
+        const payload = message?.data ?? message?.GameLoadFailed ?? message;
         const gameId = parseU32GameId(payload?.game_id);
 
         if (gameId === null) {
@@ -239,6 +240,10 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
           return;
         }
 
+        if (serverAssignedGameRef.current === gameId) {
+          serverAssignedGameRef.current = null;
+          setMatchmakingStatus('idle');
+        }
         const requestedGame = requestedGameRef.current;
         if (
           !requestedGame ||
@@ -260,10 +265,6 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
         if (user) {
           clearGameCommandOutbox(gameId, user.id);
         }
-        if (serverAssignedGameRef.current === gameId) {
-          serverAssignedGameRef.current = null;
-          setIsQueued(false);
-        }
 
         const reason =
           typeof payload?.reason === 'string' && payload.reason.trim()
@@ -272,7 +273,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
 
         console.warn(`Failed to load game ${gameId}: ${reason}`);
         updateGameSnapshotSynchronization(false);
-        setIsJoiningGame(false);
+        setMatchmakingStatus('idle');
         updateAwaitingGameSnapshot(null);
         setGameLoadFailure({
           gameId,
@@ -297,8 +298,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
           // the retry once the route is mounted.
           serverAssignedGameRef.current = gameId;
           setCurrentGameId(gameId.toString());
-          setIsQueued(false);
-          setIsJoiningGame(true);
+          setMatchmakingStatus('joining');
           navigate(`/play/${gameId}`);
           return;
         }
@@ -312,7 +312,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
         updateGameSnapshotSynchronization(false);
         updateAwaitingGameSnapshot(requestedGame.routeGameId);
         setGameLoadFailure(null);
-        setIsJoiningGame(true);
+        setMatchmakingStatus('joining');
         if (warmingRetryTimeout) {
           clearTimeout(warmingRetryTimeout);
         }
@@ -371,8 +371,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
           console.log('Match found! Game ID:', parsedGameId);
           serverAssignedGameRef.current = parsedGameId;
           setCurrentGameId(parsedGameId.toString());
-          setIsQueued(false);
-          setIsJoiningGame(true);
+          setMatchmakingStatus('joining');
           
           // DON'T send JoinGame back - GameArena will handle joining
           // sendMessage({ JoinGame: parseInt(gameId.toString()) });
@@ -388,8 +387,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
       onMessage('AccessDenied', (message: any) => {
         console.error('Access denied:', message.data.reason);
         serverAssignedGameRef.current = null;
-        setIsQueued(false);
-        setIsJoiningGame(false);
+        setMatchmakingStatus('idle');
         // TODO: Show error to user
       })
     );
@@ -398,8 +396,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
       onMessage('QueueLeft', () => {
         console.log('Received QueueLeft message from server, clearing queue state');
         serverAssignedGameRef.current = null;
-        setIsQueued(false);
-        setIsJoiningGame(false);
+        setMatchmakingStatus('idle');
       })
     );
 
@@ -481,6 +478,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     navigate,
     sendMessage,
     serverCapabilities,
+    setMatchmakingStatus,
     updateAwaitingGameSnapshot,
     updateGameSnapshotSynchronization,
     user,
@@ -492,11 +490,12 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
       completedOutcomeBarriersRef.current.delete(requestedGame.gameId);
       updateGameSnapshotSynchronization(false);
       updateAwaitingGameSnapshot(requestedGame.routeGameId);
-      setIsJoiningGame(true);
+      setMatchmakingStatus('joining');
     }
   }, [
     isConnected,
     isSessionAuthenticated,
+    setMatchmakingStatus,
     updateAwaitingGameSnapshot,
     updateGameSnapshotSynchronization,
   ]);
@@ -522,7 +521,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
       updateGameSnapshotSynchronization(false);
       gameEventQueueRef.current = [];
       updateAwaitingGameSnapshot(null);
-      setIsJoiningGame(false);
+      setMatchmakingStatus('idle');
       setGameLoadFailure({
         gameId: null,
         requestedGameId: gameId,
@@ -541,13 +540,14 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     gameEventQueueRef.current = [];
     setGameLoadFailure(null);
     updateAwaitingGameSnapshot(gameId);
-    setIsJoiningGame(true);
+    setMatchmakingStatus('joining');
     sendMessage({
       JoinGame: parsedGameId
     });
     return true;
   }, [
     sendMessage,
+    setMatchmakingStatus,
     updateAwaitingGameSnapshot,
     updateGameSnapshotSynchronization,
   ]);
@@ -561,7 +561,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     updateGameSnapshotSynchronization(true);
     updateAwaitingGameSnapshot(null);
     setGameLoadFailure(null);
-    setIsJoiningGame(false);
+    setMatchmakingStatus('idle');
     if (
       !user ||
       !serverCapabilities.has('command-delivery-v2') ||
@@ -577,7 +577,7 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     for (const command of takeGameCommandsDueForRetry(gameId, user.id, Date.now(), 0)) {
       sendMessage({ GameCommandV2: command });
     }
-  }, [sendMessage, serverCapabilities, updateAwaitingGameSnapshot, updateGameSnapshotSynchronization, user]);
+  }, [sendMessage, serverCapabilities, setMatchmakingStatus, updateAwaitingGameSnapshot, updateGameSnapshotSynchronization, user]);
 
   // A semantic executor result is the acknowledgement. Periodic exact resends
   // cover an ambiguous gateway/XADD failure without adding a weaker receipt
@@ -677,38 +677,55 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
   const createSoloGame = useCallback(() => {
     console.log('Queueing for a solo game');
     serverAssignedGameRef.current = null;
-    setIsQueued(true);
-    setIsJoiningGame(false);
-    sendMessage({
-      QueueForMatch: { game_type: 'Solo', queue_mode: 'Quickmatch' }
-    });
-  }, [sendMessage]);
+    setMatchmakingStatus('queued');
+    try {
+      if (!sendMessage({
+        QueueForMatch: { game_type: 'Solo', queue_mode: 'Quickmatch' }
+      })) {
+        throw new Error('Connection was lost before matchmaking could start');
+      }
+    } catch (error) {
+      setMatchmakingStatus('idle');
+      throw error;
+    }
+  }, [sendMessage, setMatchmakingStatus]);
 
   const queueForMatch = useCallback((gameType: GameType, queueMode: 'Quickmatch' | 'Competitive' = 'Quickmatch') => {
     console.log('Queueing for match with game type:', gameType, 'mode:', queueMode);
-    setIsQueued(true);
-    setIsJoiningGame(false);
-    sendMessage({
-      QueueForMatch: { game_type: gameType, queue_mode: queueMode }
-    });
-  }, [sendMessage]);
+    setMatchmakingStatus('queued');
+    try {
+      if (!sendMessage({
+        QueueForMatch: { game_type: gameType, queue_mode: queueMode }
+      })) {
+        throw new Error('Connection was lost before matchmaking could start');
+      }
+    } catch (error) {
+      setMatchmakingStatus('idle');
+      throw error;
+    }
+  }, [sendMessage, setMatchmakingStatus]);
 
   const queueForMatchMulti = useCallback((gameTypes: GameType[], queueMode: 'Quickmatch' | 'Competitive' = 'Quickmatch') => {
     console.log('Queueing for match with multiple game types:', gameTypes, 'mode:', queueMode);
-    setIsQueued(true);
-    setIsJoiningGame(false);
-    sendMessage({
-      QueueForMatchMulti: { game_types: gameTypes, queue_mode: queueMode }
-    });
-  }, [sendMessage]);
+    setMatchmakingStatus('queued');
+    try {
+      if (!sendMessage({
+        QueueForMatchMulti: { game_types: gameTypes, queue_mode: queueMode }
+      })) {
+        throw new Error('Connection was lost before matchmaking could start');
+      }
+    } catch (error) {
+      setMatchmakingStatus('idle');
+      throw error;
+    }
+  }, [sendMessage, setMatchmakingStatus]);
 
   const leaveQueue = useCallback(() => {
     console.log('Sending LeaveQueue message');
     sendMessage('LeaveQueue');
     serverAssignedGameRef.current = null;
-    setIsQueued(false);
-    setIsJoiningGame(false);
-  }, [sendMessage]);
+    setMatchmakingStatus('idle');
+  }, [sendMessage, setMatchmakingStatus]);
 
   const leaveGame = useCallback(() => {
     console.log('Sending LeaveGame message (initial state issue):');
@@ -730,10 +747,10 @@ export const useGameWebSocket = (): UseGameWebSocketReturn => {
     setIsHost(false);
     setCustomGameCode(null);
     setGameLoadFailure(null);
-    setIsQueued(false);
-    setIsJoiningGame(false);
+    setMatchmakingStatus('idle');
   }, [
     sendMessage,
+    setMatchmakingStatus,
     updateAwaitingGameSnapshot,
     updateGameSnapshotSynchronization,
     user,

--- a/client/web/tests/start-game-connection-race.spec.js
+++ b/client/web/tests/start-game-connection-race.spec.js
@@ -1,0 +1,167 @@
+const { test, expect } = require('@playwright/test');
+const { WebSocketServer } = require('ws');
+
+test.use({ headless: true });
+
+const REQUIRED_CAPABILITIES = [
+  'explicit-auth-v1',
+  'planned-drain-v1',
+  'socket-generation-v1',
+  'command-delivery-v2',
+  'command-outcomes-v1',
+  'command-outcome-barrier-v1',
+  'terminal-command-cutoff-v1',
+];
+
+const appUrl = process.env.SNAKETRON_TEST_BASE_URL || 'http://localhost:3000';
+
+test('an early Start Game click waits for the authenticated regional socket', async ({ page }) => {
+  const receivedMessages = [];
+  let authenticationAcknowledged = false;
+  let commandSentBeforeAuthentication = false;
+  const webSocketServer = new WebSocketServer({ host: '127.0.0.1', port: 0 });
+  await new Promise((resolve, reject) => {
+    webSocketServer.once('listening', resolve);
+    webSocketServer.once('error', reject);
+  });
+
+  const address = webSocketServer.address();
+  if (!address || typeof address === 'string') {
+    throw new Error('Failed to start the test WebSocket server');
+  }
+
+  webSocketServer.on('connection', socket => {
+    socket.on('message', data => {
+      const message = JSON.parse(data.toString());
+      receivedMessages.push(message);
+
+      if (message?.Ping) {
+        socket.send(JSON.stringify({
+          Pong: {
+            client_time: message.Ping.client_time,
+            server_time: Date.now(),
+          },
+        }));
+      }
+
+      if (message?.Token) {
+        setTimeout(() => {
+          authenticationAcknowledged = true;
+          socket.send(JSON.stringify({
+            Authenticated: {
+              task_boot_id: 'start-race-test',
+              protocol_version: 2,
+              capabilities: REQUIRED_CAPABILITIES,
+              socket_generation: 1,
+            },
+          }));
+        }, 200);
+      }
+
+      if (message === 'CreateLobby') {
+        commandSentBeforeAuthentication = !authenticationAcknowledged;
+        socket.send(JSON.stringify({
+          LobbyCreated: { lobby_code: 'RACE123' },
+        }));
+      }
+    });
+  });
+
+  let releaseRegions;
+  const regionGate = new Promise(resolve => {
+    releaseRegions = resolve;
+  });
+
+  await page.addInitScript(() => window.localStorage.clear());
+  await page.route('http://localhost:8080/api/**', async route => {
+    const { pathname } = new URL(route.request().url());
+    const corsHeaders = { 'access-control-allow-origin': '*' };
+
+    if (pathname === '/api/regions') {
+      await regionGate;
+      await route.fulfill({
+        contentType: 'application/json',
+        headers: corsHeaders,
+        body: JSON.stringify([{
+          id: 'race-region',
+          name: 'Race Region',
+          origin: 'http://race-region.test',
+          ws_url: `ws://127.0.0.1:${address.port}`,
+        }]),
+      });
+      return;
+    }
+
+    if (pathname === '/api/regions/user-counts') {
+      await route.fulfill({
+        contentType: 'application/json',
+        headers: corsHeaders,
+        body: JSON.stringify({ 'race-region': 0 }),
+      });
+      return;
+    }
+
+    if (pathname === '/api/auth/guest') {
+      await route.fulfill({
+        contentType: 'application/json',
+        headers: corsHeaders,
+        body: JSON.stringify({
+          token: 'guest-race-token',
+          user: { id: 42, username: 'RacePlayer', isGuest: true },
+        }),
+      });
+      return;
+    }
+
+    await route.abort();
+  });
+
+  await page.route('http://race-region.test/api/health', route => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    headers: { 'access-control-allow-origin': '*' },
+    body: JSON.stringify({ status: 'ok' }),
+  }));
+
+  try {
+    await page.goto(appUrl);
+    await page.getByPlaceholder('Nickname').fill('RacePlayer');
+
+    const startButton = page.locator('button[type="submit"]');
+    await expect(startButton).toBeEnabled();
+    await startButton.click();
+    await expect(startButton).toHaveText('Starting...');
+
+    // Keep region discovery blocked beyond the old hard-coded 500 ms delay.
+    // The submitted intent must remain pending rather than becoming a no-op.
+    await page.waitForTimeout(650);
+    expect(receivedMessages).toEqual([]);
+
+    releaseRegions();
+
+    await expect.poll(() => receivedMessages.some(message => message?.QueueForMatch)).toBe(true);
+    expect(commandSentBeforeAuthentication).toBe(false);
+    await expect(page.getByText('Finding match...', { exact: true })).toBeVisible();
+    await expect(startButton).toHaveText('Finding Match...');
+
+    const startSequence = receivedMessages.filter(message =>
+      message?.Token || message === 'CreateLobby' || message?.QueueForMatch
+    );
+    expect(startSequence).toEqual([
+      { Token: 'guest-race-token' },
+      'CreateLobby',
+      {
+        QueueForMatch: {
+          game_type: { TeamMatch: { per_team: 1 } },
+          queue_mode: 'Quickmatch',
+        },
+      },
+    ]);
+  } finally {
+    releaseRegions();
+    for (const client of webSocketServer.clients) {
+      client.terminate();
+    }
+    await new Promise(resolve => webSocketServer.close(resolve));
+  }
+});

--- a/client/web/types/index.ts
+++ b/client/web/types/index.ts
@@ -19,7 +19,7 @@ export interface AuthContextType {
 
 // Lobby Types
 export interface Lobby {
-  id: number;
+  id: number | null;
   code: string;
   hostUserId: number;
   region: string;
@@ -49,6 +49,7 @@ export interface ChatMessage {
 
 export type LobbyState = 'waiting' | 'queued' | 'matched';
 export type LobbyGameMode = 'duel' | '2v2' | 'solo' | 'ffa';
+export type MatchmakingStatus = 'idle' | 'queued' | 'joining';
 
 export interface LobbyPreferences {
   selectedModes: LobbyGameMode[];
@@ -60,11 +61,15 @@ export interface WebSocketContextType {
   isConnected: boolean;
   isSessionAuthenticated: boolean;
   serverCapabilities: ReadonlySet<string>;
-  sendMessage: (message: any) => void;
+  sendMessage: (message: any) => boolean;
+  waitForSessionReady: (timeoutMs?: number) => Promise<void>;
   onMessage: (type: string, handler: (message: any) => void) => () => void;
   connect: (url: string, onConnect?: () => void) => void;
   disconnect: () => void;
-  connectToRegion: (wsUrl: string, options?: { regionId?: string; origin?: string }) => void;
+  connectToRegion: (
+    wsUrl: string,
+    options?: { regionId?: string; origin?: string; forceReconnect?: boolean }
+  ) => void;
   currentRegionUrl: string | null;
   latencyMs: number;
 
@@ -74,6 +79,8 @@ export interface WebSocketContextType {
   lobbyChatMessages: ChatMessage[];
   gameChatMessages: ChatMessage[];
   lobbyPreferences: LobbyPreferences | null;
+  matchmakingStatus: MatchmakingStatus;
+  setMatchmakingStatus: (status: MatchmakingStatus) => void;
 
   // Lobby methods
   createLobby: () => Promise<void>;


### PR DESCRIPTION
## Summary

- wait for the active regional WebSocket to receive a server authentication acknowledgment for the exact player token before sending lobby or matchmaking commands
- retain matchmaking intent across transport handoffs and share matchmaking status so the UI immediately shows Finding Match
- remove timing-based sleeps and manual authentication, surface start failures, and safely rotate sockets when player identity changes
- add a deterministic regression that delays both region discovery and the authentication acknowledgment

## Testing

- `npm run type-check`
- `npm run build`
- `npm run test:unit` (33 passed)
- `SNAKETRON_TEST_BASE_URL=http://127.0.0.1:3100 npx playwright test tests/start-game-connection-race.spec.js --project=chromium --repeat-each=5` (5 passed)