### PR TITLE
Retry matchmaking admission failures

### DIFF
--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -37,8 +37,10 @@ import {
   candidateDeadlineDelayMs,
   activeGameIdFromPath,
   isCommandOwner,
+  isRetryableMatchmakingAdmissionFailure,
   isSnapshotForGame,
   isTerminalSnapshotForGame,
+  matchmakingAdmissionRetryDelayMs,
   missingRequiredServerCapabilities,
   plannedDrainRemainingMs,
   promotionOrderingFrontier,
@@ -220,9 +222,11 @@ interface StoredLobbyInfo {
 }
 
 interface PendingMatchmakingIntent {
-  message: any;
+  message: OutboundMessage;
   lobbyCode: string;
   authToken: string;
+  retryAttempt: number;
+  retryTimeoutId: ReturnType<typeof setTimeout> | null;
 }
 
 export const useWebSocket = (): WebSocketContextType => {
@@ -286,6 +290,18 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const plannedHandoffStartedAtRef = useRef<number | null>(null);
   const recoveryStartedAtRef = useRef<number | null>(null);
   const usableGapStartedAtRef = useRef<number | null>(null);
+
+  const clearPendingMatchmakingIntent = useCallback(() => {
+    const pending = pendingMatchmakingIntentRef.current;
+    if (pending?.retryTimeoutId !== null && pending?.retryTimeoutId !== undefined) {
+      clearTimeout(pending.retryTimeoutId);
+    }
+    pendingMatchmakingIntentRef.current = null;
+  }, []);
+
+  useEffect(() => () => {
+    clearPendingMatchmakingIntent();
+  }, [clearPendingMatchmakingIntent]);
 
   useEffect(() => {
     latencySettingsRef.current = latencySettings;
@@ -432,7 +448,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   }, []);
 
   const resetLobbyState = useCallback(() => {
-    pendingMatchmakingIntentRef.current = null;
+    clearPendingMatchmakingIntent();
     setMatchmakingStatus('idle');
     setCurrentLobby(null);
     currentLobbyRef.current = null;
@@ -440,7 +456,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     // console.log('setLobbyPreferences', DEFAULT_LOBBY_PREFERENCES);
     // setLobbyPreferences(DEFAULT_LOBBY_PREFERENCES);
     clearPersistedLobby();
-  }, [clearPersistedLobby]);
+  }, [clearPendingMatchmakingIntent, clearPersistedLobby]);
 
   const isLobbyMissingReason = useCallback((reason: string) => {
     if (!reason || typeof reason !== 'string') {
@@ -710,6 +726,10 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       candidate.authTokenSent === pendingMatchmakingIntent.authToken &&
       candidate.socket.readyState === WebSocket.OPEN
     ) {
+      if (pendingMatchmakingIntent.retryTimeoutId !== null) {
+        clearTimeout(pendingMatchmakingIntent.retryTimeoutId);
+        pendingMatchmakingIntent.retryTimeoutId = null;
+      }
       candidate.socket.send(JSON.stringify(pendingMatchmakingIntent.message));
     }
     if (previous && previous !== candidate) {
@@ -826,6 +846,56 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       messageMatchesPendingIdentity &&
       lobbyCode === pendingMatchmakingIntent.lobbyCode,
     );
+    const accessDeniedReason = typeof rawMessage?.AccessDenied?.reason === 'string'
+      ? rawMessage.AccessDenied.reason
+      : null;
+    if (
+      pendingMatchmakingIntent &&
+      messageMatchesPendingIdentity &&
+      isRetryableMatchmakingAdmissionFailure(accessDeniedReason) &&
+      slot.role === 'active' &&
+      activeSlotRef.current === slot &&
+      slot.authenticated &&
+      slot.socket.readyState === WebSocket.OPEN
+    ) {
+      const retryDelayMs = matchmakingAdmissionRetryDelayMs(
+        pendingMatchmakingIntent.retryAttempt,
+      );
+      if (retryDelayMs !== null) {
+        if (pendingMatchmakingIntent.retryTimeoutId === null) {
+          const retryNumber = pendingMatchmakingIntent.retryAttempt + 1;
+          pendingMatchmakingIntent.retryAttempt = retryNumber;
+          pendingMatchmakingIntent.retryTimeoutId = setTimeout(() => {
+            const retainedIntent = pendingMatchmakingIntentRef.current;
+            if (retainedIntent !== pendingMatchmakingIntent) {
+              return;
+            }
+            retainedIntent.retryTimeoutId = null;
+            const retrySlot = activeSlotRef.current;
+            const currentLobbyCode = (
+              currentLobbyRef.current?.code ?? storedLobbyRef.current?.code ?? ''
+            ).trim().toUpperCase();
+            if (
+              retrySlot &&
+              retrySlot.role === 'active' &&
+              retrySlot.authenticated &&
+              retrySlot.authTokenSent === retainedIntent.authToken &&
+              retrySlot.socket.readyState === WebSocket.OPEN &&
+              currentLobbyCode === retainedIntent.lobbyCode
+            ) {
+              retrySlot.socket.send(JSON.stringify(retainedIntent.message));
+            }
+          }, retryDelayMs);
+          console.warn(
+            `Retrying matchmaking queue admission in ${retryDelayMs}ms ` +
+            `(attempt ${retryNumber})`,
+          );
+        }
+        return;
+      }
+      console.error('Matchmaking queue admission retries exhausted');
+      clearPendingMatchmakingIntent();
+    }
     if (
       messageMatchesPendingIdentity && (
         rawMessage?.JoinGame !== undefined ||
@@ -835,7 +905,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         (updateMatchesPendingLobby && (lobbyState === 'queued' || lobbyState === 'matched'))
       )
     ) {
-      pendingMatchmakingIntentRef.current = null;
+      clearPendingMatchmakingIntent();
     } else if (
       updateMatchesPendingLobby &&
       lobbyState === 'waiting' &&
@@ -847,6 +917,10 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     ) {
       // The replacement has restored the same lobby and Redis still says the
       // admission never committed. Replay the one retained logical request.
+      if (pendingMatchmakingIntent.retryTimeoutId !== null) {
+        clearTimeout(pendingMatchmakingIntent.retryTimeoutId);
+        pendingMatchmakingIntent.retryTimeoutId = null;
+      }
       slot.socket.send(JSON.stringify(pendingMatchmakingIntent.message));
     }
 
@@ -1062,7 +1136,16 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       // an already-caught-up candidate to complete atomic promotion.
       promoteCandidate(candidate);
     }
-  }, [buildInitialLobbyPreferences, completeActiveRecovery, dispatchRawMessage, promoteCandidate, recoverAfterCandidateFailure, restoreCandidateContext, setAuthHandshakeState]);
+  }, [
+    buildInitialLobbyPreferences,
+    clearPendingMatchmakingIntent,
+    completeActiveRecovery,
+    dispatchRawMessage,
+    promoteCandidate,
+    recoverAfterCandidateFailure,
+    restoreCandidateContext,
+    setAuthHandshakeState,
+  ]);
 
   const attachSocketHandlers = useCallback((slot: SocketSlot, onConnect?: () => void) => {
     slot.socket.onopen = () => {
@@ -1403,9 +1486,16 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       if (!authToken) {
         throw new Error('Cannot queue for matchmaking before authentication');
       }
-      pendingMatchmakingIntentRef.current = { message, lobbyCode, authToken };
+      clearPendingMatchmakingIntent();
+      pendingMatchmakingIntentRef.current = {
+        message,
+        lobbyCode,
+        authToken,
+        retryAttempt: 0,
+        retryTimeoutId: null,
+      };
     } else if (message === 'LeaveQueue' || message === 'LeaveLobby') {
-      pendingMatchmakingIntentRef.current = null;
+      clearPendingMatchmakingIntent();
     }
     const target = activeSlotRef.current;
     const targetCanSend = () => Boolean(
@@ -1448,7 +1538,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     } else {
       return doSend() || isQueueIntent;
     }
-  }, [getToken, latencySettings]);
+  }, [clearPendingMatchmakingIntent, getToken, latencySettings]);
 
   const authenticateConnection = useCallback(() => {
     const slot = activeSlotRef.current;
@@ -1605,7 +1695,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       pendingMatchmakingIntentRef.current &&
       pendingMatchmakingIntentRef.current.authToken !== token
     ) {
-      pendingMatchmakingIntentRef.current = null;
+      clearPendingMatchmakingIntent();
       setMatchmakingStatus('idle');
     }
     if (!token) {
@@ -1680,6 +1770,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     disconnect,
     getToken,
     authenticateConnection,
+    clearPendingMatchmakingIntent,
     setAuthHandshakeState,
   ]);
 

--- a/client/web/services/websocketLifecycle.ts
+++ b/client/web/services/websocketLifecycle.ts
@@ -1,5 +1,6 @@
 export const RECONNECT_BASE_MS = 100;
 export const RECONNECT_MAX_MS = 2000;
+export const MATCHMAKING_ADMISSION_RETRY_DELAYS_MS = [250, 500, 1000] as const;
 export const PLANNED_HANDOFF_MAX_MS = 20_000;
 export const PLANNED_HANDOFF_MIN_MS = 2_000;
 export const REQUIRED_SERVER_CAPABILITIES = [
@@ -13,6 +14,9 @@ export const REQUIRED_SERVER_CAPABILITIES = [
 ] as const;
 
 export type ReplacementFailureAction = 'retry-candidate' | 'reconnect-active' | 'none';
+
+const RETRYABLE_MATCHMAKING_ADMISSION_REASON =
+  'failed to queue lobby: failed to add lobby to matchmaking queue';
 
 export interface ReplacementReadiness {
   socketOpen: boolean;
@@ -38,6 +42,18 @@ export function isCommandOwner(
   readyState: number,
 ): boolean {
   return activeGeneration === targetGeneration && role === 'active' && readyState === 1;
+}
+
+export function isRetryableMatchmakingAdmissionFailure(reason: unknown): boolean {
+  return typeof reason === 'string' &&
+    reason.trim().toLowerCase() === RETRYABLE_MATCHMAKING_ADMISSION_REASON;
+}
+
+export function matchmakingAdmissionRetryDelayMs(attempt: number): number | null {
+  if (!Number.isInteger(attempt) || attempt < 0) {
+    return null;
+  }
+  return MATCHMAKING_ADMISSION_RETRY_DELAYS_MS[attempt] ?? null;
 }
 
 /** First retry is immediate; later retries use bounded full-width jitter. */

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -10,6 +10,9 @@ const REQUIRED_CAPABILITIES = [
   'terminal-command-cutoff-v1',
 ];
 
+const RETRYABLE_MATCHMAKING_ADMISSION_REASON =
+  'Failed to queue lobby: Failed to add lobby to matchmaking queue';
+
 const gameState = (tick = 5) => ({
   tick,
   status: { Started: { server_id: 1 } },
@@ -840,6 +843,100 @@ test('an unacknowledged matchmaking admission replays only while restored state 
   });
   await page.waitForTimeout(250);
   expect(await socketMessages(page, acknowledgedReplacementIndex, 'QueueForMatch')).toEqual([]);
+});
+
+for (const [messageType, payload] of [
+  ['QueueForMatch', {
+    game_type: { FreeForAll: { max_players: 2 } },
+    queue_mode: 'Quickmatch',
+  }],
+  ['QueueForMatchMulti', {
+    game_types: [
+      { FreeForAll: { max_players: 2 } },
+      { TeamMatch: { per_team: 1 } },
+    ],
+    queue_mode: 'Quickmatch',
+  }],
+]) {
+  test(`${messageType} retries the returned matchmaking admission failure`, async ({ page }) => {
+    const socketIndex = await establishAuthenticatedLobby(page);
+    await page.evaluate(({ messageType, payload }) => {
+      window.__wsContext.sendMessage({ [messageType]: payload });
+    }, { messageType, payload });
+    await expect.poll(() => socketMessages(page, socketIndex, messageType)).toHaveLength(1);
+
+    await emitServerMessage(page, socketIndex, {
+      AccessDenied: { reason: RETRYABLE_MATCHMAKING_ADMISSION_REASON },
+    });
+    await expect.poll(() => socketMessages(page, socketIndex, messageType)).toHaveLength(2);
+    const messages = await socketMessages(page, socketIndex, messageType);
+    expect(messages[1]).toEqual(messages[0]);
+
+    await emitServerMessage(page, socketIndex, {
+      AccessDenied: { reason: RETRYABLE_MATCHMAKING_ADMISSION_REASON },
+    });
+    await emitServerMessage(page, socketIndex, {
+      LobbyUpdate: {
+        ...lobbyUpdate.LobbyUpdate,
+        state: 'queued',
+      },
+    });
+    await page.waitForTimeout(600);
+    expect(await socketMessages(page, socketIndex, messageType)).toHaveLength(2);
+  });
+}
+
+test('matchmaking admission retries are bounded and surface the final denial', async ({ page }) => {
+  const socketIndex = await establishAuthenticatedLobby(page);
+  await page.evaluate(() => {
+    window.__matchmakingAdmissionDenials = [];
+    window.__wsContext.onMessage('AccessDenied', (message) => {
+      window.__matchmakingAdmissionDenials.push(message.data.reason);
+    });
+    window.__wsContext.sendMessage({
+      QueueForMatch: {
+        game_type: { FreeForAll: { max_players: 2 } },
+        queue_mode: 'Quickmatch',
+      },
+    });
+  });
+  await expect.poll(() => socketMessages(page, socketIndex, 'QueueForMatch')).toHaveLength(1);
+
+  for (let expectedSendCount = 2; expectedSendCount <= 4; expectedSendCount += 1) {
+    await emitServerMessage(page, socketIndex, {
+      AccessDenied: { reason: RETRYABLE_MATCHMAKING_ADMISSION_REASON },
+    });
+    await expect.poll(() => socketMessages(page, socketIndex, 'QueueForMatch'), {
+      timeout: 2_000,
+    }).toHaveLength(expectedSendCount);
+    expect(await page.evaluate(() => window.__matchmakingAdmissionDenials)).toEqual([]);
+  }
+
+  await emitServerMessage(page, socketIndex, {
+    AccessDenied: { reason: RETRYABLE_MATCHMAKING_ADMISSION_REASON },
+  });
+  await expect.poll(() => page.evaluate(() => window.__matchmakingAdmissionDenials))
+    .toEqual([RETRYABLE_MATCHMAKING_ADMISSION_REASON]);
+  await page.waitForTimeout(1_100);
+  expect(await socketMessages(page, socketIndex, 'QueueForMatch')).toHaveLength(4);
+});
+
+test('unrelated access denials do not retry matchmaking admission', async ({ page }) => {
+  const socketIndex = await establishAuthenticatedLobby(page);
+  await page.evaluate(() => {
+    window.__wsContext.sendMessage({
+      QueueForMatch: {
+        game_type: { FreeForAll: { max_players: 2 } },
+        queue_mode: 'Quickmatch',
+      },
+    });
+  });
+  await expect.poll(() => socketMessages(page, socketIndex, 'QueueForMatch')).toHaveLength(1);
+  await emitServerMessage(page, socketIndex, {
+    AccessDenied: { reason: 'Join a lobby before queueing for matchmaking' },
+  });
+  await page.waitForTimeout(350);
+  expect(await socketMessages(page, socketIndex, 'QueueForMatch')).toHaveLength(1);
 });
 
 test('planned lobby handoff replays only after the candidate restores authoritative waiting state', async ({ page }) => {

--- a/client/web/tests/unit/websocketLifecycle.test.ts
+++ b/client/web/tests/unit/websocketLifecycle.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  MATCHMAKING_ADMISSION_RETRY_DELAYS_MS,
   PLANNED_HANDOFF_MAX_MS,
   RECONNECT_MAX_MS,
   advanceCandidateGameWatermark,
@@ -10,8 +11,10 @@ import {
   candidateCoversActiveWatermark,
   isFreshSnapshotForGame,
   isCommandOwner,
+  isRetryableMatchmakingAdmissionFailure,
   isSnapshotForGame,
   isTerminalSnapshotForGame,
+  matchmakingAdmissionRetryDelayMs,
   missingRequiredServerCapabilities,
   plannedDrainRemainingMs,
   promotionOrderingFrontier,
@@ -19,6 +22,41 @@ import {
   replacementFailureAction,
   replacementReadyForPromotion,
 } from '../../services/websocketLifecycle.ts';
+
+test('only the returned matchmaking admission failure is retryable', () => {
+  assert.equal(
+    isRetryableMatchmakingAdmissionFailure(
+      'Failed to queue lobby: Failed to add lobby to matchmaking queue',
+    ),
+    true,
+  );
+  assert.equal(
+    isRetryableMatchmakingAdmissionFailure(
+      ' failed to queue lobby: failed to add lobby to matchmaking queue ',
+    ),
+    true,
+  );
+  assert.equal(
+    isRetryableMatchmakingAdmissionFailure('Join a lobby before queueing for matchmaking'),
+    false,
+  );
+  assert.equal(isRetryableMatchmakingAdmissionFailure(null), false);
+});
+
+test('matchmaking admission retries stop after the bounded delay schedule', () => {
+  assert.deepEqual(
+    MATCHMAKING_ADMISSION_RETRY_DELAYS_MS.map((_, attempt) => (
+      matchmakingAdmissionRetryDelayMs(attempt)
+    )),
+    [...MATCHMAKING_ADMISSION_RETRY_DELAYS_MS],
+  );
+  assert.equal(
+    matchmakingAdmissionRetryDelayMs(MATCHMAKING_ADMISSION_RETRY_DELAYS_MS.length),
+    null,
+  );
+  assert.equal(matchmakingAdmissionRetryDelayMs(-1), null);
+  assert.equal(matchmakingAdmissionRetryDelayMs(0.5), null);
+});
 
 test('the current websocket protocol fails closed when a capability is absent', () => {
   const current = [


### PR DESCRIPTION
## Summary

- retry retained QueueForMatch and QueueForMatchMulti requests when the server returns the known matchmaking admission denial
- use bounded 250 ms, 500 ms, and 1,000 ms backoff while suppressing intermediate denials and surfacing the final denial
- cancel stale retries when matchmaking succeeds, the lobby or auth identity changes, the user leaves, or the provider unmounts
- cover payload preservation, acknowledgement cancellation, bounded exhaustion, and unrelated denials

## Testing

- wasm-pack build --target web --out-dir pkg
- npm run type-check
- npm run test:unit (35 passed)
- npm run test:drain (20 passed)
- npm run build:prod