### PR TITLE
Polish lobby UX and preserve guest accounts on sign-up

### DIFF
--- a/client/web/App.tsx
+++ b/client/web/App.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
-import { BrowserRouter, Route, matchPath, useLocation } from 'react-router-dom';
+import React, { useEffect, useState } from 'react';
+import { BrowserRouter, Navigate, Route, matchPath, useLocation } from 'react-router-dom';
 import './index.css';
-import Auth from './components/Auth';
+import { AccountModal } from './components/AccountModal';
+import type { AccountModalView } from './components/AccountModal';
+import AuthModal from './components/AuthModal';
 import CustomGameCreator from './components/CustomGameCreator';
 import GameLobby from './components/GameLobby';
 import GameArena from './components/GameArena';
@@ -14,23 +16,56 @@ import { ArenaBackdrop, SHOW_BACKDROP_DURING_GAMEPLAY } from './components/Arena
 import { Leaderboard } from './components/Leaderboard';
 import { MatchmakingBanner } from './components/MatchmakingBanner';
 import { WebSocketProvider } from './contexts/WebSocketContext';
-import { AuthProvider } from './contexts/AuthContext';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { UIProvider } from './contexts/UIContext';
 import { LatencyProvider } from './contexts/LatencyContext';
 
 function AppContent() {
   const location = useLocation();
+  const { user } = useAuth();
+  const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
+  const [accountModalView, setAccountModalView] = useState<AccountModalView | null>(null);
   const isGameArenaActive = matchPath('/play/:gameId', location.pathname) !== null;
   const showBackdrop = SHOW_BACKDROP_DURING_GAMEPLAY || !isGameArenaActive;
+
+  useEffect(() => {
+    if (location.pathname === '/auth') {
+      setIsAuthModalOpen(true);
+    }
+  }, [location.pathname]);
+
+  useEffect(() => {
+    if (!user || user.isGuest) {
+      setAccountModalView(null);
+    }
+  }, [user]);
 
   return (
     <div className="min-h-screen flex flex-col">
       {showBackdrop && <ArenaBackdrop />}
       <MatchmakingBanner />
       <AnimatedRoutes>
-        <Route path="/" element={<NewHome />} />
-        <Route path="/auth" element={<Auth />} />
-        <Route path="/leaderboards" element={<Leaderboard />} />
+        <Route
+          path="/"
+          element={
+            <NewHome
+              onOpenAuth={() => setIsAuthModalOpen(true)}
+              onOpenAccount={setAccountModalView}
+            />
+          }
+        />
+        <Route path="/auth" element={<Navigate to="/" replace />} />
+        <Route
+          path="/leaderboards"
+          element={
+            <Leaderboard
+              onOpenAuth={() => setIsAuthModalOpen(true)}
+              onOpenAccount={setAccountModalView}
+            />
+          }
+        />
+        <Route path="/profile" element={<Navigate to="/" replace />} />
+        <Route path="/history" element={<Navigate to="/" replace />} />
         <Route path="/game-modes/:category" element={<GameModeSelector />} />
         <Route path="/custom" element={<CustomGameCreator />} />
         <Route path="/lobby/:lobbyCode" element={<LobbyInvitePage />} />
@@ -51,6 +86,15 @@ function AppContent() {
           }
         />
       </AnimatedRoutes>
+      <AuthModal
+        isOpen={isAuthModalOpen}
+        onClose={() => setIsAuthModalOpen(false)}
+      />
+      <AccountModal
+        view={accountModalView}
+        user={user}
+        onClose={() => setAccountModalView(null)}
+      />
     </div>
   );
 }

--- a/client/web/components/AccountModal.tsx
+++ b/client/web/components/AccountModal.tsx
@@ -1,0 +1,67 @@
+import React, { useRef } from 'react';
+import { User } from '../types';
+import { HistoryIcon } from './Icons';
+import { LobbyModal } from './LobbyModal';
+
+export type AccountModalView = 'profile' | 'history';
+
+interface AccountModalProps {
+  view: AccountModalView | null;
+  user: User | null;
+  onClose: () => void;
+}
+
+export const AccountModal: React.FC<AccountModalProps> = ({ view, user, onClose }) => {
+  const doneButtonRef = useRef<HTMLButtonElement>(null);
+
+  if (!view || !user || user.isGuest) {
+    return null;
+  }
+
+  const isHistory = view === 'history';
+
+  return (
+    <LobbyModal
+      isOpen
+      onClose={onClose}
+      title={isHistory ? 'History' : 'Profile'}
+      description={isHistory
+        ? 'Completed matches will be collected here.'
+        : 'Your Snaketron player details.'}
+      initialFocusRef={doneButtonRef}
+    >
+      {isHistory ? (
+        <div className="account-history-empty">
+          <HistoryIcon className="account-history-icon" />
+          <h3>Match history is coming soon</h3>
+        </div>
+      ) : (
+        <dl className="account-profile-details">
+          <div>
+            <dt>Username</dt>
+            <dd>{user.username}</dd>
+          </div>
+          <div>
+            <dt>Player ID</dt>
+            <dd>#{user.id}</dd>
+          </div>
+          <div>
+            <dt>Rating</dt>
+            <dd>{user.mmr?.toLocaleString() ?? '—'}</dd>
+          </div>
+        </dl>
+      )}
+
+      <div className="lobby-modal-actions lobby-modal-invite-actions">
+        <button
+          ref={doneButtonRef}
+          type="button"
+          className="lobby-modal-button is-secondary"
+          onClick={onClose}
+        >
+          Done
+        </button>
+      </div>
+    </LobbyModal>
+  );
+};

--- a/client/web/components/Auth.tsx
+++ b/client/web/components/Auth.tsx
@@ -229,7 +229,7 @@ function Auth() {
                     Currently playing as guest: <strong>{user.username}</strong>
                   </p>
                   <p className="text-xs text-blue-600 mt-1">
-                    Log in to access more features such as competitive play.
+                    Sign in to access more features such as competitive play.
                   </p>
                 </div>
               )}
@@ -283,7 +283,7 @@ function Auth() {
                       : 'border-gray-300 bg-gray-50 cursor-not-allowed opacity-50 text-gray-500'
                   }`}
                 >
-                  LOGIN
+                  SIGN IN
                 </button>
               </div>
             </>

--- a/client/web/components/AuthModal.tsx
+++ b/client/web/components/AuthModal.tsx
@@ -1,141 +1,433 @@
-import React, { useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
+import { useDebouncedValue } from '../hooks/useDebouncedValue';
+import { api, isApiError } from '../services/api';
 import { AuthModalProps, FormEventHandler } from '../types';
+import { LobbyModal } from './LobbyModal';
+
+type AuthOperation = 'login' | 'register';
+type AuthErrorTarget = 'username' | 'password' | 'form' | null;
+type UsernameLookup =
+  | { kind: 'idle' }
+  | { kind: 'checking'; value: string }
+  | { kind: 'login'; value: string }
+  | { kind: 'register'; value: string }
+  | { kind: 'invalid'; value: string; message: string }
+  | { kind: 'failed'; value: string };
+
+const usernameValidationError = (value: string): string | null => {
+  if (!value) {
+    return 'Enter your username.';
+  }
+  if (value.length < 3) {
+    return 'Username must be at least 3 characters.';
+  }
+  if (value.length > 20) {
+    return 'Username must be 20 characters or fewer.';
+  }
+  if (!/^[\p{L}\p{N}_-]+$/u.test(value)) {
+    return 'Use only letters, numbers, underscores, or hyphens.';
+  }
+  if (/^[_-]|[_-]$/.test(value)) {
+    return 'Username cannot begin or end with an underscore or hyphen.';
+  }
+  return null;
+};
+
+const withTerminalPunctuation = (message: string): string =>
+  /[.!?]$/.test(message) ? message : `${message}.`;
+
+const checkUsername = async (value: string): Promise<UsernameLookup> => {
+  const validationError = usernameValidationError(value);
+  if (validationError) {
+    return { kind: 'invalid', value, message: validationError };
+  }
+
+  const result = await api.checkUsername(value);
+  if (result.available) {
+    return { kind: 'register', value };
+  }
+
+  const existingAccount = result.errors.some((message) =>
+    message.toLowerCase().includes('already taken'),
+  );
+  if (existingAccount) {
+    return { kind: 'login', value };
+  }
+
+  if (result.errors.length > 0) {
+    return {
+      kind: 'invalid',
+      value,
+      message: withTerminalPunctuation(result.errors[0]),
+    };
+  }
+
+  return { kind: 'failed', value };
+};
+
+const getInitialUsername = (guestUsername?: string): string => {
+  if (guestUsername) {
+    return guestUsername;
+  }
+
+  try {
+    return window.localStorage.getItem('savedUsername')?.trim() ?? '';
+  } catch {
+    return '';
+  }
+};
+
+const authenticationErrorMessage = (
+  error: unknown,
+  operation: AuthOperation,
+): string => {
+  if (isApiError(error)) {
+    if (error.response.status === 401) {
+      return 'That username and password do not match.';
+    }
+    if (error.response.status === 409) {
+      return 'That username is already in use. Try signing in instead.';
+    }
+    if (error.message && error.message !== 'Request failed' && error.message !== 'Internal server error') {
+      return error.message;
+    }
+  }
+
+  if (error instanceof TypeError) {
+    return 'Could not reach the server. Check your connection and try again.';
+  }
+
+  return operation === 'login'
+    ? 'Could not sign in. Try again in a moment.'
+    : 'Could not create the account. Try again in a moment.';
+};
+
+const lookupOperation = (lookup: UsernameLookup, value: string): AuthOperation | null => {
+  if (lookup.kind === 'login' && lookup.value === value) {
+    return 'login';
+  }
+  if (lookup.kind === 'register' && lookup.value === value) {
+    return 'register';
+  }
+  return null;
+};
 
 const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose }) => {
-  const [mode, setMode] = useState('login'); // 'login' or 'register'
+  const { user, login, register } = useAuth();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
-  const [confirmPassword, setConfirmPassword] = useState('');
-  const [error, setError] = useState('');
-  const [loading, setLoading] = useState(false);
-  
-  const { login, register } = useAuth();
+  const [lookup, setLookup] = useState<UsernameLookup>({ kind: 'idle' });
+  const [error, setError] = useState<string | null>(null);
+  const [errorTarget, setErrorTarget] = useState<AuthErrorTarget>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submittingOperation, setSubmittingOperation] = useState<AuthOperation | null>(null);
+  const debouncedUsername = useDebouncedValue(username.trim(), 400);
+  const usernameRef = useRef<HTMLInputElement>(null);
+  const lookupRequestRef = useRef(0);
+  const usernameId = useId();
+  const passwordId = useId();
+  const statusId = useId();
+  const errorId = useId();
 
-  const handleSubmit: FormEventHandler = async (e) => {
-    e.preventDefault();
-    setError('');
-
-    // Validation
-    if (!username || !password) {
-      setError('Please fill in all fields');
+  useEffect(() => {
+    if (!isOpen) {
+      lookupRequestRef.current += 1;
       return;
     }
 
-    if (mode === 'register') {
-      if (password.length < 6) {
-        setError('Password must be at least 6 characters');
-        return;
-      }
-      if (password !== confirmPassword) {
-        setError('Passwords do not match');
-        return;
-      }
+    const initialUsername = getInitialUsername(user?.isGuest ? user.username : undefined);
+    setUsername(initialUsername);
+    setPassword('');
+    setLookup(initialUsername.length >= 3
+      ? { kind: 'checking', value: initialUsername }
+      : { kind: 'idle' });
+    setError(null);
+    setErrorTarget(null);
+    setIsSubmitting(false);
+    setSubmittingOperation(null);
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
     }
 
-    setLoading(true);
+    const normalizedUsername = username.trim();
+    const requestId = lookupRequestRef.current + 1;
+    lookupRequestRef.current = requestId;
 
-    try {
-      if (mode === 'login') {
-        await login(username, password);
-      } else {
-        await register(username, password);
+    if (debouncedUsername !== normalizedUsername) {
+      setLookup(normalizedUsername.length >= 3
+        ? { kind: 'checking', value: normalizedUsername }
+        : { kind: 'idle' });
+      return;
+    }
+    if (!normalizedUsername) {
+      setLookup({ kind: 'idle' });
+      return;
+    }
+    if (normalizedUsername.length < 3) {
+      setLookup({ kind: 'idle' });
+      return;
+    }
+
+    setLookup({ kind: 'checking', value: normalizedUsername });
+    void checkUsername(normalizedUsername).then((result) => {
+      if (lookupRequestRef.current === requestId) {
+        setLookup(result);
       }
-      
+    });
+  }, [debouncedUsername, isOpen, username]);
+
+  const handleDismiss = () => {
+    if (!isSubmitting) {
       onClose();
-      // Reset form
-      setUsername('');
-      setPassword('');
-      setConfirmPassword('');
-    } finally {
-      setLoading(false);
     }
   };
 
-  if (!isOpen) return null;
+  const clearError = () => {
+    if (error) {
+      setError(null);
+      setErrorTarget(null);
+    }
+  };
+
+  const handleUsernameChange: React.ChangeEventHandler<HTMLInputElement> = (event) => {
+    const nextUsername = event.target.value;
+    const normalizedUsername = nextUsername.trim();
+    lookupRequestRef.current += 1;
+    setUsername(nextUsername);
+    setLookup(normalizedUsername.length >= 3
+      ? { kind: 'checking', value: normalizedUsername }
+      : { kind: 'idle' });
+    clearError();
+  };
+
+  const handleSubmit: FormEventHandler = async (event) => {
+    event.preventDefault();
+    const normalizedUsername = username.trim();
+    const usernameError = usernameValidationError(normalizedUsername);
+
+    if (usernameError) {
+      setError(usernameError);
+      setErrorTarget('username');
+      return;
+    }
+    if (!password) {
+      setError('Enter your password.');
+      setErrorTarget('password');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    setErrorTarget(null);
+    let activeOperation: AuthOperation | null = null;
+
+    try {
+      let operation = lookupOperation(lookup, normalizedUsername);
+      if (!operation) {
+        setLookup({ kind: 'checking', value: normalizedUsername });
+        const resolvedLookup = await checkUsername(normalizedUsername);
+        setLookup(resolvedLookup);
+        operation = lookupOperation(resolvedLookup, normalizedUsername);
+
+        if (!operation) {
+          if (resolvedLookup.kind === 'invalid') {
+            setError(resolvedLookup.message);
+            setErrorTarget('username');
+          } else {
+            setError('Could not check that username. Try again in a moment.');
+            setErrorTarget('form');
+          }
+          return;
+        }
+      }
+
+      if (operation === 'register' && password.length < 6) {
+        setError('Use at least 6 characters to create an account.');
+        setErrorTarget('password');
+        return;
+      }
+
+      activeOperation = operation;
+      setSubmittingOperation(operation);
+      if (operation === 'login') {
+        await login(normalizedUsername, password);
+      } else {
+        await register(normalizedUsername, password);
+      }
+
+      try {
+        window.localStorage.setItem('savedUsername', normalizedUsername);
+      } catch {
+        // Authentication still succeeds when storage is unavailable.
+      }
+
+      onClose();
+      setPassword('');
+      setError(null);
+      setErrorTarget(null);
+    } catch (authenticationError: unknown) {
+      const operation = activeOperation ?? lookupOperation(lookup, normalizedUsername) ?? 'login';
+      setError(authenticationErrorMessage(authenticationError, operation));
+      setErrorTarget('form');
+    } finally {
+      setIsSubmitting(false);
+      setSubmittingOperation(null);
+    }
+  };
+
+  const operation = lookupOperation(lookup, username.trim());
+  const isCheckingUsername = lookup.kind === 'checking';
+  const canRetryLookup = lookup.kind === 'failed';
+  const submitLabel = isSubmitting
+    ? submittingOperation === 'register'
+      ? 'Creating account…'
+      : submittingOperation === 'login'
+        ? 'Signing in…'
+        : 'Checking…'
+    : operation === 'register'
+      ? 'Create account'
+      : operation === 'login'
+        ? 'Sign in'
+        : isCheckingUsername
+          ? 'Checking…'
+          : canRetryLookup
+            ? 'Try again'
+            : 'Continue';
+
+  const status = (() => {
+    if (lookup.kind === 'checking') {
+      return { text: 'Checking username…', isError: false };
+    }
+    if (lookup.kind === 'register') {
+      return { text: 'New username — enter a password to create your account.', isError: false };
+    }
+    if (lookup.kind === 'login') {
+      return { text: 'Account found — enter your password to sign in.', isError: false };
+    }
+    if (lookup.kind === 'invalid') {
+      return { text: lookup.message, isError: true };
+    }
+    if (lookup.kind === 'failed') {
+      return { text: 'Could not check that username. Try again.', isError: true };
+    }
+    return { text: 'Usernames are 3–20 characters.', isError: false };
+  })();
+
+  const isSubmitDisabled = isSubmitting
+    || !username.trim()
+    || !password
+    || isCheckingUsername
+    || lookup.kind === 'idle'
+    || lookup.kind === 'invalid';
+  const isGuest = Boolean(user?.isGuest);
+  const modalDescription = isGuest && user ? (
+    <span className="auth-modal-guest-description">
+      <span className="auth-modal-guest-identity">
+        You’re playing as <strong>{user.username}</strong>{' '}
+        <span className="auth-modal-guest-suffix">(guest)</span>.
+      </span>{' '}
+      <span className="auth-modal-guest-guidance">
+        Sign in to an existing account, or create one to keep your name and progress.
+      </span>
+    </span>
+  ) : (
+    'Enter your username to sign in or create an account.'
+  );
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-      <div className="bg-white rounded-lg p-8 max-w-md w-full mx-4">
-        <h2 className="text-2xl font-black italic uppercase mb-6 text-center">
-          {mode === 'login' ? 'Login' : 'Create Account'}
-        </h2>
-        
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
+    <LobbyModal
+      isOpen={isOpen}
+      onClose={handleDismiss}
+      title="Sign in or create account"
+      description={modalDescription}
+      initialFocusRef={usernameRef}
+      isDismissDisabled={isSubmitting}
+    >
+      <form
+        className="lobby-modal-form auth-modal-form"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-busy={isSubmitting}
+      >
+        <div className="auth-modal-fields">
+          <div className="auth-modal-field">
+            <label className="visually-hidden" htmlFor={usernameId}>Username</label>
             <input
+              ref={usernameRef}
+              id={usernameId}
               type="text"
               placeholder="Username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:border-black"
-              disabled={loading}
+              onChange={handleUsernameChange}
+              className="auth-modal-input"
+              autoComplete="username"
+              autoCapitalize="none"
+              spellCheck={false}
+              maxLength={20}
+              disabled={isSubmitting}
+              aria-invalid={errorTarget === 'username' || lookup.kind === 'invalid'}
+              aria-describedby={error ? errorId : statusId}
             />
           </div>
-          
-          <div>
+
+          <div className="auth-modal-field">
+            <label className="visually-hidden" htmlFor={passwordId}>Password</label>
             <input
+              id={passwordId}
               type="password"
-              placeholder="Password"
+              placeholder={operation === 'register' ? 'Password (6+ characters)' : 'Password'}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:border-black"
-              disabled={loading}
+              onChange={(event) => {
+                setPassword(event.target.value);
+                clearError();
+              }}
+              className="auth-modal-input"
+              autoComplete={operation === 'register' ? 'new-password' : 'current-password'}
+              disabled={isSubmitting}
+              aria-invalid={errorTarget === 'password'}
+              aria-describedby={error ? errorId : undefined}
             />
           </div>
-          
-          {mode === 'register' && (
-            <div>
-              <input
-                type="password"
-                placeholder="Confirm Password"
-                value={confirmPassword}
-                onChange={(e) => setConfirmPassword(e.target.value)}
-                className="w-full px-4 py-2 border border-gray-300 rounded focus:outline-none focus:border-black"
-                disabled={loading}
-              />
-            </div>
+
+          {error ? (
+            <p id={errorId} className="auth-modal-status is-error" role="alert">
+              {error}
+            </p>
+          ) : (
+            <p
+              id={statusId}
+              className={`auth-modal-status ${status.isError ? 'is-error' : ''}`}
+              aria-live="polite"
+            >
+              {status.text}
+            </p>
           )}
-          
-          {error && (
-            <div className="text-red-500 text-sm text-center">{error}</div>
-          )}
-          
+        </div>
+
+        <div className="lobby-modal-actions">
+          <button
+            type="button"
+            className="lobby-modal-button is-secondary"
+            onClick={handleDismiss}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </button>
           <button
             type="submit"
-            disabled={loading}
-            className="w-full bg-black text-white py-2 rounded font-bold uppercase tracking-wider hover:bg-gray-800 transition-colors disabled:opacity-50"
+            className="lobby-modal-button is-primary"
+            disabled={isSubmitDisabled}
           >
-            {loading ? 'Loading...' : (mode === 'login' ? 'Login' : 'Register')}
-          </button>
-        </form>
-        
-        <div className="mt-4 text-center">
-          <button
-            onClick={() => {
-              setMode(mode === 'login' ? 'register' : 'login');
-              setError('');
-            }}
-            className="text-sm text-gray-600 hover:text-black"
-            disabled={loading}
-          >
-            {mode === 'login' 
-              ? "Don't have an account? Register" 
-              : "Already have an account? Login"}
+            {isSubmitting && <span className="lobby-modal-spinner" aria-hidden="true" />}
+            <span>{submitLabel}</span>
           </button>
         </div>
-        
-        <button
-          onClick={onClose}
-          className="absolute top-4 right-4 text-gray-400 hover:text-gray-600"
-          disabled={loading}
-        >
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </button>
-      </div>
-    </div>
+      </form>
+    </LobbyModal>
   );
 };
 

--- a/client/web/components/GameArena.tsx
+++ b/client/web/components/GameArena.tsx
@@ -659,7 +659,7 @@ export default function GameArena() {
   const showAuthLoading = authLoading || !user;
 
   if (showAuthLoading) {
-    return <LoadingScreen message={authLoading ? 'Authenticating...' : 'Please log in to play'} />;
+    return <LoadingScreen message={authLoading ? 'Authenticating...' : 'Please sign in to play'} />;
   }
   
   return (

--- a/client/web/components/GameModeSelector.tsx
+++ b/client/web/components/GameModeSelector.tsx
@@ -237,7 +237,7 @@ function GameModeSelector() {
               />
               <div className="auth-message ml-2 h-8 mb-1 mt-1 flex items-center">
                 {isAuthenticating && (
-                  <p className="text-sm text-gray-700">Logging in...</p>
+                  <p className="text-sm text-gray-700">Signing in...</p>
                 )}
                 {authError && (
                   <p className="text-red-600 text-sm">{authError}</p>

--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -56,7 +56,7 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
   const [isCompetitive, setIsCompetitive] = useState<boolean | null>(null);
   const nicknameInputRef = useRef<HTMLInputElement>(null);
   const lastSubmittedNicknameRef = useRef<string | null>(null);
-  const { user } = useAuth();
+  const { user, updateGuestNickname } = useAuth();
   const { sendMessage } = useWebSocket();
   const prevUsernameRef = useRef<string | null>(null);
   const canEdit = !isLobbyQueued;
@@ -152,9 +152,12 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
       return;
     }
 
-    sendMessage({ UpdateNickname: { nickname: nextNickname } });
+    if (!sendMessage({ UpdateNickname: { nickname: nextNickname } })) {
+      return;
+    }
+    updateGuestNickname(nextNickname);
     lastSubmittedNicknameRef.current = nextNickname;
-  }, [debouncedNickname, user, sendMessage]);
+  }, [debouncedNickname, user, sendMessage, updateGuestNickname]);
 
   const gameModes: Array<{ id: LobbyGameMode; label: string }> = [
     { id: 'duel', label: 'DUEL' },
@@ -196,11 +199,27 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
 
   const isFormValid = selectedModes && selectedModes.size > 0 && nickname.trim().length >= 3;
   const startButtonDisabled = isLobbyQueued || !isFormValid || isLoading;
+  const startButtonActivating = isLobbyQueued || isLoading;
   const startButtonLabel = isLobbyQueued
     ? 'Finding Match...'
     : isLoading
         ? 'Starting...'
         : 'Start Game';
+  const wasStartButtonDisabledRef = useRef(startButtonDisabled);
+  const [enableAnimation, setEnableAnimation] = useState({ key: 0, visible: false });
+
+  useEffect(() => {
+    const wasDisabled = wasStartButtonDisabledRef.current;
+    wasStartButtonDisabledRef.current = startButtonDisabled;
+
+    if (wasDisabled && !startButtonDisabled) {
+      setEnableAnimation(({ key }) => ({ key: key + 1, visible: true }));
+    } else if (startButtonDisabled) {
+      setEnableAnimation((current) => (
+        current.visible ? { ...current, visible: false } : current
+      ));
+    }
+  }, [startButtonDisabled]);
 
   return (
     <form onSubmit={handleSubmit} className="w-full max-w-md mx-auto">
@@ -256,7 +275,7 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
                   onClick={() => toggleMode(mode.id)}
                   disabled={!canEdit || isLoading}
                   className={`
-                    relative py-4 px-4 rounded-lg font-black italic uppercase tracking-1 text-base
+                    game-mode-choice relative py-4 px-4 rounded-lg font-black uppercase tracking-1 text-base
                     transition-all border-2
                     ${isSelected
                       ? 'border-blue-500 bg-blue-50 text-black-70'
@@ -353,16 +372,68 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
         <button
           type="submit"
           disabled={startButtonDisabled}
+          aria-busy={startButtonActivating}
           className={`
-            w-full py-4 rounded-lg font-black italic uppercase tracking-1 text-lg
-            transition-all border-2
+            game-start-button w-full py-4 rounded-lg font-black uppercase tracking-1 text-lg
+            inline-flex items-center justify-center
+            border-2
             ${startButtonDisabled
-              ? 'bg-gray-50 border-gray-200 text-gray-400 cursor-not-allowed'
-              : 'bg-white border-black-70 text-black-70 hover:bg-gray-50 cursor-pointer'
+              ? startButtonActivating
+                ? 'is-activating cursor-wait'
+                : 'is-disabled bg-gray-50 border-gray-200 text-gray-400 cursor-not-allowed'
+              : 'cursor-pointer'
             }
           `}
         >
-          {startButtonLabel}
+          {enableAnimation.visible && (
+            <span
+              key={enableAnimation.key}
+              className="game-start-enable-sweep"
+              aria-hidden="true"
+            >
+              <svg
+                className="game-start-enable-chevron is-primary"
+                viewBox="0 0 42 34"
+              >
+                <path d="M0 0h11l17 17-17 17H0l17-17ZM13 0h11l17 17-17 17H13l17-17Z" />
+              </svg>
+              <svg
+                className="game-start-enable-chevron is-echo"
+                viewBox="0 0 42 34"
+                onAnimationEnd={(event) => {
+                  if (event.animationName !== 'game-start-enable-sweep-motion') {
+                    return;
+                  }
+                  setEnableAnimation((current) => (
+                    current.key === enableAnimation.key
+                      ? { ...current, visible: false }
+                      : current
+                  ));
+                }}
+              >
+                <path d="M0 0h11l17 17-17 17H0l17-17ZM13 0h11l17 17-17 17H13l17-17Z" />
+              </svg>
+            </span>
+          )}
+          <svg
+            className="game-start-chevrons is-left"
+            viewBox="0 0 31 28"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M0 2h8l12 12L8 26H0l12-12Z" />
+          </svg>
+          <span className="game-start-content">
+            <span className="game-start-label">{startButtonLabel}</span>
+          </span>
+          <svg
+            className="game-start-chevrons is-right"
+            viewBox="0 0 31 28"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path d="M10 2h8l12 12-12 12h-8l12-12Z" />
+          </svg>
         </button>
         <div className="min-h-5 mt-3" aria-live="polite">
           {errorMessage && (

--- a/client/web/components/HomeHeader.tsx
+++ b/client/web/components/HomeHeader.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { LobbyMember, User } from '../types';
-import { KeyIcon, LogoutIcon, UserPlusIcon } from './Icons';
+import type { AccountModalView } from './AccountModal';
+import { HistoryIcon, KeyIcon, LogoutIcon, UserIcon, UserPlusIcon } from './Icons';
 
 interface HomeHeaderProps {
   activePage?: 'play' | 'leaderboards';
@@ -12,7 +13,8 @@ interface HomeHeaderProps {
   onInvite: () => void;
   onJoinGame: () => void;
   onLeaveLobby: () => void;
-  onLoginClick: () => void;
+  onAuthClick: () => void;
+  onOpenAccount: (view: AccountModalView) => void;
   onLogout: () => void;
 }
 
@@ -25,22 +27,34 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
   onInvite,
   onJoinGame,
   onLeaveLobby,
-  onLoginClick,
+  onAuthClick,
+  onOpenAccount,
   onLogout,
 }) => {
   const [isSocialOpen, setIsSocialOpen] = useState(false);
+  const [isAccountOpen, setIsAccountOpen] = useState(false);
   const socialMenuRef = useRef<HTMLDivElement>(null);
+  const accountMenuRef = useRef<HTMLDivElement>(null);
+  const accountTriggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     const handlePointerDown = (event: MouseEvent) => {
       if (socialMenuRef.current && !socialMenuRef.current.contains(event.target as Node)) {
         setIsSocialOpen(false);
       }
+      if (accountMenuRef.current && !accountMenuRef.current.contains(event.target as Node)) {
+        setIsAccountOpen(false);
+      }
     };
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setIsSocialOpen(false);
+        setIsAccountOpen(false);
+
+        if (accountMenuRef.current?.contains(document.activeElement)) {
+          accountTriggerRef.current?.focus();
+        }
       }
     };
 
@@ -53,6 +67,12 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
   }, []);
 
   const closeSocialMenu = () => setIsSocialOpen(false);
+  const closeAccountMenu = () => setIsAccountOpen(false);
+  const openAccountModal = (view: AccountModalView) => {
+    closeAccountMenu();
+    accountTriggerRef.current?.focus();
+    onOpenAccount(view);
+  };
 
   return (
     <header className="home-header">
@@ -76,7 +96,10 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             <button
               type="button"
               className={`home-nav-link home-social-trigger ${isSocialOpen ? 'is-open' : ''}`}
-              onClick={() => setIsSocialOpen((current) => !current)}
+              onClick={() => {
+                setIsAccountOpen(false);
+                setIsSocialOpen((current) => !current);
+              }}
               aria-expanded={isSocialOpen}
               aria-haspopup="menu"
             >
@@ -155,17 +178,135 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
           </div>
         </nav>
 
-        <div className="home-account">
+        <div className="home-account home-account-menu" ref={accountMenuRef}>
           {currentUser && !currentUser.isGuest ? (
             <>
-              <span className="home-account-name">{currentUser.username}</span>
-              <button type="button" onClick={onLogout} className="home-account-action">
-                Log out
+              <button
+                ref={accountTriggerRef}
+                id="account-menu-trigger"
+                type="button"
+                className={`home-account-action home-account-trigger ${isAccountOpen ? 'is-open' : ''}`}
+                onClick={() => {
+                  setIsSocialOpen(false);
+                  setIsAccountOpen((current) => !current);
+                }}
+                aria-expanded={isAccountOpen}
+                aria-haspopup="menu"
+                aria-controls="account-menu"
+              >
+                <span className="home-account-username">{currentUser.username}</span>
+                <svg viewBox="0 0 12 8" aria-hidden="true">
+                  <path d="M1 1.5 6 6.5l5-5" />
+                </svg>
               </button>
+
+              {isAccountOpen && (
+                <div
+                  id="account-menu"
+                  className="home-social-panel home-account-panel"
+                  role="menu"
+                  aria-labelledby="account-menu-trigger"
+                >
+                  <div className="home-social-actions home-account-actions">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => openAccountModal('profile')}
+                    >
+                      <span>Profile</span>
+                      <UserIcon className="home-social-action-icon" />
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => openAccountModal('history')}
+                    >
+                      <span>History</span>
+                      <HistoryIcon className="home-social-action-icon" />
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="is-destructive"
+                      onClick={() => {
+                        closeAccountMenu();
+                        onLogout();
+                      }}
+                    >
+                      <span>Logout</span>
+                      <LogoutIcon className="home-social-action-icon" />
+                    </button>
+                  </div>
+                </div>
+              )}
+            </>
+          ) : currentUser?.isGuest ? (
+            <>
+              <button
+                ref={accountTriggerRef}
+                id="guest-account-menu-trigger"
+                type="button"
+                className={`home-account-action home-account-trigger ${isAccountOpen ? 'is-open' : ''}`}
+                onClick={() => {
+                  setIsSocialOpen(false);
+                  setIsAccountOpen((current) => !current);
+                }}
+                aria-expanded={isAccountOpen}
+                aria-haspopup="menu"
+                aria-controls="guest-account-menu"
+              >
+                <span className="home-account-guest-label">
+                  <span className="home-account-username">{currentUser.username}</span>
+                  <span className="home-account-guest-suffix">(guest)</span>
+                </span>
+                <svg viewBox="0 0 12 8" aria-hidden="true">
+                  <path d="M1 1.5 6 6.5l5-5" />
+                </svg>
+              </button>
+
+              {isAccountOpen && (
+                <div
+                  id="guest-account-menu"
+                  className="home-social-panel home-account-panel"
+                  role="menu"
+                  aria-labelledby="guest-account-menu-trigger"
+                >
+                  <div className="home-social-actions home-account-actions">
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        closeAccountMenu();
+                        accountTriggerRef.current?.focus();
+                        onAuthClick();
+                      }}
+                    >
+                      <span>Sign in</span>
+                      <UserIcon className="home-social-action-icon" />
+                    </button>
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className="is-destructive"
+                      onClick={() => {
+                        closeAccountMenu();
+                        onLogout();
+                      }}
+                    >
+                      <span>Logout</span>
+                      <LogoutIcon className="home-social-action-icon" />
+                    </button>
+                  </div>
+                </div>
+              )}
             </>
           ) : (
-            <button type="button" onClick={onLoginClick} className="home-account-action">
-              Log in
+            <button
+              type="button"
+              onClick={onAuthClick}
+              className="home-account-action"
+            >
+              Sign in
             </button>
           )}
         </div>

--- a/client/web/components/Icons.tsx
+++ b/client/web/components/Icons.tsx
@@ -65,6 +65,23 @@ export const UserPlusIcon = ({ className = '' }) => (
   </svg>
 );
 
+export const HistoryIcon = ({ className = '' }) => (
+  <svg
+    className={className}
+    aria-hidden="true"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    strokeWidth={1.8}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M4.5 8.5V4.75m0 0h3.75m-3.75 0A8.5 8.5 0 1 1 3.6 14M12 7.5V12l3 2"
+    />
+  </svg>
+);
+
 export const KeyIcon = ({ className = '' }) => (
   <svg
     className={className}

--- a/client/web/components/InviteFriendsModal.tsx
+++ b/client/web/components/InviteFriendsModal.tsx
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { LobbyModal } from './LobbyModal';
 
 interface InviteFriendsModalProps {
   isOpen: boolean;
@@ -6,110 +7,187 @@ interface InviteFriendsModalProps {
   lobbyCode: string | null;
 }
 
+type CopyState = 'idle' | 'copied' | 'failed';
+type CopyTarget = 'code' | 'link';
+
+const copyFeedbackText = (
+  target: CopyTarget,
+  state: CopyState,
+): string => {
+  if (state === 'copied') {
+    return target === 'code' ? 'Lobby code copied.' : 'Invite link copied.';
+  }
+  if (state === 'failed') {
+    return target === 'code'
+      ? 'Could not copy the lobby code. Try again.'
+      : 'Could not copy the invite link. Try again.';
+  }
+  return '';
+};
+
 export const InviteFriendsModal: React.FC<InviteFriendsModalProps> = ({
   isOpen,
   onClose,
   lobbyCode,
 }) => {
-  const [copiedCode, setCopiedCode] = useState(false);
-  const [copiedUrl, setCopiedUrl] = useState(false);
+  const [codeCopyState, setCodeCopyState] = useState<CopyState>('idle');
+  const [linkCopyState, setLinkCopyState] = useState<CopyState>('idle');
+  const [latestCopyTarget, setLatestCopyTarget] = useState<CopyTarget | null>(null);
+  const copyCodeButtonRef = useRef<HTMLButtonElement>(null);
+  const resetTimersRef = useRef<Partial<Record<CopyTarget, ReturnType<typeof setTimeout>>>>({});
+  const copyOperationRef = useRef<Record<CopyTarget, number>>({ code: 0, link: 0 });
+  const isMountedRef = useRef(true);
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
 
-  if (!isOpen) return null;
+  const lobbyUrl = useMemo(() => {
+    if (!lobbyCode || typeof window === 'undefined') {
+      return '';
+    }
+    return `${window.location.origin}/lobby/${encodeURIComponent(lobbyCode)}`;
+  }, [lobbyCode]);
 
-  const lobbyUrl = lobbyCode
-    ? `${window.location.origin}/lobby/${lobbyCode}`
+  const clearResetTimer = (target: CopyTarget) => {
+    const timer = resetTimersRef.current[target];
+    if (timer) {
+      clearTimeout(timer);
+      delete resetTimersRef.current[target];
+    }
+  };
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+      clearResetTimer('code');
+      clearResetTimer('link');
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isOpen) {
+      return;
+    }
+    clearResetTimer('code');
+    clearResetTimer('link');
+    copyOperationRef.current.code += 1;
+    copyOperationRef.current.link += 1;
+    setCodeCopyState('idle');
+    setLinkCopyState('idle');
+    setLatestCopyTarget(null);
+  }, [isOpen]);
+
+  const copyToClipboard = async (
+    target: CopyTarget,
+    value: string,
+    setCopyState: React.Dispatch<React.SetStateAction<CopyState>>,
+  ) => {
+    if (!value) {
+      return;
+    }
+
+    clearResetTimer(target);
+    const operation = copyOperationRef.current[target] + 1;
+    copyOperationRef.current[target] = operation;
+    setLatestCopyTarget(target);
+    setCopyState('idle');
+
+    try {
+      if (!navigator.clipboard?.writeText) {
+        throw new Error('Clipboard API unavailable');
+      }
+      await navigator.clipboard.writeText(value);
+      if (
+        !isMountedRef.current ||
+        !isOpenRef.current ||
+        copyOperationRef.current[target] !== operation
+      ) {
+        return;
+      }
+      setCopyState('copied');
+    } catch (error: unknown) {
+      console.error(`Failed to copy lobby ${target}:`, error);
+      if (
+        !isMountedRef.current ||
+        !isOpenRef.current ||
+        copyOperationRef.current[target] !== operation
+      ) {
+        return;
+      }
+      setCopyState('failed');
+    }
+
+    if (isMountedRef.current && isOpenRef.current) {
+      resetTimersRef.current[target] = setTimeout(() => {
+        if (
+          isMountedRef.current &&
+          isOpenRef.current &&
+          copyOperationRef.current[target] === operation
+        ) {
+          setCopyState('idle');
+        }
+        delete resetTimersRef.current[target];
+      }, 2000);
+    }
+  };
+
+  const statusMessage = latestCopyTarget
+    ? copyFeedbackText(
+        latestCopyTarget,
+        latestCopyTarget === 'code' ? codeCopyState : linkCopyState,
+      )
     : '';
 
-  const handleCopyCode = async () => {
-    if (lobbyCode) {
-      try {
-        await navigator.clipboard.writeText(lobbyCode);
-        setCopiedCode(true);
-        setTimeout(() => setCopiedCode(false), 2000);
-      } catch (err) {
-        console.error('Failed to copy code:', err);
-      }
-    }
-  };
-
-  const handleCopyUrl = async () => {
-    if (lobbyUrl) {
-      try {
-        await navigator.clipboard.writeText(lobbyUrl);
-        setCopiedUrl(true);
-        setTimeout(() => setCopiedUrl(false), 2000);
-      } catch (err) {
-        console.error('Failed to copy URL:', err);
-      }
-    }
-  };
-
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center p-4 z-50"
-      onClick={onClose}
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+    <LobbyModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Invite friends"
+      description="Share the lobby code or send a direct invite link."
+      initialFocusRef={copyCodeButtonRef}
     >
-      <div
-        className="bg-white rounded-lg p-8 w-full max-w-lg"
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          border: '2px solid rgba(0, 0, 0, 0.65)',
-          boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.2)'
-        }}
-      >
-        <div className="text-center mb-6">
-          <h2 className="text-2xl font-black italic uppercase tracking-1 text-black-70 mb-2">
-            Invite Friends
-          </h2>
-          <p className="text-sm text-black-70 opacity-60">
-            Share this code or link with your friends
-          </p>
-        </div>
-
-        <div className="mb-5">
-          <label className="block text-xs font-black italic uppercase tracking-1 text-black-70 mb-2 opacity-50">
-            Code
-          </label>
-          <div className="flex gap-2">
-            <div className="flex-1 px-4 py-3 border-2 border-black-70 rounded-lg font-mono text-2xl text-center uppercase tracking-widest text-black-70">
-              {lobbyCode || 'XXXXXXXX'}
-            </div>
+      <div className="lobby-modal-share-list">
+        <div className="lobby-modal-field">
+          <span className="lobby-modal-label">Lobby code</span>
+          <div className="lobby-modal-share-row">
+            <div className="lobby-modal-value is-code">{lobbyCode || 'Preparing…'}</div>
             <button
-              onClick={handleCopyCode}
-              className="px-5 py-3 border-2 border-black-70 rounded-lg font-black italic uppercase text-xs text-black-70 hover:bg-gray-50 transition-colors"
-              style={{ letterSpacing: '1px' }}
+              ref={copyCodeButtonRef}
+              type="button"
+              className="lobby-modal-button is-copy"
+              onClick={() => copyToClipboard('code', lobbyCode ?? '', setCodeCopyState)}
+              disabled={!lobbyCode}
             >
-              {copiedCode ? 'Copied!' : 'Copy'}
+              {codeCopyState === 'copied' ? 'Copied' : codeCopyState === 'failed' ? 'Try again' : 'Copy'}
             </button>
           </div>
         </div>
 
-        <div className="mb-6">
-          <label className="block text-xs font-black italic uppercase tracking-1 text-black-70 mb-2 opacity-50">
-            Link
-          </label>
-          <div className="flex gap-2">
-            <div className="flex-1 px-4 py-3 border-2 border-black-70 rounded-lg text-sm text-black-70 overflow-hidden text-ellipsis whitespace-nowrap">
-              {lobbyUrl}
-            </div>
+        <div className="lobby-modal-field">
+          <span className="lobby-modal-label">Invite link</span>
+          <div className="lobby-modal-share-row">
+            <div className="lobby-modal-value is-link" title={lobbyUrl}>{lobbyUrl || 'Preparing…'}</div>
             <button
-              onClick={handleCopyUrl}
-              className="px-5 py-3 border-2 border-black-70 rounded-lg font-black italic uppercase text-xs text-black-70 hover:bg-gray-50 transition-colors"
-              style={{ letterSpacing: '1px' }}
+              type="button"
+              className="lobby-modal-button is-copy"
+              onClick={() => copyToClipboard('link', lobbyUrl, setLinkCopyState)}
+              disabled={!lobbyUrl}
             >
-              {copiedUrl ? 'Copied!' : 'Copy'}
+              {linkCopyState === 'copied' ? 'Copied' : linkCopyState === 'failed' ? 'Try again' : 'Copy'}
             </button>
           </div>
         </div>
+      </div>
 
-        <button
-          onClick={onClose}
-          className="w-full px-6 py-3 border-2 border-black-70 rounded-lg font-black italic uppercase tracking-1 text-black-70 hover:bg-gray-50 transition-colors"
-        >
-          Close
+      <p className="sr-only" aria-live="polite">
+        {statusMessage}
+      </p>
+
+      <div className="lobby-modal-actions lobby-modal-invite-actions">
+        <button type="button" className="lobby-modal-button is-secondary" onClick={onClose}>
+          Done
         </button>
       </div>
-    </div>
+    </LobbyModal>
   );
 };

--- a/client/web/components/JoinGameModal.tsx
+++ b/client/web/components/JoinGameModal.tsx
@@ -1,106 +1,196 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { useGameWebSocket } from '../hooks/useGameWebSocket';
-import { JoinGameModalProps, FormEventHandler } from '../types';
+import React, { useId, useRef, useState } from 'react';
+import { useAuth } from '../contexts/AuthContext';
+import { useWebSocket } from '../contexts/WebSocketContext';
+import { FormEventHandler, JoinGameModalProps } from '../types';
+import {
+  getLobbyCodeValidationError,
+  normalizeLobbyCodeInput,
+} from '../utils/lobbyCode';
+import { LobbyModal } from './LobbyModal';
+
+const generateGuestNickname = (): string =>
+  `Guest${Math.floor(1000 + Math.random() * 9000)}`;
+
+const guestNickname = (): string => {
+  try {
+    const savedNickname = window.localStorage.getItem('savedUsername')?.trim();
+    if (savedNickname && savedNickname.length >= 3) {
+      return savedNickname;
+    }
+  } catch {
+    // Storage can be unavailable in privacy modes; a generated name is enough.
+  }
+  return generateGuestNickname();
+};
+
+const joinErrorMessage = (error: unknown): string => {
+  const message = error instanceof Error
+    ? error.message.trim()
+    : error && typeof error === 'object' && 'message' in error && typeof error.message === 'string'
+      ? error.message.trim()
+      : '';
+  const normalizedMessage = message.toLowerCase();
+
+  if (normalizedMessage.includes('leave your current lobby')) {
+    return 'Leave your current lobby before joining another one.';
+  }
+  if (normalizedMessage.includes('timeout waiting to join lobby')) {
+    return 'Joining took too long. Check the code and try again.';
+  }
+  if (
+    normalizedMessage.includes('not connected') ||
+    normalizedMessage.includes('could not connect') ||
+    normalizedMessage.includes('connection was lost')
+  ) {
+    return 'The game server is still connecting. Try again in a moment.';
+  }
+  if (normalizedMessage.includes('not found') || normalizedMessage.includes('missing')) {
+    return 'That lobby could not be found. Check the code and try again.';
+  }
+  if (message && !normalizedMessage.includes('access denied')) {
+    return message;
+  }
+
+  return 'Could not join that lobby. Check the code and try again.';
+};
 
 function JoinGameModal({ isOpen, onClose }: JoinGameModalProps) {
-  const navigate = useNavigate();
-  const { joinCustomGame, isConnected } = useGameWebSocket();
-  const [gameCode, setGameCode] = useState('');
-  const [error, setError] = useState('');
-  const [isJoining, setIsJoining] = useState(false);
+  const { user, createGuest, loading: isAuthLoading } = useAuth();
+  const { isConnected, joinLobby } = useWebSocket();
+  const [codeInput, setCodeInput] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [joinStatus, setJoinStatus] = useState<'idle' | 'creating-guest' | 'joining'>('idle');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
+  const hintId = useId();
+  const errorId = useId();
+  const isJoining = joinStatus !== 'idle';
 
-  const handleSubmit: FormEventHandler = async (e) => {
-    e.preventDefault();
-    
-    if (!gameCode.trim()) {
-      setError('Please enter a game code');
-      return;
-    }
-    
-    if (!isConnected) {
-      setError('Not connected to server');
-      return;
-    }
-    
-    setIsJoining(true);
-    setError('');
-    
-    try {
-      await joinCustomGame(gameCode.toUpperCase());
-      // Navigation will be handled by WebSocket response
-      navigate(`/game/${gameCode.toUpperCase()}`);
+  const handleDismiss = () => {
+    if (!isJoining) {
       onClose();
-    } catch (err) {
-      setError('Failed to join game. Please check the code and try again.');
-      setIsJoining(false);
     }
   };
 
-  if (!isOpen) return null;
+  const handleSubmit: FormEventHandler = async (event) => {
+    event.preventDefault();
+
+    const validationError = getLobbyCodeValidationError(codeInput);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+
+    if (isAuthLoading) {
+      setError('Your player session is still loading. Try again in a moment.');
+      return;
+    }
+
+    if (!isConnected) {
+      setError('The game server is still connecting. Try again in a moment.');
+      return;
+    }
+
+    const lobbyCode = normalizeLobbyCodeInput(codeInput);
+    setError(null);
+
+    try {
+      if (!user) {
+        setJoinStatus('creating-guest');
+        await createGuest(guestNickname());
+      }
+
+      setJoinStatus('joining');
+      await joinLobby(lobbyCode);
+
+      setCodeInput('');
+      setError(null);
+      setJoinStatus('idle');
+      onClose();
+    } catch (joinError: unknown) {
+      setError(joinErrorMessage(joinError));
+      setJoinStatus('idle');
+    }
+  };
+
+  const submitLabel = isAuthLoading
+    ? 'Checking session…'
+    : joinStatus === 'creating-guest'
+      ? 'Creating guest…'
+      : joinStatus === 'joining'
+        ? 'Joining lobby…'
+        : 'Join lobby';
 
   return (
-    <div
-      className="fixed inset-0 flex items-center justify-center p-4 z-50"
-      onClick={onClose}
-      style={{ backgroundColor: 'rgba(0, 0, 0, 0.5)' }}
+    <LobbyModal
+      isOpen={isOpen}
+      onClose={handleDismiss}
+      title="Join game"
+      description="Enter a lobby code or paste an invite link."
+      initialFocusRef={inputRef}
+      isDismissDisabled={isJoining}
     >
-      <div
-        className="bg-white rounded-lg p-8 w-full max-w-lg"
-        onClick={(e) => e.stopPropagation()}
-        style={{
-          border: '2px solid rgba(0, 0, 0, 0.65)',
-          boxShadow: '0 4px 6px -1px rgba(0, 0, 0, 0.2)'
-        }}
+      <form
+        className="lobby-modal-form"
+        onSubmit={handleSubmit}
+        noValidate
+        aria-busy={isJoining}
       >
-        <div className="text-center mb-6">
-          <h2 className="text-2xl font-black italic uppercase tracking-1 text-black-70 mb-2">
-            Join Game
-          </h2>
-          <p className="text-sm text-black-70 opacity-60">
-            Enter the lobby code to join your friends
+        <div className="lobby-modal-field">
+          <label className="lobby-modal-label" htmlFor={inputId}>Lobby code</label>
+          <div className="lobby-modal-input-wrap">
+            <input
+              ref={inputRef}
+              id={inputId}
+              type="text"
+              value={codeInput}
+              onChange={(event) => {
+                setCodeInput(event.target.value);
+                if (error) {
+                  setError(null);
+                }
+              }}
+              placeholder="USE1-XXXXXXXX"
+              className="lobby-modal-input"
+              autoComplete="off"
+              autoCapitalize="characters"
+              spellCheck={false}
+              disabled={isJoining}
+              aria-invalid={Boolean(error)}
+              aria-describedby={error ? `${hintId} ${errorId}` : hintId}
+            />
+          </div>
+          <p id={hintId} className="lobby-modal-hint">
+            Example: USE1-4K7MP9QX.
           </p>
         </div>
 
-        <form onSubmit={handleSubmit}>
-          <div className="mb-5">
-            <label className="block text-xs font-black italic uppercase tracking-1 text-black-70 mb-2 opacity-50">
-              Code
-            </label>
-            <input
-              type="text"
-              value={gameCode}
-              onChange={(e) => setGameCode(e.target.value.toUpperCase())}
-              placeholder="XXXXXXXX"
-              maxLength={8}
-              className="w-full px-4 py-3 border-2 border-black-70 rounded-lg font-mono text-2xl text-center uppercase tracking-widest text-black-70"
-              autoFocus
-            />
-          </div>
+        {error && (
+          <p id={errorId} className="lobby-modal-error" role="alert">
+            {error}
+          </p>
+        )}
 
-          {error && (
-            <p className="text-red-600 text-sm mb-5 text-center">{error}</p>
-          )}
-
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="flex-1 px-6 py-3 border-2 border-black-70 rounded-lg font-black italic uppercase tracking-1 text-black-70 hover:bg-gray-50 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              disabled={isJoining || !gameCode.trim()}
-              className="flex-1 px-6 py-3 border-2 border-black-70 rounded-lg font-black italic uppercase tracking-1 text-black-70 hover:bg-gray-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-            >
-              {isJoining ? 'Joining...' : 'Join'}
-            </button>
-          </div>
-        </form>
-      </div>
-    </div>
+        <div className="lobby-modal-actions">
+          <button
+            type="button"
+            className="lobby-modal-button is-secondary"
+            onClick={handleDismiss}
+            disabled={isJoining}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className="lobby-modal-button is-primary"
+            disabled={isJoining || isAuthLoading || !codeInput.trim()}
+          >
+            {isJoining && <span className="lobby-modal-spinner" aria-hidden="true" />}
+            <span>{submitLabel}</span>
+          </button>
+        </div>
+      </form>
+    </LobbyModal>
   );
 }
 

--- a/client/web/components/Leaderboard.tsx
+++ b/client/web/components/Leaderboard.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import { Link, useNavigate, useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
+import type { AccountModalView } from './AccountModal';
 import { HomeHeader } from './HomeHeader';
 import { SocialFooter } from './SocialFooter';
 import { LobbyChat } from './LobbyChat';
@@ -122,6 +123,7 @@ const LeaderboardContent: React.FC<{
   seasons,
   isAuthenticated
 }) => {
+  const navigate = useNavigate();
   const { queueForMatch } = useGameWebSocket();
   const { isConnected, currentLobby, createLobby, updateLobbyPreferences } = useWebSocket();
   const [leaderboardData, setLeaderboardData] = useState<LeaderboardEntry[]>([]);
@@ -131,11 +133,11 @@ const LeaderboardContent: React.FC<{
   const [offset, setOffset] = useState(0);
   const [userRanking, setUserRanking] = useState<UserRankingResponse | null>(null);
   const LIMIT = 25;
-  const [isStartingPlacementQueue, setIsStartingPlacementQueue] = useState(false);
+  const [isStartingQueue, setIsStartingQueue] = useState(false);
 
-  // Fetch user's ranking when authenticated and filters change
+  // Fetch the user's competitive ranking when it is relevant to the selected mode.
   useEffect(() => {
-    if (!isAuthenticated) {
+    if (!isAuthenticated || selectedMode === 'solo') {
       setUserRanking(null);
       return;
     }
@@ -212,12 +214,13 @@ const LeaderboardContent: React.FC<{
     }
   };
 
-  const startPlacementQueue = async () => {
-    if (isStartingPlacementQueue || selectedMode === 'solo') {
+  const startSelectedQueue = async (competitive: boolean) => {
+    if (isStartingQueue) {
       return;
     }
 
-    setIsStartingPlacementQueue(true);
+    const modeToStart = selectedMode;
+    setIsStartingQueue(true);
     try {
       if (!isConnected) {
         throw new Error('Not connected to game server');
@@ -228,18 +231,18 @@ const LeaderboardContent: React.FC<{
       }
 
       updateLobbyPreferences({
-        selectedModes: [selectedMode],
-        competitive: true,
+        selectedModes: [modeToStart],
+        competitive,
       });
 
       // Small delay so the server registers preference updates
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      queueForMatch(toGameType(selectedMode), 'Competitive');
+      queueForMatch(toGameType(modeToStart), competitive ? 'Competitive' : 'Quickmatch');
     } catch (err) {
-      console.error('Failed to start placement matchmaking:', err);
+      console.error('Failed to start matchmaking:', err);
     } finally {
-      setIsStartingPlacementQueue(false);
+      setIsStartingQueue(false);
     }
   };
 
@@ -248,50 +251,81 @@ const LeaderboardContent: React.FC<{
   const rankImage = getRankImage(rankTier);
   const hasCompetitiveMMR = Boolean(rank);
   const rankLabel = rank ? formatRankLabel(rank) : 'UNRANKED';
+  const isSoloMode = selectedMode === 'solo';
+  const selectedModeLabel =
+    GAME_MODES.find(mode => mode.id === selectedMode)?.label ?? selectedMode.toUpperCase();
+  const playActionLabel = isSoloMode ? 'Play Snake Now' : 'Play Ranked Now';
+  const startingActionLabel = isSoloMode ? 'Starting game...' : 'Starting matchmaking...';
+
+  const playSelectedMode = () => {
+    const competitive = !isSoloMode;
+
+    if (!isAuthenticated) {
+      updateLobbyPreferences({
+        selectedModes: [selectedMode],
+        competitive,
+      });
+      navigate('/');
+      return;
+    }
+
+    void startSelectedQueue(competitive);
+  };
 
   return (
     <div className="leaderboard-content w-full max-w-4xl mx-auto px-4 py-8">
       {/* Header row with rank and selectors */}
       <div className="leaderboard-summary flex flex-col md:flex-row md:items-start md:justify-between gap-6 mb-8">
-        {/* Your Rank Display (left side) - Not shown for Solo mode */}
-        {selectedMode !== 'solo' ? (
-          <div className="flex items-start gap-4">
+        {/* Keep a stable left summary column as the selected game mode changes. */}
+        <div className="leaderboard-mode-summary flex items-start gap-4">
+          {isSoloMode ? (
+            <svg
+              className="w-16 h-16 flex-shrink-0 text-black-70"
+              viewBox="0 0 64 64"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              role="img"
+              aria-label="Solo trophy"
+            >
+              <path d="M19 10h26v11c0 10-5.8 17-13 17s-13-7-13-17V10Z" />
+              <path d="M19 15H9v4c0 7.8 4.5 12.5 11.8 13.4" />
+              <path d="M45 15h10v4c0 7.8-4.5 12.5-11.8 13.4" />
+              <path d="M32 38v9" />
+              <path d="M25 47h14l3 7H22l3-7Z" />
+            </svg>
+          ) : (
             <img
               src={rankImage}
               alt={rankTier}
-              className="w-16 h-16 object-contain"
+              className="w-16 h-16 flex-shrink-0 object-contain"
             />
-            <div className="flex flex-col gap-1">
-              <div className="text-xs font-bold uppercase tracking-wider text-gray-500 px-1">
-                Your Rank
-              </div>
-              <div className="font-black italic tracking-1 text-lg text-black-70">
-                {rankLabel}
-              </div>
-              <div className="text-xs text-black-70">
-                {!isAuthenticated ? (
-                  <Link to="/auth" className="font-bold text-blue-600 hover:underline">
-                    Login to play ranked
-                  </Link>
-                ) : hasCompetitiveMMR && userRanking?.mmr != null ? (
-                  `${userRanking.mmr} MMR`
-                ) : (
-                  <button
-                    type="button"
-                    onClick={startPlacementQueue}
-                    disabled={isStartingPlacementQueue}
-                    className="font-bold text-blue-600 hover:underline disabled:opacity-60 disabled:cursor-not-allowed"
-                  >
-                    {isStartingPlacementQueue ? 'Starting matchmaking...' : 'Play ranked now'}
-                  </button>
-                )}
-              </div>
+          )}
+          <div className="flex flex-col gap-1">
+            <div className="text-xs font-bold uppercase tracking-wider text-gray-500 px-1">
+              {isSoloMode ? 'Classic Snake' : isAuthenticated ? 'Your Rank' : 'Ranked Play'}
+            </div>
+            <div className="font-black italic tracking-1 text-lg text-black-70">
+              {isSoloMode ? 'SOLO' : isAuthenticated ? rankLabel : selectedModeLabel}
+            </div>
+            <div className="text-xs text-black-70">
+              {!isSoloMode && isAuthenticated && hasCompetitiveMMR && userRanking?.mmr != null ? (
+                `${userRanking.mmr} MMR`
+              ) : (
+                <button
+                  type="button"
+                  onClick={playSelectedMode}
+                  disabled={isStartingQueue}
+                  className="font-bold text-blue-600 hover:underline disabled:opacity-60 disabled:cursor-not-allowed"
+                >
+                  {isStartingQueue ? startingActionLabel : playActionLabel}
+                </button>
+              )}
             </div>
           </div>
-        ) : (
-          // Empty div to maintain flex layout spacing
-          <div className="hidden md:block"></div>
-        )}
+        </div>
 
         {/* Selectors (right side) */}
         <div className="flex flex-col sm:flex-row gap-6">
@@ -542,7 +576,12 @@ const LeaderboardContent: React.FC<{
   );
 };
 
-export const Leaderboard: React.FC = () => {
+interface LeaderboardProps {
+  onOpenAuth: () => void;
+  onOpenAccount: (view: AccountModalView) => void;
+}
+
+export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAccount }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const { user, logout } = useAuth();
@@ -734,10 +773,6 @@ export const Leaderboard: React.FC = () => {
     }
   };
 
-  const handleLoginClick = () => {
-    navigate('/auth');
-  };
-
   const shouldShowRegionReminder = !regionsLoading && !regionsError && currentRegionId === '';
   const shouldShowRegionError = Boolean(regionsError);
   const shouldShowConnectionBanner = !isConnected;
@@ -757,7 +792,8 @@ export const Leaderboard: React.FC = () => {
           onInvite={handleInvite}
           onJoinGame={() => setShowJoinModal(true)}
           onLeaveLobby={handleLeaveLobby}
-          onLoginClick={handleLoginClick}
+          onAuthClick={onOpenAuth}
+          onOpenAccount={onOpenAccount}
           onLogout={logout}
         />
 
@@ -798,7 +834,7 @@ export const Leaderboard: React.FC = () => {
             selectedRegion={selectedLeaderboardRegion}
             setSelectedRegion={setSelectedLeaderboardRegion}
             seasons={seasons}
-            isAuthenticated={Boolean(user && !user.isGuest)}
+            isAuthenticated={Boolean(user)}
           />
         </main>
 

--- a/client/web/components/LobbyChat.tsx
+++ b/client/web/components/LobbyChat.tsx
@@ -128,7 +128,7 @@ export const LobbyChat: React.FC<LobbyChatUIProps> = ({
   }
 
   const statusMessage = !currentUsername
-    ? 'Login to chat'
+    ? 'Sign in to chat'
     : isActive
       ? null
       : inactiveMessage;

--- a/client/web/components/LobbyModal.tsx
+++ b/client/web/components/LobbyModal.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useId, useRef } from 'react';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+interface LobbyModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  description: React.ReactNode;
+  children: React.ReactNode;
+  initialFocusRef?: React.RefObject<HTMLElement | null>;
+  isDismissDisabled?: boolean;
+}
+
+/**
+ * Shared lobby-dialog frame with focus containment and focus restoration.
+ * Feature-specific forms remain in the caller so their async state stays local.
+ */
+export const LobbyModal: React.FC<LobbyModalProps> = ({
+  isOpen,
+  onClose,
+  title,
+  description,
+  children,
+  initialFocusRef,
+  isDismissDisabled = false,
+}) => {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const onCloseRef = useRef(onClose);
+  const isDismissDisabledRef = useRef(isDismissDisabled);
+  const titleId = useId();
+  const descriptionId = useId();
+
+  onCloseRef.current = onClose;
+  isDismissDisabledRef.current = isDismissDisabled;
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const previouslyFocused = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    const previousBodyOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+
+    const focusInitialControl = window.requestAnimationFrame(() => {
+      const requestedTarget = initialFocusRef?.current;
+      const preferredTarget = requestedTarget?.matches(FOCUSABLE_SELECTOR)
+        ? requestedTarget
+        : null;
+      const fallbackTarget = dialogRef.current?.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+      (preferredTarget ?? fallbackTarget ?? dialogRef.current)?.focus();
+    });
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        if (!isDismissDisabledRef.current) {
+          event.preventDefault();
+          onCloseRef.current();
+        }
+        return;
+      }
+
+      if (event.key !== 'Tab' || !dialogRef.current) {
+        return;
+      }
+
+      const focusableElements = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((element) => element.getAttribute('aria-hidden') !== 'true');
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialogRef.current.focus();
+        return;
+      }
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey && (activeElement === firstElement || activeElement === dialogRef.current)) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      window.cancelAnimationFrame(focusInitialControl);
+      document.removeEventListener('keydown', handleKeyDown);
+      document.body.style.overflow = previousBodyOverflow;
+      if (previouslyFocused?.isConnected) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [initialFocusRef, isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  const handleBackdropMouseDown: React.MouseEventHandler<HTMLDivElement> = (event) => {
+    if (event.target === event.currentTarget && !isDismissDisabled) {
+      onClose();
+    }
+  };
+
+  return (
+    <div className="lobby-modal-backdrop" onMouseDown={handleBackdropMouseDown}>
+      <div
+        ref={dialogRef}
+        className="lobby-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        tabIndex={-1}
+      >
+        <header className="lobby-modal-header">
+          <h2 id={titleId} className="lobby-modal-title">{title}</h2>
+          <p id={descriptionId} className="lobby-modal-description">{description}</p>
+        </header>
+
+        <div className="lobby-modal-body">{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/client/web/components/MobileHeader.tsx
+++ b/client/web/components/MobileHeader.tsx
@@ -59,7 +59,7 @@ export const MobileHeader: React.FC<MobileHeaderProps> = ({
               onClick={onLoginClick}
               className="text-sm text-black-70 font-bold uppercase hover:opacity-70 transition-opacity"
             >
-              LOGIN
+              SIGN IN
             </button>
           )}
         </div>

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import type { AccountModalView } from './AccountModal';
 import { HomeHeader } from './HomeHeader';
 import { GameStartForm } from './GameStartForm';
 import { SocialFooter } from './SocialFooter';
@@ -15,9 +16,14 @@ import { LobbyGameMode } from '../types';
 
 const generateGuestNickname = () => `Guest${Math.floor(1000 + Math.random() * 9000)}`;
 
-export const NewHome: React.FC = () => {
+interface NewHomeProps {
+  onOpenAuth: () => void;
+  onOpenAccount: (view: AccountModalView) => void;
+}
+
+export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) => {
   const navigate = useNavigate();
-  const { user, createGuest, logout, updateGuestNickname } = useAuth();
+  const { user, createGuest, logout } = useAuth();
   const {
     connectToRegion,
     isConnected,
@@ -195,10 +201,6 @@ export const NewHome: React.FC = () => {
     }
   };
 
-  const handleLoginClick = () => {
-    navigate('/auth');
-  };
-
   const shouldShowRegionReminder = !regionsLoading && !regionsError && currentRegionId === '';
   const shouldShowRegionError = Boolean(regionsError);
   const shouldShowConnectionBanner = !isConnected;
@@ -210,6 +212,7 @@ export const NewHome: React.FC = () => {
     <>
       <div className="home-page">
         <HomeHeader
+          activePage="play"
           currentUser={user}
           lobbyMembers={lobbyMembers}
           hasLobby={Boolean(currentLobby)}
@@ -217,7 +220,8 @@ export const NewHome: React.FC = () => {
           onInvite={handleInvite}
           onJoinGame={() => setShowJoinModal(true)}
           onLeaveLobby={handleLeaveLobby}
-          onLoginClick={handleLoginClick}
+          onAuthClick={onOpenAuth}
+          onOpenAccount={onOpenAccount}
           onLogout={logout}
         />
 

--- a/client/web/contexts/AuthContext.tsx
+++ b/client/web/contexts/AuthContext.tsx
@@ -55,40 +55,25 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const login = useCallback(async (username: string, password: string) => {
     try {
-      // If currently logged in as a guest, clear the guest session first
-      if (user?.isGuest) {
-        console.log('Logging out guest user before full login');
-        api.setAuthToken(null);
-        setUser(null);
-        // Wait a brief moment for state to settle
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
-
+      // Keep an active guest session intact until authentication succeeds.
+      // The auth endpoint replaces the token atomically on success, allowing
+      // the WebSocket context to reconnect under the new identity.
       const data = await api.login(username, password);
       setUser(data.user);
     } catch (err) {
       throw err;
     }
-  }, [user]);
+  }, []);
 
   const register = useCallback(async (username: string, password: string | null) => {
     try {
-      // If currently logged in as a guest, clear the guest session first
-      if (user?.isGuest) {
-        console.log('Logging out guest user before registration');
-        api.setAuthToken(null);
-        setUser(null);
-        // Wait a brief moment for state to settle
-        await new Promise(resolve => setTimeout(resolve, 100));
-      }
-
-      // Support guest registration (no password)
+      // As with login, retain the guest token unless account creation succeeds.
       const data = await api.register(username, password || '');
       setUser(data.user);
     } catch (err) {
       throw err;
     }
-  }, [user]);
+  }, []);
 
   const createGuest = useCallback(async (nickname: string) => {
     try {

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -453,6 +453,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     setCurrentLobby(null);
     currentLobbyRef.current = null;
     setLobbyMembers([]);
+    setLobbyChatMessages([]);
+    lobbyChatLobbyIdRef.current = null;
     // console.log('setLobbyPreferences', DEFAULT_LOBBY_PREFERENCES);
     // setLobbyPreferences(DEFAULT_LOBBY_PREFERENCES);
     clearPersistedLobby();
@@ -1707,6 +1709,27 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         (active.authenticated || active.authTokenSent !== null),
       );
 
+      // A transport close is intentionally resumable on the server, so it does
+      // not mean "leave the lobby." Logout is explicit user intent: enqueue a
+      // LeaveLobby frame on the authenticated socket before retiring it. The
+      // WebSocket close handshake preserves frames queued before close, and the
+      // server removes every transport generation for this user on explicit
+      // leave. Clear local/persisted state immediately so the old identity can
+      // never remain visible or be restored into a later session.
+      if (
+        currentLobbyRef.current &&
+        active?.role === 'active' &&
+        active.authenticated &&
+        active.socket.readyState === WebSocket.OPEN
+      ) {
+        try {
+          active.socket.send(JSON.stringify('LeaveLobby'));
+        } catch (error) {
+          console.warn('Failed to notify the game server while leaving the lobby on logout', error);
+        }
+      }
+      resetLobbyState();
+
       previousUserRef.current = user;
       setMatchmakingStatus('idle');
       setAuthHandshakeState(false);
@@ -1771,6 +1794,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     getToken,
     authenticateConnection,
     clearPendingMatchmakingIntent,
+    resetLobbyState,
     setAuthHandshakeState,
   ]);
 

--- a/client/web/index.css
+++ b/client/web/index.css
@@ -212,7 +212,7 @@ body {
   gap: 8px;
 }
 
-.home-social-actions button {
+.home-social-actions :is(button, a) {
   display: flex;
   min-height: 42px;
   align-items: center;
@@ -227,6 +227,7 @@ body {
   font-weight: 800;
   letter-spacing: 0.7px;
   text-transform: uppercase;
+  text-decoration: none;
   cursor: pointer;
   transition: border-color 150ms ease, background-color 150ms ease, color 150ms ease;
 }
@@ -237,7 +238,12 @@ body {
   flex: 0 0 18px;
 }
 
-.home-social-actions button:hover:not(:disabled) {
+.home-social-actions :is(button, a):hover:not(:disabled) {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.home-social-actions a[aria-current="page"] {
   border-color: #3b82f6;
   background: #eff6ff;
 }
@@ -273,6 +279,676 @@ body {
   color: rgba(0, 0, 0, 0.7);
 }
 
+.home-account-menu {
+  position: relative;
+}
+
+.home-account-trigger {
+  display: inline-flex;
+  max-width: min(34vw, 280px);
+  align-items: center;
+  gap: 7px;
+}
+
+.home-account-guest-label {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+}
+
+.home-account-username {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.home-account-guest-suffix {
+  flex: 0 0 auto;
+  margin-left: 4px;
+  white-space: nowrap;
+}
+
+.home-account-trigger svg {
+  width: 10px;
+  flex: 0 0 10px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  transition: transform 150ms ease;
+}
+
+.home-account-trigger.is-open svg {
+  transform: rotate(180deg);
+}
+
+.home-account-panel {
+  top: calc(100% - 6px);
+  right: 8px;
+  left: auto;
+  width: 220px;
+}
+
+.home-account-actions :is(button, a) {
+  width: 100%;
+}
+
+/* Keep the primary action's frame upright while its label and paired chevrons
+   lean forward. A primary wake and lighter echo mark each enable transition. */
+.game-mode-choice {
+  font-style: normal;
+}
+
+.game-start-button {
+  position: relative;
+  isolation: isolate;
+  min-height: 64px;
+  overflow: hidden;
+  font-size: 19px;
+  font-style: normal;
+  transform: none;
+}
+
+.game-start-button:not(:disabled) {
+  border-color: #3b82f6;
+  background: #3b82f6;
+  color: #fff;
+  box-shadow: none;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease;
+}
+
+.game-start-content {
+  position: relative;
+  z-index: 2;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.game-start-label {
+  font-style: italic;
+  line-height: 1;
+}
+
+.game-start-chevrons {
+  /* Keep the edge artwork available for a later pass without showing it now. */
+  display: none;
+  position: absolute;
+  top: 50%;
+  z-index: 2;
+  width: 46px;
+  height: 28px;
+  fill: currentColor;
+  stroke: none;
+  opacity: 0.92;
+  transform: translateY(-50%) skewX(-8deg);
+  transform-origin: center;
+}
+
+.game-start-chevrons.is-left {
+  left: 18px;
+}
+
+.game-start-chevrons.is-right {
+  right: 18px;
+}
+
+.game-start-enable-sweep {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  overflow: hidden;
+  pointer-events: none;
+  -webkit-mask-image: linear-gradient(90deg, transparent 0%, #000 20%, #000 80%, transparent 100%);
+  mask-image: linear-gradient(90deg, transparent 0%, #000 20%, #000 80%, transparent 100%);
+}
+
+.game-start-enable-chevron {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  width: clamp(168px, 52%, 224px);
+  height: auto;
+  fill: #fff;
+  opacity: 0;
+  transform: translate3d(-100%, -50%, 0) skewX(-8deg);
+  transform-origin: center;
+  will-change: opacity, transform;
+}
+
+.game-start-enable-chevron.is-primary {
+  animation:
+    game-start-enable-sweep-motion 1450ms cubic-bezier(0.65, 0, 0.35, 1) both,
+    game-start-enable-primary-opacity 1450ms linear both;
+}
+
+.game-start-enable-chevron.is-echo {
+  animation:
+    game-start-enable-sweep-motion 1540ms cubic-bezier(0.65, 0, 0.35, 1) 220ms both,
+    game-start-enable-echo-opacity 1540ms linear 220ms both;
+}
+
+.game-start-button:hover:not(:disabled) {
+  border-color: #2563eb;
+  background: #2563eb;
+  box-shadow: none;
+}
+
+.game-start-button:active:not(:disabled) {
+  border-color: #1d4ed8;
+  background: #1d4ed8;
+}
+
+.game-start-button.is-activating:disabled {
+  border-color: #3b82f6;
+  background: #3b82f6;
+  color: #fff;
+  box-shadow: none;
+}
+
+.game-start-button:focus-visible {
+  outline: 3px solid rgba(59, 130, 246, 0.35);
+  outline-offset: 4px;
+}
+
+.game-start-button.is-disabled {
+  border-color: #e2e8f0;
+  background: #f8fafc;
+  color: #cbd5e1;
+  box-shadow: none;
+}
+
+@keyframes game-start-enable-sweep-motion {
+  from {
+    transform: translate3d(-100%, -50%, 0) skewX(-8deg);
+  }
+
+  to {
+    transform: translate3d(210%, -50%, 0) skewX(-8deg);
+  }
+}
+
+@keyframes game-start-enable-primary-opacity {
+  0% {
+    opacity: 0;
+  }
+
+  11%,
+  30% {
+    opacity: 0.06;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+@keyframes game-start-enable-echo-opacity {
+  0% {
+    opacity: 0;
+  }
+
+  10%,
+  26% {
+    opacity: 0.026;
+  }
+
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (max-width: 380px) {
+  .game-start-chevrons {
+    width: 38px;
+    height: 24px;
+  }
+
+  .game-start-chevrons.is-left {
+    left: 12px;
+  }
+
+  .game-start-chevrons.is-right {
+    right: 12px;
+  }
+
+  .game-start-button.is-activating {
+    font-size: clamp(15px, 4.5vw, 17px);
+  }
+
+  .game-start-button.is-activating .game-start-label {
+    letter-spacing: 0.6px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons {
+    width: 34px;
+    height: 22px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons.is-left {
+    left: 10px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons.is-right {
+    right: 10px;
+  }
+}
+
+@media (max-width: 340px) {
+  .game-start-button.is-activating .game-start-label {
+    letter-spacing: 0.3px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons {
+    width: 30px;
+    height: 20px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons.is-left {
+    left: 8px;
+  }
+
+  .game-start-button.is-activating .game-start-chevrons.is-right {
+    right: 8px;
+  }
+}
+
+/* Lobby dialogs use the same flat panels, type, borders, and interaction blue
+   as the rest of the home screen. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.lobby-modal-backdrop {
+  position: fixed;
+  z-index: 100;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  background: rgba(17, 24, 39, 0.36);
+  animation: lobby-modal-backdrop-in 120ms ease-out both;
+}
+
+.lobby-modal {
+  position: relative;
+  width: min(100%, 500px);
+  max-height: calc(100dvh - 48px);
+  overflow: auto;
+  border: 2px solid #9ca3af;
+  border-radius: 8px;
+  background: #fff;
+  box-shadow: none;
+  color: rgba(0, 0, 0, 0.7);
+  animation: lobby-modal-in 120ms ease-out both;
+}
+
+.lobby-modal-header {
+  padding: 28px 30px 18px;
+  text-align: center;
+}
+
+.lobby-modal-title {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 22px;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: -0.25px;
+  line-height: 1.2;
+}
+
+.lobby-modal-description {
+  margin: 8px 0 0;
+  color: #6b7280;
+  font-size: 13px;
+  font-style: normal;
+  line-height: 1.4;
+}
+
+.lobby-modal-body {
+  padding: 0 30px 30px;
+}
+
+.lobby-modal-form,
+.lobby-modal-share-list {
+  display: grid;
+  gap: 20px;
+}
+
+.lobby-modal-field {
+  display: grid;
+  gap: 7px;
+}
+
+.lobby-modal-label {
+  color: #6b7280;
+  font-size: 11px;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+}
+
+.lobby-modal-input-wrap {
+  position: relative;
+}
+
+.lobby-modal-input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 52px;
+  padding: 0 15px;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.7);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: 1.3px;
+  text-transform: uppercase;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.lobby-modal-input::placeholder {
+  color: #9ca3af;
+}
+
+.lobby-modal-input:focus {
+  border-color: #3b82f6;
+  outline: 0;
+  box-shadow: none;
+}
+
+.lobby-modal-input[aria-invalid="true"] {
+  border-color: #ef4444;
+}
+
+.lobby-modal-input:disabled {
+  background: #f8fafc;
+  cursor: wait;
+}
+
+.lobby-modal-hint {
+  margin: 0;
+  color: #9ca3af;
+  font-size: 10px;
+  line-height: 1.45;
+}
+
+.lobby-modal-error {
+  margin: -4px 0 0;
+  color: #dc2626;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.4;
+}
+
+.lobby-modal-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 2px;
+}
+
+.lobby-modal-actions:has(> :only-child) {
+  grid-template-columns: 1fr;
+}
+
+.lobby-modal-button {
+  display: inline-flex;
+  min-height: 52px;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 0 18px;
+  border: 2px solid transparent;
+  border-radius: 8px;
+  font-size: 12px;
+  font-style: normal;
+  font-weight: 800;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition:
+    background-color 150ms ease,
+    border-color 150ms ease,
+    color 150ms ease;
+}
+
+.lobby-modal-button.is-primary {
+  border-color: #3b82f6;
+  background: #3b82f6;
+  color: #fff;
+}
+
+.lobby-modal-button.is-primary:hover:not(:disabled) {
+  border-color: #2563eb;
+  background: #2563eb;
+}
+
+.lobby-modal-button.is-secondary {
+  border-color: #d1d5db;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.lobby-modal-button.is-secondary:hover:not(:disabled) {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.lobby-modal-button.is-copy {
+  min-width: 96px;
+  border-color: #d1d5db;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.7);
+}
+
+.lobby-modal-button.is-copy:hover:not(:disabled) {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.lobby-modal-button:focus-visible {
+  outline: none;
+}
+
+.lobby-modal-button.is-primary:focus-visible {
+  border-color: #2563eb;
+  background: #2563eb;
+}
+
+.lobby-modal-button.is-secondary:focus-visible,
+.lobby-modal-button.is-copy:focus-visible {
+  border-color: #3b82f6;
+  background: #eff6ff;
+}
+
+.lobby-modal-button:disabled {
+  border-color: #e2e8f0;
+  background: #f1f5f9;
+  color: #cbd5e1;
+  cursor: not-allowed;
+}
+
+.lobby-modal-spinner {
+  width: 15px;
+  height: 15px;
+  border: 2px solid rgba(255, 255, 255, 0.42);
+  border-top-color: currentColor;
+  border-radius: 50%;
+  animation: spin 800ms linear infinite;
+}
+
+.lobby-modal-share-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 8px;
+}
+
+.lobby-modal-value {
+  display: flex;
+  min-width: 0;
+  min-height: 52px;
+  align-items: center;
+  padding: 0 14px;
+  overflow: hidden;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.7);
+  user-select: all;
+}
+
+.lobby-modal-value.is-code {
+  display: block;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 16px;
+  font-weight: 700;
+  letter-spacing: 1.2px;
+  line-height: 48px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lobby-modal-value.is-link {
+  display: block;
+  font-size: 12.5px;
+  line-height: 48px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.lobby-modal-invite-actions {
+  margin-top: 28px;
+}
+
+.auth-modal-fields {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-modal-field {
+  min-width: 0;
+}
+
+.auth-modal-input {
+  box-sizing: border-box;
+  width: 100%;
+  height: 52px;
+  padding: 0 15px;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+  color: rgba(0, 0, 0, 0.7);
+  font-family: inherit;
+  font-size: 16px;
+  font-style: normal;
+  font-weight: 400;
+  letter-spacing: 0;
+  transition: border-color 150ms ease, background-color 150ms ease;
+}
+
+.auth-modal-input::placeholder {
+  color: #9ca3af;
+  opacity: 1;
+}
+
+.auth-modal-input:focus {
+  border-color: #3b82f6;
+  outline: 0;
+  box-shadow: none;
+}
+
+.auth-modal-input[aria-invalid="true"] {
+  border-color: #ef4444;
+}
+
+.auth-modal-input:disabled {
+  background: #f8fafc;
+  cursor: wait;
+}
+
+.auth-modal-status {
+  min-height: 17px;
+  margin: 1px 2px 0;
+  color: #6b7280;
+  font-size: 11px;
+  font-style: normal;
+  line-height: 1.45;
+}
+
+.auth-modal-status.is-error {
+  color: #b91c1c;
+}
+
+.auth-modal-guest-description {
+  display: block;
+  max-width: 420px;
+  margin: 0 auto 7px;
+  color: #667085;
+  font-size: 13px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 1.55;
+}
+
+.auth-modal-guest-identity {
+  display: inline;
+  color: inherit;
+  font-size: inherit;
+  font-style: normal;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
+.auth-modal-guest-identity strong {
+  color: #4b5563;
+  font-weight: 650;
+}
+
+.auth-modal-guest-suffix {
+  color: inherit;
+  font-weight: inherit;
+}
+
+.auth-modal-guest-guidance {
+  display: inline;
+  margin: 0;
+  color: inherit;
+  font-size: inherit;
+  font-style: normal;
+  font-weight: inherit;
+  line-height: inherit;
+}
+
+@keyframes lobby-modal-backdrop-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes lobby-modal-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 .home-main {
   position: relative;
   z-index: 10;
@@ -282,6 +958,74 @@ body {
   align-items: center;
   justify-content: center;
   padding: 84px 20px 76px;
+}
+
+.account-profile-details {
+  overflow: hidden;
+  margin: 0;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background: #fff;
+}
+
+.account-profile-details > div {
+  display: flex;
+  min-height: 56px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 0 15px;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.account-profile-details > div:last-child {
+  border-bottom: 0;
+}
+
+.account-profile-details dt {
+  color: #6b7280;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.7px;
+  text-transform: uppercase;
+}
+
+.account-profile-details dd {
+  margin: 0;
+  overflow: hidden;
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 14px;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.account-history-empty {
+  display: flex;
+  min-height: 154px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  border: 2px solid #d1d5db;
+  border-radius: 8px;
+  background: #f8fafc;
+  text-align: center;
+}
+
+.account-history-icon {
+  width: 28px;
+  height: 28px;
+  margin-bottom: 14px;
+  color: #9ca3af;
+}
+
+.account-history-empty h3 {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.7);
+  font-size: 15px;
+  font-style: normal;
+  font-weight: 750;
 }
 
 .leaderboard-main {
@@ -774,7 +1518,7 @@ a.home-social-icon:hover {
 
 .home-nav-link:focus-visible,
 .home-account-action:focus-visible,
-.home-social-actions button:focus-visible,
+.home-social-actions :is(button, a):focus-visible,
 .home-social-icon:focus-visible,
 .home-utility-dock .region-selector-trigger:focus-visible,
 .home-chat-trigger:focus-visible {
@@ -795,18 +1539,21 @@ a.home-social-icon:hover {
 @media (max-width: 700px) {
   .home-header {
     height: 64px;
-    padding: 0 14px;
+    padding: 0 10px;
   }
 
   .home-top-nav {
-    gap: 14px;
+    gap: 8px;
     height: 40px;
-    padding: 0 12px;
+    padding: 0 2px;
   }
 
-  .home-nav-link,
+  .home-nav-link {
+    font-size: 9.5px;
+  }
+
   .home-account-action {
-    font-size: 11px;
+    font-size: 10px;
   }
 
   .home-account-name {
@@ -816,7 +1563,11 @@ a.home-social-icon:hover {
   .home-account {
     gap: 10px;
     height: 40px;
-    padding: 0 12px;
+    padding: 0 6px;
+  }
+
+  .home-account-trigger {
+    max-width: 140px;
   }
 
   .home-nav-link.is-active::after {
@@ -918,6 +1669,45 @@ a.home-social-icon:hover {
   .home-chat-input {
     font-size: 16px;
   }
+
+  .lobby-modal-backdrop {
+    padding: 12px;
+  }
+
+  .lobby-modal {
+    max-height: calc(100dvh - 24px);
+  }
+
+  .lobby-modal-header {
+    padding: 24px 20px 16px;
+  }
+
+  .lobby-modal-title {
+    font-size: 20px;
+  }
+
+  .lobby-modal-description {
+    font-size: 12px;
+  }
+
+  .lobby-modal-body {
+    padding: 0 20px 20px;
+  }
+
+  .lobby-modal-button.is-copy {
+    min-width: 86px;
+  }
+
+  .lobby-modal-input {
+    font-size: 16px;
+    letter-spacing: 1.1px;
+  }
+}
+
+@media (max-width: 340px) {
+  .lobby-modal-actions {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (min-width: 701px) and (max-height: 640px) {
@@ -936,6 +1726,15 @@ a.home-social-icon:hover {
 @media (max-width: 390px) {
   .home-top-nav {
     gap: 10px;
+  }
+
+  .home-account {
+    padding-right: 4px;
+    padding-left: 6px;
+  }
+
+  .home-account-trigger {
+    max-width: 140px;
   }
 
   .home-social-count,
@@ -970,10 +1769,27 @@ a.home-social-icon:hover {
   }
 
   .home-social-trigger svg,
+  .home-account-trigger svg,
   .home-status-dot,
-  .home-status-spinner {
+  .home-status-spinner,
+  .game-start-button,
+  .lobby-modal-backdrop,
+  .lobby-modal,
+  .lobby-modal-spinner {
     animation: none;
     transition: none;
+  }
+
+  .game-start-enable-chevron {
+    animation: none;
+    opacity: 0;
+    will-change: auto;
+  }
+
+  .game-start-enable-chevron.is-primary {
+    left: 50%;
+    opacity: 0.035;
+    transform: translate3d(-50%, -50%, 0) skewX(-8deg);
   }
 }
 

--- a/client/web/tests/e2e/specs/account-modals.spec.js
+++ b/client/web/tests/e2e/specs/account-modals.spec.js
@@ -1,0 +1,88 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ headless: true });
+
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('token', 'account-modal-test-token');
+
+    const nativeFetch = window.fetch.bind(window);
+    window.fetch = async (input, init) => {
+      const url = typeof input === 'string'
+        ? input
+        : (input instanceof URL ? input.href : input.url);
+
+      if (url.endsWith('/client_bg.wasm')) {
+        return nativeFetch(input, init);
+      }
+
+      let payload;
+      if (url.endsWith('/api/auth/me')) {
+        payload = { id: 7, username: 'ModalTester', mmr: 1234, isGuest: false };
+      } else if (url.endsWith('/api/regions')) {
+        payload = [];
+      } else if (url.endsWith('/api/regions/user-counts')) {
+        payload = {};
+      } else {
+        throw new Error(`Unexpected fetch in account modal test: ${url}`);
+      }
+
+      return new Response(JSON.stringify(payload), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    };
+  });
+});
+
+test('Profile and History open over the current page without navigation', async ({ page }) => {
+  await page.goto('/');
+  const originalUrl = page.url();
+  const accountTrigger = page.getByRole('button', { name: 'ModalTester' });
+
+  await expect(accountTrigger).toBeVisible();
+  await accountTrigger.click();
+  await page.getByRole('menuitem', { name: 'Profile' }).click();
+
+  const profileDialog = page.getByRole('dialog', { name: 'Profile' });
+  await expect(profileDialog).toBeVisible();
+  await expect(page.getByRole('dialog')).toHaveCount(1);
+  await expect(profileDialog.getByText('ModalTester', { exact: true })).toBeVisible();
+  await expect(profileDialog.getByText('#7', { exact: true })).toBeVisible();
+  await expect(profileDialog.getByText('1,234', { exact: true })).toBeVisible();
+  expect(page.url()).toBe(originalUrl);
+
+  await profileDialog.getByRole('button', { name: 'Done' }).click();
+  await expect(profileDialog).toHaveCount(0);
+  await expect(accountTrigger).toBeFocused();
+
+  await accountTrigger.click();
+  await page.getByRole('menuitem', { name: 'History' }).click();
+
+  const historyDialog = page.getByRole('dialog', { name: 'History' });
+  await expect(historyDialog).toBeVisible();
+  await expect(page.getByRole('dialog')).toHaveCount(1);
+  await expect(historyDialog.getByText('Match history is coming soon', { exact: true })).toBeVisible();
+  expect(page.url()).toBe(originalUrl);
+
+  await page.setViewportSize({ width: 360, height: 720 });
+  const mobileDialogBounds = await historyDialog.boundingBox();
+  expect(mobileDialogBounds).not.toBeNull();
+  expect(mobileDialogBounds.x).toBeGreaterThanOrEqual(0);
+  expect(mobileDialogBounds.x + mobileDialogBounds.width).toBeLessThanOrEqual(360);
+  expect(mobileDialogBounds.y + mobileDialogBounds.height).toBeLessThanOrEqual(720);
+
+  await page.keyboard.press('Escape');
+  await expect(historyDialog).toHaveCount(0);
+  await expect(accountTrigger).toBeFocused();
+  expect(page.url()).toBe(originalUrl);
+});
+
+for (const legacyPath of ['/profile', '/history']) {
+  test(`${legacyPath} redirects to Play instead of rendering an account page`, async ({ page }) => {
+    await page.goto(legacyPath);
+    await expect(page).toHaveURL('/');
+    await expect(page.getByRole('dialog')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'ModalTester' })).toBeVisible();
+  });
+}

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -367,6 +367,64 @@ test.beforeEach(async ({ page }) => {
   });
 });
 
+test('logout explicitly leaves the lobby before retiring the authenticated socket', async ({ page }) => {
+  const oldSocketIndex = await establishAuthenticatedLobby(page);
+  await emitServerMessage(page, oldSocketIndex, {
+    LobbyChatMessage: {
+      lobby_id: 1,
+      message_id: 'logout-regression-message',
+      user_id: 7,
+      username: 'drain-tester',
+      message: 'This must not leak into the next session.',
+      timestamp_ms: Date.now(),
+    },
+  });
+
+  await expect.poll(() => page.evaluate(() => ({
+    lobbyCode: window.__wsContext?.currentLobby?.code,
+    memberCount: window.__wsContext?.lobbyMembers.length,
+    chatCount: window.__wsContext?.lobbyChatMessages.length,
+  }))).toEqual({ lobbyCode: 'LOBBY1', memberCount: 1, chatCount: 1 });
+  const socketCountBeforeLogout = await page.evaluate(() => window.__mockSockets.length);
+
+  await page.getByRole('button', { name: 'drain-tester' }).click();
+  await page.getByRole('menuitem', { name: 'Logout' }).click();
+
+  await expect.poll(() => page.evaluate((socketIndex) => {
+    const oldSocket = window.__mockSockets[socketIndex];
+    const decodedMessages = oldSocket.sent.map((raw) => JSON.parse(raw));
+    return {
+      leaveCount: decodedMessages.filter((message) => message === 'LeaveLobby').length,
+      closeCount: oldSocket.closeCalls.length,
+      lobby: window.__wsContext?.currentLobby ?? null,
+      memberCount: window.__wsContext?.lobbyMembers.length,
+      chatCount: window.__wsContext?.lobbyChatMessages.length,
+      token: localStorage.getItem('token'),
+      storedLobby: localStorage.getItem('snaketron:lastLobby'),
+    };
+  }, oldSocketIndex)).toEqual({
+    leaveCount: 1,
+    closeCount: 1,
+    lobby: null,
+    memberCount: 0,
+    chatCount: 0,
+    token: null,
+    storedLobby: null,
+  });
+
+  await expect(page.getByRole('button', { name: 'Sign in' })).toBeVisible();
+  await expect.poll(() => page.evaluate(() => window.__mockSockets.length))
+    .toBeGreaterThan(socketCountBeforeLogout);
+  await expect.poll(() => page.evaluate((index) => window.__mockSockets
+    .slice(index)
+    .flatMap((socket) => socket.sent.map((raw) => JSON.parse(raw)))
+    .filter((message) => (
+      message &&
+      typeof message === 'object' &&
+      ('Token' in message || 'JoinLobby' in message)
+    )).length, socketCountBeforeLogout)).toBe(0);
+});
+
 test('planned drain keeps the old game socket usable until the replacement is fully ready', async ({ page }) => {
   const oldSocketIndex = await establishActiveGame(page);
   await sendCommandProbe(page, 'before-drain');

--- a/client/web/tests/unit/lobbyCode.test.ts
+++ b/client/web/tests/unit/lobbyCode.test.ts
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  getLobbyCodeValidationError,
+  normalizeLobbyCodeInput,
+} from '../../utils/lobbyCode.ts';
+
+test('normalizes complete region-prefixed lobby codes', () => {
+  assert.equal(normalizeLobbyCodeInput('  use1-a3b2c4d5  '), 'USE1-A3B2C4D5');
+  assert.equal(getLobbyCodeValidationError('USE1-A3B2C4D5'), null);
+});
+
+test('extracts lobby codes from current and legacy invite links', () => {
+  assert.equal(
+    normalizeLobbyCodeInput('https://snaketron.io/lobby/USE1-A3B2C4D5?from=copy#invite'),
+    'USE1-A3B2C4D5',
+  );
+  assert.equal(
+    normalizeLobbyCodeInput('/join/us-6bkvcpvp/'),
+    'US-6BKVCPVP',
+  );
+});
+
+test('decodes copied URL path segments', () => {
+  assert.equal(
+    normalizeLobbyCodeInput('https://snaketron.io/lobby/USE1%2DA3B2C4D5'),
+    'USE1-A3B2C4D5',
+  );
+});
+
+test('accepts older unprefixed codes and rejects malformed input', () => {
+  assert.equal(getLobbyCodeValidationError('A3B2C4D5'), null);
+  assert.equal(
+    getLobbyCodeValidationError('USE1_A3B2C4D5'),
+    'Lobby codes use only letters, numbers, and hyphens.',
+  );
+  assert.equal(
+    getLobbyCodeValidationError('   '),
+    'Enter a lobby code or invite link.',
+  );
+});

--- a/client/web/types/index.ts
+++ b/client/web/types/index.ts
@@ -57,6 +57,7 @@ export type HighScoreEntry = GenHighScoreEntry;
 export interface User {
   id: number;
   username: string;
+  mmr?: number;
   token?: string;
   isGuest?: boolean;
 }

--- a/client/web/utils/lobbyCode.ts
+++ b/client/web/utils/lobbyCode.ts
@@ -1,0 +1,40 @@
+const LOBBY_CODE_PATTERN = /^[A-Z0-9]+(?:-[A-Z0-9]+)*$/;
+const MAX_LOBBY_CODE_LENGTH = 64;
+
+/**
+ * Extract a lobby code from either a raw code or a copied `/lobby/:code`
+ * (`/join/:code` is accepted for compatibility with older invite links).
+ */
+export function normalizeLobbyCodeInput(input: string): string {
+  const trimmedInput = input.trim();
+  if (!trimmedInput) {
+    return '';
+  }
+
+  const pathMatch = trimmedInput.match(/(?:^|\/)(?:lobby|join)\/([^/?#]+)/i);
+  let candidate = pathMatch?.[1] ?? trimmedInput.split(/[?#]/, 1)[0];
+
+  try {
+    candidate = decodeURIComponent(candidate);
+  } catch {
+    // Keep the original text so validation can explain that it is not a code.
+  }
+
+  return candidate.replace(/\s+/g, '').toUpperCase();
+}
+
+export function getLobbyCodeValidationError(input: string): string | null {
+  const code = normalizeLobbyCodeInput(input);
+
+  if (!code) {
+    return 'Enter a lobby code or invite link.';
+  }
+  if (code.length > MAX_LOBBY_CODE_LENGTH) {
+    return 'That lobby code is too long.';
+  }
+  if (!LOBBY_CODE_PATTERN.test(code)) {
+    return 'Lobby codes use only letters, numbers, and hyphens.';
+  }
+
+  return null;
+}

--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -7,10 +7,11 @@ use axum::{
 use bcrypt::{DEFAULT_COST, hash, verify};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use crate::db::Database;
 use crate::matchmaking_pool::MatchmakingPool;
+use crate::user_cache::UserCache;
 
 use super::jwt::JwtManager;
 use super::middleware::AuthUser;
@@ -19,6 +20,7 @@ use super::middleware::AuthUser;
 pub struct AuthState {
     pub db: Arc<dyn Database>,
     pub jwt_manager: Arc<JwtManager>,
+    pub user_cache: Option<UserCache>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -104,12 +106,32 @@ impl IntoResponse for AppError {
             msg if msg.contains("Username already exists") => {
                 (StatusCode::CONFLICT, "Username already exists")
             }
+            msg if msg.contains("Account is already registered") => {
+                (StatusCode::CONFLICT, "Account is already registered")
+            }
             msg if msg.contains("Invalid username or password") => {
                 (StatusCode::UNAUTHORIZED, "Invalid username or password")
             }
+            msg if msg.contains("Invalid or expired guest session")
+                || msg.contains("Guest account not found")
+                || msg.contains("Guest account has already been upgraded") =>
+            {
+                (StatusCode::UNAUTHORIZED, "Invalid or expired guest session")
+            }
+            msg if msg.contains("Stress-test guest accounts cannot be upgraded") => (
+                StatusCode::FORBIDDEN,
+                "Stress-test guest accounts cannot be upgraded",
+            ),
             msg if msg.contains("Invalid stress test key") => {
                 (StatusCode::UNAUTHORIZED, "Invalid stress test key")
             }
+            msg if msg.contains("Invalid username") => {
+                (StatusCode::BAD_REQUEST, "Invalid username")
+            }
+            msg if msg.contains("Password must be at least 6 characters") => (
+                StatusCode::BAD_REQUEST,
+                "Password must be at least 6 characters",
+            ),
             msg if msg.contains("User not found") => (StatusCode::NOT_FOUND, "User not found"),
             _ => (StatusCode::INTERNAL_SERVER_ERROR, "Internal server error"),
         };
@@ -167,6 +189,7 @@ pub fn validate_username(username: &str) -> Vec<String> {
 
 pub async fn register(
     State(state): State<AuthState>,
+    headers: HeaderMap,
     Json(req): Json<RegisterRequest>,
 ) -> Result<Response, AppError> {
     // Validate username format
@@ -179,20 +202,104 @@ pub async fn register(
         return Err(anyhow::anyhow!("Password must be at least 6 characters").into());
     }
 
-    // Check if username already exists
-    let existing_user = state.db.get_user_by_username(&req.username).await?;
-    if existing_user.is_some() {
-        return Err(anyhow::anyhow!("Username already exists").into());
+    // Registration is also the guest-upgrade endpoint. The browser already
+    // sends its current bearer token; fail closed when a presented token is
+    // malformed or stale so an upgrade can never silently create a second ID.
+    let guest_claims = match headers.get(header::AUTHORIZATION) {
+        None => None,
+        Some(value) => {
+            let value = value
+                .to_str()
+                .map_err(|_| anyhow::anyhow!("Invalid or expired guest session"))?;
+            let token = value
+                .strip_prefix("Bearer ")
+                .filter(|token| !token.is_empty())
+                .ok_or_else(|| anyhow::anyhow!("Invalid or expired guest session"))?;
+            let claims = state
+                .jwt_manager
+                .verify_token(token)
+                .map_err(|_| anyhow::anyhow!("Invalid or expired guest session"))?;
+            Some(claims)
+        }
+    };
+
+    let upgraded_guest_id = guest_claims
+        .as_ref()
+        .map(|claims| {
+            if !claims.is_guest {
+                return Err(anyhow::anyhow!("Account is already registered"));
+            }
+            if claims.matchmaking_pool != MatchmakingPool::Public {
+                return Err(anyhow::anyhow!(
+                    "Stress-test guest accounts cannot be upgraded"
+                ));
+            }
+            claims
+                .sub
+                .parse::<i32>()
+                .map_err(|_| anyhow::anyhow!("Invalid or expired guest session"))
+        })
+        .transpose()?;
+
+    let user = if let Some(guest_id) = upgraded_guest_id {
+        let current = state
+            .db
+            .get_user_by_id(guest_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Guest account not found"))?;
+
+        if current.is_stress_test {
+            return Err(anyhow::anyhow!("Stress-test guest accounts cannot be upgraded").into());
+        }
+
+        if !current.is_guest {
+            // If DynamoDB committed but the prior HTTP response was lost, the
+            // browser still holds its old guest token. Allow an exact retry
+            // only when the submitted credentials already authenticate the
+            // converted account.
+            let is_exact_retry = current.username == req.username
+                && verify(&req.password, &current.password_hash)
+                    .context("Failed to verify upgraded account password")?;
+            if !is_exact_retry {
+                return Err(anyhow::anyhow!("Guest account has already been upgraded").into());
+            }
+            current
+        } else {
+            let password_hash =
+                hash(&req.password, DEFAULT_COST).context("Failed to hash password")?;
+            state
+                .db
+                .upgrade_guest_to_account(guest_id, &req.username, &password_hash)
+                .await?
+        }
+    } else {
+        // Signed-out registration retains the original new-account behavior.
+        if state
+            .db
+            .get_user_by_username(&req.username)
+            .await?
+            .is_some()
+        {
+            return Err(anyhow::anyhow!("Username already exists").into());
+        }
+        let password_hash = hash(&req.password, DEFAULT_COST).context("Failed to hash password")?;
+        state
+            .db
+            .create_user(&req.username, &password_hash, 1000)
+            .await?
+    };
+
+    if upgraded_guest_id.is_some()
+        && let Some(user_cache) = &state.user_cache
+        && let Err(cache_error) = user_cache.replace_after_guest_upgrade(&user).await
+    {
+        // The durable conversion already committed. A cache outage must not
+        // turn that success into an apparent failure that encourages retries.
+        warn!(
+            "Failed to replace user cache after upgrading guest {}: {}",
+            user.id, cache_error
+        );
     }
-
-    // Hash password
-    let password_hash = hash(&req.password, DEFAULT_COST).context("Failed to hash password")?;
-
-    // Create user
-    let user = state
-        .db
-        .create_user(&req.username, &password_hash, 1000)
-        .await?;
 
     let user_info = UserInfo {
         id: user.id,
@@ -285,11 +392,15 @@ pub async fn get_current_user(
         .await?
         .ok_or_else(|| anyhow::anyhow!("User not found"))?;
 
+    if user.is_guest != auth_user.is_guest {
+        return Err(anyhow::anyhow!("Invalid or expired guest session").into());
+    }
+
     let user_info = UserInfo {
         id: user.id,
         username: user.username,
         mmr: user.mmr,
-        is_guest: auth_user.is_guest,
+        is_guest: user.is_guest,
     };
 
     // Build response with cache-control headers to prevent caching

--- a/server/src/api/leaderboard.rs
+++ b/server/src/api/leaderboard.rs
@@ -316,6 +316,16 @@ pub async fn get_my_ranking(
     State(state): State<LeaderboardState>,
     Query(query): Query<LeaderboardQuery>,
 ) -> Result<Json<UserRankingResponse>, StatusCode> {
+    let user = state
+        .db
+        .get_user_by_id(auth_user.user_id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+    if user.is_guest != auth_user.is_guest {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
     // Parse queue mode
     let queue_mode = match query.queue_mode.to_lowercase().as_str() {
         "quickmatch" | "casual" => QueueMode::Quickmatch,

--- a/server/src/api/middleware.rs
+++ b/server/src/api/middleware.rs
@@ -8,6 +8,9 @@ use axum::{
 use serde_json::json;
 use std::sync::Arc;
 
+use crate::db::Database;
+use crate::matchmaking_pool::MatchmakingPool;
+
 use super::jwt::JwtManager;
 
 /// Authenticated user information extracted from JWT token
@@ -17,8 +20,14 @@ pub struct AuthUser {
     pub is_guest: bool,
 }
 
+#[derive(Clone)]
+pub struct AuthMiddlewareState {
+    pub jwt_manager: Arc<JwtManager>,
+    pub db: Arc<dyn Database>,
+}
+
 pub async fn auth_middleware(
-    State(jwt_manager): State<Arc<JwtManager>>,
+    State(state): State<AuthMiddlewareState>,
     mut request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
@@ -40,14 +49,44 @@ pub async fn auth_middleware(
     };
 
     // Verify the token
-    match jwt_manager.verify_token(token) {
+    match state.jwt_manager.verify_token(token) {
         Ok(claims) => {
             // Parse user_id from claims
             if let Ok(user_id) = claims.sub.parse::<i32>() {
+                let user = match state.db.get_user_by_id(user_id).await {
+                    Ok(Some(user)) => user,
+                    Ok(None) => {
+                        return Ok((
+                            StatusCode::UNAUTHORIZED,
+                            Json(json!({ "error": "Invalid or expired token" })),
+                        )
+                            .into_response());
+                    }
+                    Err(_) => {
+                        return Ok((
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            Json(json!({ "error": "Authentication service unavailable" })),
+                        )
+                            .into_response());
+                    }
+                };
+                let database_pool = if user.is_stress_test {
+                    MatchmakingPool::Stress
+                } else {
+                    MatchmakingPool::Public
+                };
+                if user.is_guest != claims.is_guest || database_pool != claims.matchmaking_pool {
+                    return Ok((
+                        StatusCode::UNAUTHORIZED,
+                        Json(json!({ "error": "Invalid or expired token" })),
+                    )
+                        .into_response());
+                }
+
                 // Insert AuthUser (with both user_id and is_guest) into request extensions
                 let auth_user = AuthUser {
                     user_id,
-                    is_guest: claims.is_guest,
+                    is_guest: user.is_guest,
                 };
                 request.extensions_mut().insert(auth_user);
                 Ok(next.run(request).await)

--- a/server/src/api/server.rs
+++ b/server/src/api/server.rs
@@ -12,15 +12,20 @@ use crate::db::Database;
 
 use super::auth::{self, AuthState};
 use super::jwt::JwtManager;
-use super::middleware::auth_middleware;
+use super::middleware::{AuthMiddlewareState, auth_middleware};
 use super::rate_limit::{rate_limit_layer, rate_limit_middleware};
 
 pub async fn run_api_server(addr: &str, db: Arc<dyn Database>, jwt_secret: &str) -> Result<()> {
     let jwt_manager = Arc::new(JwtManager::new(jwt_secret));
 
     let auth_state = AuthState {
-        db,
+        db: db.clone(),
         jwt_manager: jwt_manager.clone(),
+        user_cache: None,
+    };
+    let auth_middleware_state = AuthMiddlewareState {
+        jwt_manager: jwt_manager.clone(),
+        db,
     };
 
     // Configure CORS
@@ -36,7 +41,7 @@ pub async fn run_api_server(addr: &str, db: Arc<dyn Database>, jwt_secret: &str)
     let protected_routes = Router::new()
         .route("/api/auth/me", get(auth::get_current_user))
         .layer(middleware::from_fn_with_state(
-            jwt_manager.clone(),
+            auth_middleware_state,
             auth_middleware,
         ));
 

--- a/server/src/db/dynamodb.rs
+++ b/server/src/db/dynamodb.rs
@@ -33,7 +33,14 @@ const SECONDS_PER_DAY: i64 = 24 * 60 * 60;
 const DYNAMODB_CONTROL_PLANE_MAX_ATTEMPTS: usize = 30;
 const DYNAMODB_CONTROL_PLANE_RETRY_DELAY: Duration = Duration::from_secs(1);
 const COMPLETION_RANKING_MAX_ATTEMPTS: usize = 16;
+const GUEST_UPGRADE_MAX_ATTEMPTS: usize = 8;
 const DYNAMODB_RUNTIME_MAX_ATTEMPTS: u32 = 5;
+
+#[derive(Clone, Copy)]
+enum UserProgressMutation {
+    Add(i32),
+    Set(i32),
+}
 
 /// How long a SERVER registration item lives past its last heartbeat before
 /// DynamoDB TTL reaps it. Deliberately generous: staleness is already handled
@@ -962,6 +969,99 @@ impl DynamoDatabase {
         ))
     }
 
+    fn user_progress_value(user: &User, field: &str) -> Result<i32> {
+        match field {
+            "mmr" => Ok(user.mmr),
+            "rankedMmr" => Ok(user.ranked_mmr),
+            "casualMmr" => Ok(user.casual_mmr),
+            "xp" => Ok(user.xp),
+            _ => Err(anyhow!("Unsupported user progress field '{field}'")),
+        }
+    }
+
+    /// Mutate canonical progress and its registered-user compatibility mirror
+    /// in one transaction. The guest/account state guard makes an upgrade race
+    /// retry with the correct mirror shape instead of skipping or doubling it.
+    async fn mutate_user_progress(
+        &self,
+        user_id: i32,
+        field: &str,
+        mutation: UserProgressMutation,
+    ) -> Result<i32> {
+        for attempt in 0..GUEST_UPGRADE_MAX_ATTEMPTS {
+            let user = self
+                .get_user_by_id(user_id)
+                .await?
+                .ok_or_else(|| anyhow!("User not found"))?;
+            let (update_expression, value) = match mutation {
+                UserProgressMutation::Add(delta) => ("ADD #progress :value", delta),
+                UserProgressMutation::Set(value) => ("SET #progress = :value", value),
+            };
+
+            let main_update = Update::builder()
+                .table_name(self.main_table())
+                .key("pk", Self::av_s(format!("USER#{user_id}")))
+                .key("sk", Self::av_s("META"))
+                .update_expression(update_expression)
+                .condition_expression(concat!(
+                    "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                    "username=:username AND isGuest=:is_guest"
+                ))
+                .expression_attribute_names("#progress", field)
+                .expression_attribute_values(":value", Self::av_n(value))
+                .expression_attribute_values(":username", Self::av_s(&user.username))
+                .expression_attribute_values(":is_guest", Self::av_bool(user.is_guest))
+                .build()
+                .with_context(|| format!("Failed to build canonical {field} mutation"))?;
+            let mut mutations = vec![TransactWriteItem::builder().update(main_update).build()];
+
+            if !user.is_guest {
+                let mirror_update = Update::builder()
+                    .table_name(self.usernames_table())
+                    .key("username", Self::av_s(&user.username))
+                    .update_expression(update_expression)
+                    .condition_expression("attribute_exists(username) AND userId=:user_id")
+                    .expression_attribute_names("#progress", field)
+                    .expression_attribute_values(":value", Self::av_n(value))
+                    .expression_attribute_values(":user_id", Self::av_n(user_id))
+                    .build()
+                    .with_context(|| format!("Failed to build mirrored {field} mutation"))?;
+                mutations.push(TransactWriteItem::builder().update(mirror_update).build());
+            }
+
+            let result = self
+                .client
+                .transact_write_items()
+                .client_request_token(uuid::Uuid::new_v4().to_string())
+                .set_transact_items(Some(mutations))
+                .send()
+                .await;
+            match result {
+                Ok(_) => {
+                    let current = self
+                        .get_user_by_id(user_id)
+                        .await?
+                        .ok_or_else(|| anyhow!("User not found"))?;
+                    return Self::user_progress_value(&current, field);
+                }
+                Err(error) if attempt + 1 < GUEST_UPGRADE_MAX_ATTEMPTS => {
+                    let exponent = attempt.min(6) as u32;
+                    sleep(Duration::from_millis(1_u64 << exponent)).await;
+                    debug!(
+                        "Retrying {} mutation for user {} after concurrent identity change: {}",
+                        field, user_id, error
+                    );
+                }
+                Err(error) => {
+                    return Err(error)
+                        .with_context(|| format!("Failed to atomically mutate user {field}"));
+                }
+            }
+        }
+
+        unreachable!("user progress mutation attempt loop always returns")
+    }
+
     async fn transact_completion_effect(
         &self,
         completion: &CompletionRecordV1,
@@ -1275,7 +1375,7 @@ impl Database for DynamoDatabase {
             .put_item()
             .table_name(self.usernames_table())
             .set_item(Some(username_item))
-            .condition_expression("attribute_not_exists(username)")
+            .condition_expression("attribute_not_exists(username) OR attribute_not_exists(userId)")
             .send()
             .await
             .map_err(|_| anyhow!("Username already exists"))?;
@@ -1378,6 +1478,144 @@ impl Database for DynamoDatabase {
         })
     }
 
+    async fn upgrade_guest_to_account(
+        &self,
+        user_id: i32,
+        username: &str,
+        password_hash: &str,
+    ) -> Result<User> {
+        for attempt in 0..GUEST_UPGRADE_MAX_ATTEMPTS {
+            let guest = self
+                .get_user_by_id(user_id)
+                .await?
+                .ok_or_else(|| anyhow!("Guest account not found"))?;
+
+            if !guest.is_guest {
+                return Err(anyhow!("Guest account has already been upgraded"));
+            }
+            if guest.is_stress_test {
+                return Err(anyhow!("Stress-test guest accounts cannot be upgraded"));
+            }
+
+            // Keep a complete mirror during rolling deployments, even though
+            // current readers use this table only as a username -> user ID
+            // index and load canonical progress from the main user record.
+            let mut username_item = HashMap::new();
+            username_item.insert("username".to_string(), Self::av_s(username));
+            username_item.insert("userId".to_string(), Self::av_n(user_id));
+            username_item.insert("passwordHash".to_string(), Self::av_s(password_hash));
+            username_item.insert("mmr".to_string(), Self::av_n(guest.mmr));
+            username_item.insert("rankedMmr".to_string(), Self::av_n(guest.ranked_mmr));
+            username_item.insert("casualMmr".to_string(), Self::av_n(guest.casual_mmr));
+            username_item.insert("xp".to_string(), Self::av_n(guest.xp));
+
+            let username_put = Put::builder()
+                .table_name(self.usernames_table())
+                .set_item(Some(username_item))
+                .condition_expression(concat!(
+                    "attribute_not_exists(username) OR ",
+                    "attribute_not_exists(userId) OR userId=:user_id"
+                ))
+                .expression_attribute_values(":user_id", Self::av_n(user_id))
+                .build()
+                .context("Failed to build guest username reservation")?;
+
+            // Progress fields participate in the condition, but not the SET.
+            // If a game completes between the read and transaction, the
+            // conditional cancellation forces a fresh snapshot and prevents a
+            // stale username mirror from being published.
+            let guest_update = Update::builder()
+                .table_name(self.main_table())
+                .key("pk", Self::av_s(format!("USER#{user_id}")))
+                .key("sk", Self::av_s("META"))
+                .update_expression(concat!(
+                    "SET username=:username, passwordHash=:password_hash, ",
+                    "isGuest=:not_guest, isStressTest=:not_stress ",
+                    "REMOVE guestToken"
+                ))
+                .condition_expression(concat!(
+                    "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                    "isGuest=:guest AND ",
+                    "(attribute_not_exists(isStressTest) OR isStressTest=:not_stress) AND ",
+                    "username=:old_username AND passwordHash=:old_password_hash AND ",
+                    "mmr=:mmr AND rankedMmr=:ranked_mmr AND ",
+                    "casualMmr=:casual_mmr AND xp=:xp"
+                ))
+                .expression_attribute_values(":username", Self::av_s(username))
+                .expression_attribute_values(":password_hash", Self::av_s(password_hash))
+                .expression_attribute_values(":not_guest", Self::av_bool(false))
+                .expression_attribute_values(":not_stress", Self::av_bool(false))
+                .expression_attribute_values(":guest", Self::av_bool(true))
+                .expression_attribute_values(":old_username", Self::av_s(&guest.username))
+                .expression_attribute_values(":old_password_hash", Self::av_s(&guest.password_hash))
+                .expression_attribute_values(":mmr", Self::av_n(guest.mmr))
+                .expression_attribute_values(":ranked_mmr", Self::av_n(guest.ranked_mmr))
+                .expression_attribute_values(":casual_mmr", Self::av_n(guest.casual_mmr))
+                .expression_attribute_values(":xp", Self::av_n(guest.xp))
+                .build()
+                .context("Failed to build in-place guest account upgrade")?;
+
+            let result = self
+                .client
+                .transact_write_items()
+                .client_request_token(uuid::Uuid::new_v4().to_string())
+                .transact_items(TransactWriteItem::builder().put(username_put).build())
+                .transact_items(TransactWriteItem::builder().update(guest_update).build())
+                .send()
+                .await;
+
+            match result {
+                Ok(_) => {
+                    let mut upgraded = guest;
+                    upgraded.username = username.to_string();
+                    upgraded.password_hash = password_hash.to_string();
+                    upgraded.is_guest = false;
+                    upgraded.guest_token = None;
+                    upgraded.is_stress_test = false;
+                    info!(
+                        "Upgraded guest user {} in place as account '{}'",
+                        user_id, username
+                    );
+                    return Ok(upgraded);
+                }
+                Err(error) => {
+                    // A response can be lost after DynamoDB commits. Recognize
+                    // this exact attempt as success instead of marooning the
+                    // browser with an invalidated guest token.
+                    let current = self
+                        .get_user_by_id(user_id)
+                        .await?
+                        .ok_or_else(|| anyhow!("Guest account not found"))?;
+                    if !current.is_guest {
+                        if current.username == username && current.password_hash == password_hash {
+                            return Ok(current);
+                        }
+                        return Err(anyhow!("Guest account has already been upgraded"));
+                    }
+
+                    if let Some(owner) = self.get_user_by_username(username).await?
+                        && owner.id != user_id
+                    {
+                        return Err(anyhow!("Username already exists"));
+                    }
+
+                    if attempt + 1 == GUEST_UPGRADE_MAX_ATTEMPTS {
+                        return Err(error).context("Failed to atomically upgrade guest account");
+                    }
+
+                    let exponent = attempt.min(6) as u32;
+                    sleep(Duration::from_millis(1_u64 << exponent)).await;
+                    debug!(
+                        "Retrying guest upgrade for user {} after concurrent mutation",
+                        user_id
+                    );
+                }
+            }
+        }
+
+        unreachable!("guest upgrade attempt loop always returns")
+    }
+
     async fn get_user_by_id(&self, user_id: i32) -> Result<Option<User>> {
         let response = self
             .client
@@ -1422,65 +1660,33 @@ impl Database for DynamoDatabase {
             .get_item()
             .table_name(self.usernames_table())
             .key("username", Self::av_s(username))
+            .consistent_read(true)
             .send()
             .await
             .context("Failed to get user by username")?;
 
         match response.item {
             Some(item) => {
-                let user_id = Self::extract_number(&item, "userId")
-                    .ok_or_else(|| anyhow!("Missing user ID"))?;
-
-                // Return user data directly from username table (it has all needed fields)
-                let user = User {
-                    id: user_id,
-                    username: username.to_string(),
-                    password_hash: Self::extract_string(&item, "passwordHash").unwrap_or_default(),
-                    mmr: Self::extract_number(&item, "mmr").unwrap_or(1000),
-                    ranked_mmr: Self::extract_number(&item, "rankedMmr").unwrap_or(1000),
-                    casual_mmr: Self::extract_number(&item, "casualMmr").unwrap_or(1000),
-                    xp: Self::extract_number(&item, "xp").unwrap_or(0),
-                    created_at: Utc::now(), // Not stored in username table, use current time
-                    is_guest: false,        // Users in username table are never guests
-                    guest_token: None,
-                    is_stress_test: false,
+                let Some(user_id) = Self::extract_number(&item, "userId") else {
+                    // Older progress writers could accidentally create a
+                    // partial row for a guest nickname. Treat it as an
+                    // unclaimed index entry so account creation can repair it.
+                    warn!("Ignoring incomplete username index row for '{}'", username);
+                    return Ok(None);
                 };
-                Ok(Some(user))
+
+                // The username table is the uniqueness/index boundary. The
+                // main record remains canonical for credentials and progress,
+                // avoiding stale mirror reads during an in-place guest claim.
+                self.get_user_by_id(user_id).await
             }
             None => Ok(None),
         }
     }
 
     async fn update_user_mmr(&self, user_id: i32, mmr: i32) -> Result<()> {
-        // Update main table
-        self.client
-            .update_item()
-            .table_name(self.main_table())
-            .key("pk", Self::av_s(format!("USER#{}", user_id)))
-            .key("sk", Self::av_s("META"))
-            .update_expression("SET mmr = :mmr")
-            .expression_attribute_values(":mmr", Self::av_n(mmr))
-            .send()
-            .await
-            .context("Failed to update user MMR")?;
-
-        // Also need to update username table
-        // First get username
-        let user = self
-            .get_user_by_id(user_id)
-            .await?
-            .ok_or_else(|| anyhow!("User not found"))?;
-
-        self.client
-            .update_item()
-            .table_name(self.usernames_table())
-            .key("username", Self::av_s(&user.username))
-            .update_expression("SET mmr = :mmr")
-            .expression_attribute_values(":mmr", Self::av_n(mmr))
-            .send()
-            .await
-            .context("Failed to update user MMR in username table")?;
-
+        self.mutate_user_progress(user_id, "mmr", UserProgressMutation::Set(mmr))
+            .await?;
         Ok(())
     }
 
@@ -1491,7 +1697,9 @@ impl Database for DynamoDatabase {
             .key("pk", Self::av_s(format!("USER#{}", user_id)))
             .key("sk", Self::av_s("META"))
             .update_expression("SET username = :username")
+            .condition_expression("attribute_exists(pk) AND isGuest = :guest")
             .expression_attribute_values(":username", Self::av_s(username))
+            .expression_attribute_values(":guest", Self::av_bool(true))
             .send()
             .await
             .context("Failed to update guest username")?;
@@ -1500,41 +1708,9 @@ impl Database for DynamoDatabase {
     }
 
     async fn add_user_xp(&self, user_id: i32, xp_to_add: i32) -> Result<i32> {
-        // Atomic ADD operation in DynamoDB main table
-        let response = self
-            .client
-            .update_item()
-            .table_name(self.main_table())
-            .key("pk", Self::av_s(format!("USER#{}", user_id)))
-            .key("sk", Self::av_s("META"))
-            .update_expression("ADD xp :xp_delta")
-            .expression_attribute_values(":xp_delta", Self::av_n(xp_to_add))
-            .return_values(ReturnValue::AllNew)
-            .send()
-            .await
-            .context("Failed to add user XP")?;
-
-        // Extract and return new XP total
-        let new_xp = response
-            .attributes
-            .and_then(|attrs| Self::extract_number(&attrs, "xp"))
-            .unwrap_or(xp_to_add);
-
-        // Also update username table for consistency
-        let user = self
-            .get_user_by_id(user_id)
-            .await?
-            .ok_or_else(|| anyhow!("User not found"))?;
-
-        self.client
-            .update_item()
-            .table_name(self.usernames_table())
-            .key("username", Self::av_s(&user.username))
-            .update_expression("ADD xp :xp_delta")
-            .expression_attribute_values(":xp_delta", Self::av_n(xp_to_add))
-            .send()
-            .await
-            .context("Failed to update XP in username table")?;
+        let new_xp = self
+            .mutate_user_progress(user_id, "xp", UserProgressMutation::Add(xp_to_add))
+            .await?;
 
         info!(
             "Added {} XP to user {} (new total: {})",
@@ -1555,41 +1731,9 @@ impl Database for DynamoDatabase {
             common::QueueMode::Quickmatch => "casualMmr",
         };
 
-        // Atomic ADD operation in DynamoDB main table
-        let response = self
-            .client
-            .update_item()
-            .table_name(self.main_table())
-            .key("pk", Self::av_s(format!("USER#{}", user_id)))
-            .key("sk", Self::av_s("META"))
-            .update_expression(format!("ADD {} :mmr_delta", mmr_field))
-            .expression_attribute_values(":mmr_delta", Self::av_n(mmr_delta))
-            .return_values(ReturnValue::AllNew)
-            .send()
-            .await
-            .context("Failed to update user MMR")?;
-
-        // Extract and return new MMR total
-        let new_mmr = response
-            .attributes
-            .and_then(|attrs| Self::extract_number(&attrs, mmr_field))
-            .unwrap_or(1000 + mmr_delta);
-
-        // Also update username table for consistency
-        let user = self
-            .get_user_by_id(user_id)
-            .await?
-            .ok_or_else(|| anyhow!("User not found"))?;
-
-        self.client
-            .update_item()
-            .table_name(self.usernames_table())
-            .key("username", Self::av_s(&user.username))
-            .update_expression(format!("ADD {} :mmr_delta", mmr_field))
-            .expression_attribute_values(":mmr_delta", Self::av_n(mmr_delta))
-            .send()
-            .await
-            .context("Failed to update MMR in username table")?;
+        let new_mmr = self
+            .mutate_user_progress(user_id, mmr_field, UserProgressMutation::Add(mmr_delta))
+            .await?;
 
         info!(
             "Updated {} for user {} by {} (new total: {})",
@@ -1887,7 +2031,12 @@ impl Database for DynamoDatabase {
     ) -> Result<EffectApplyResult> {
         completion.validate_effect(effect)?;
 
-        let max_attempts = if matches!(effect, CompletionEffect::UpdateRanking { .. }) {
+        let max_attempts = if matches!(
+            effect,
+            CompletionEffect::AddXp { .. }
+                | CompletionEffect::AddMmr { .. }
+                | CompletionEffect::UpdateRanking { .. }
+        ) {
             COMPLETION_RANKING_MAX_ATTEMPTS
         } else {
             1
@@ -2002,11 +2151,13 @@ impl Database for DynamoDatabase {
                         .key("pk", Self::av_s(format!("USER#{user_id}")))
                         .key("sk", Self::av_s("META"))
                         .update_expression("ADD xp :delta")
-                        .condition_expression(
-                            "attribute_exists(pk) AND attribute_exists(sk) AND username=:username",
-                        )
+                        .condition_expression(concat!(
+                            "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                            "username=:username AND isGuest=:is_guest"
+                        ))
                         .expression_attribute_values(":delta", Self::av_n(amount))
                         .expression_attribute_values(":username", Self::av_s(&current_username))
+                        .expression_attribute_values(":is_guest", Self::av_bool(is_guest))
                         .build()
                         .context("Failed to build idempotent XP update")?;
                     let mut mutations =
@@ -2042,11 +2193,13 @@ impl Database for DynamoDatabase {
                         .key("pk", Self::av_s(format!("USER#{user_id}")))
                         .key("sk", Self::av_s("META"))
                         .update_expression(format!("ADD {field} :delta"))
-                        .condition_expression(
-                            "attribute_exists(pk) AND attribute_exists(sk) AND username=:username",
-                        )
+                        .condition_expression(concat!(
+                            "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                            "username=:username AND isGuest=:is_guest"
+                        ))
                         .expression_attribute_values(":delta", Self::av_n(delta))
                         .expression_attribute_values(":username", Self::av_s(&current_username))
+                        .expression_attribute_values(":is_guest", Self::av_bool(is_guest))
                         .build()
                         .context("Failed to build idempotent MMR update")?;
                     let mut mutations =
@@ -2304,13 +2457,13 @@ impl Database for DynamoDatabase {
             {
                 Ok(result) => return Ok(result),
                 Err(error) if attempt + 1 < max_attempts => {
-                    // Ranking rows are sorted by MMR, so concurrent games for
-                    // one user race a conditional delete/put. Re-read and
-                    // rebuild the transaction until one observes the winner.
+                    // Ranking rows and guest-to-account transitions both use
+                    // conditional state. Re-read and rebuild until one attempt
+                    // observes the winning MMR/account state.
                     let exponent = attempt.min(6) as u32;
                     sleep(Duration::from_millis(1_u64 << exponent)).await;
                     debug!(
-                        "Retrying completion ranking effect {} after concurrent mutation: {}",
+                        "Retrying completion effect {} after concurrent mutation: {}",
                         effect.id(),
                         error
                     );

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -60,6 +60,14 @@ pub trait Database: Send + Sync {
         mmr: i32,
         is_stress_test: bool,
     ) -> Result<User>;
+    /// Convert an existing public guest into a password-backed account while
+    /// preserving the guest's durable user ID and all ID-owned progress.
+    async fn upgrade_guest_to_account(
+        &self,
+        user_id: i32,
+        username: &str,
+        password_hash: &str,
+    ) -> Result<User>;
     async fn get_user_by_id(&self, user_id: i32) -> Result<Option<User>>;
     async fn get_user_by_username(&self, username: &str) -> Result<Option<User>>;
     async fn update_user_mmr(&self, user_id: i32, mmr: i32) -> Result<()>;

--- a/server/src/game_executor_v2.rs
+++ b/server/src/game_executor_v2.rs
@@ -4352,6 +4352,11 @@ mod tests {
             mmr: i32,
             is_stress_test: bool
         ) -> User);
+        unused_database_method!(upgrade_guest_to_account(
+            user_id: i32,
+            username: &str,
+            password_hash: &str
+        ) -> User);
         unused_database_method!(get_user_by_id(user_id: i32) -> Option<User>);
         unused_database_method!(get_user_by_username(username: &str) -> Option<User>);
         unused_database_method!(update_user_mmr(user_id: i32, mmr: i32) -> ());

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -20,7 +20,7 @@ use tracing::info;
 use crate::api::auth::{self, AuthState};
 use crate::api::jwt::JwtManager;
 use crate::api::leaderboard::{self, LeaderboardState};
-use crate::api::middleware::auth_middleware;
+use crate::api::middleware::{AuthMiddlewareState, auth_middleware};
 use crate::api::rate_limit::{rate_limit_layer, rate_limit_middleware};
 use crate::api::regions;
 use crate::cluster_membership::ClusterNamespace;
@@ -231,6 +231,11 @@ pub async fn install_http_application(
     let auth_state = AuthState {
         db: db.clone(),
         jwt_manager: jwt_manager.clone(),
+        user_cache: Some(state.user_cache.clone()),
+    };
+    let auth_middleware_state = AuthMiddlewareState {
+        jwt_manager: jwt_manager.clone(),
+        db: db.clone(),
     };
 
     // Configure CORS
@@ -246,7 +251,7 @@ pub async fn install_http_application(
     let protected_routes = Router::new()
         .route("/api/auth/me", get(auth::get_current_user))
         .layer(middleware::from_fn_with_state(
-            jwt_manager.clone(),
+            auth_middleware_state.clone(),
             auth_middleware,
         ))
         .with_state(auth_state.clone());
@@ -280,7 +285,7 @@ pub async fn install_http_application(
     let protected_leaderboard_routes = Router::new()
         .route("/api/leaderboard/me", get(leaderboard::get_my_ranking))
         .layer(middleware::from_fn_with_state(
-            jwt_manager.clone(),
+            auth_middleware_state,
             auth_middleware,
         ))
         .with_state(leaderboard_state);

--- a/server/src/user_cache.rs
+++ b/server/src/user_cache.rs
@@ -9,6 +9,30 @@ use std::sync::Arc;
 
 const EXPIRATION_SECONDS: u64 = 3600; // 1 hour
 
+// A guest-to-account conversion is monotonic. A cache miss may read the guest
+// record immediately before that conversion commits, then reach Redis after the
+// upgraded account has already been written through. Keep the comparison and
+// write atomic so that late guest fill can never restore the stale identity.
+const PUT_USER_SCRIPT: &str = r#"
+local cached = redis.call('GET', KEYS[1])
+if cached and ARGV[2] == '1' then
+    local decoded_ok, cached_user = pcall(cjson.decode, cached)
+    if decoded_ok then
+        local cached_is_guest = cached_user['is_guest']
+        if cached_is_guest == nil then
+            cached_is_guest = cached_user['isGuest']
+        end
+        if cached_is_guest == false then
+            redis.call('EXPIRE', KEYS[1], ARGV[3])
+            return 0
+        end
+    end
+end
+
+redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[3])
+return 1
+"#;
+
 #[derive(Clone)]
 pub struct UserCache {
     redis: RedisConnection,
@@ -113,16 +137,30 @@ impl UserCache {
     }
 
     async fn put_to_redis(&self, user: &User) -> Result<()> {
-        self.redis
-            .clone()
-            .set_ex::<_, _, ()>(
-                RedisKeys::user(user.id as u32),
-                serde_json::to_string(user)
-                    .context("Failed to serialize user to json for Redis")?,
-                EXPIRATION_SECONDS,
-            )
+        let user_json =
+            serde_json::to_string(user).context("Failed to serialize user to json for Redis")?;
+        let mut redis = self.redis.clone();
+        redis::Script::new(PUT_USER_SCRIPT)
+            .key(RedisKeys::user(user.id as u32))
+            .arg(user_json)
+            .arg(if user.is_guest { 1 } else { 0 })
+            .arg(EXPIRATION_SECONDS)
+            .invoke_async::<i32>(&mut redis)
             .await
-            .context("Failed to put user json to Redis with expiration")
+            .context("Failed to put user json to Redis with monotonic guest state")?;
+        Ok(())
+    }
+
+    /// Write a newly upgraded account through to Redis. Combined with the
+    /// monotonic cache-fill script, this prevents a concurrent stale guest read
+    /// from overwriting the account after the durable conversion commits.
+    pub async fn replace_after_guest_upgrade(&self, user: &User) -> Result<()> {
+        if user.is_guest {
+            return Err(anyhow!(
+                "Cannot cache a guest as the result of an account upgrade"
+            ));
+        }
+        self.put_to_redis(user).await
     }
 
     pub async fn remove_from_redis(&self, user_id: u32) -> Result<()> {
@@ -139,5 +177,74 @@ impl UserCache {
             .expire::<_, ()>(RedisKeys::user(user_id), EXPIRATION_SECONDS as i64)
             .await
             .context("Failed to touch user cache expiration")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::redis_utils::RedisClient;
+    use serde_json::json;
+
+    async fn script_put(
+        redis: &mut RedisConnection,
+        key: &str,
+        value: serde_json::Value,
+        is_guest: bool,
+    ) -> Result<i32> {
+        redis::Script::new(PUT_USER_SCRIPT)
+            .key(key)
+            .arg(value.to_string())
+            .arg(if is_guest { 1 } else { 0 })
+            .arg(EXPIRATION_SECONDS)
+            .invoke_async(redis)
+            .await
+            .context("Failed to invoke monotonic user-cache script")
+    }
+
+    #[tokio::test]
+    async fn stale_guest_fill_cannot_replace_cached_account() -> Result<()> {
+        let client = RedisClient::open("redis://127.0.0.1:6379/15?protocol=resp3", None)?;
+        let mut redis = client.get_managed_connection().await?;
+        let key = format!("test:user-cache-upgrade:{}", uuid::Uuid::new_v4());
+
+        assert_eq!(
+            script_put(
+                &mut redis,
+                &key,
+                json!({ "id": 42, "username": "Guest42", "is_guest": true }),
+                true,
+            )
+            .await?,
+            1
+        );
+        assert_eq!(
+            script_put(
+                &mut redis,
+                &key,
+                json!({ "id": 42, "username": "Player42", "is_guest": false }),
+                false,
+            )
+            .await?,
+            1
+        );
+        assert_eq!(
+            script_put(
+                &mut redis,
+                &key,
+                json!({ "id": 42, "username": "Guest42", "is_guest": true }),
+                true,
+            )
+            .await?,
+            0
+        );
+
+        let cached: String = redis.get(&key).await?;
+        let cached: serde_json::Value = serde_json::from_str(&cached)?;
+        assert_eq!(cached["username"], "Player42");
+        assert_eq!(cached["is_guest"], false);
+
+        redis.del::<_, ()>(&key).await?;
+        Ok(())
     }
 }

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -3317,6 +3317,12 @@ async fn process_ws_message(
                                 .await?
                                 .ok_or_else(|| anyhow::anyhow!("User not found"))?;
 
+                            if user.is_guest != user_token.is_guest {
+                                return Err(anyhow::anyhow!(
+                                    "Authentication failed: guest claim does not match user record"
+                                ));
+                            }
+
                             let database_pool = if user.is_stress_test {
                                 MatchmakingPool::Stress
                             } else {

--- a/server/tests/auth_upgrade_tests.rs
+++ b/server/tests/auth_upgrade_tests.rs
@@ -1,0 +1,700 @@
+use anyhow::Result;
+use axum::{
+    Json, Router,
+    body::{Body, to_bytes},
+    extract::State,
+    http::{HeaderMap, HeaderValue, Request, StatusCode, header},
+    middleware,
+    response::{IntoResponse, Response},
+    routing::get,
+};
+use bcrypt::{DEFAULT_COST, hash, verify};
+use chrono::{Duration, Utc};
+use common::{GameType, QueueMode};
+use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
+use serde_json::{Value, json};
+use server::{
+    api::{
+        auth::{AuthState, LoginRequest, RegisterRequest, get_current_user, login, register},
+        jwt::{Claims, JwtManager},
+        middleware::{AuthMiddlewareState, auth_middleware},
+    },
+    db::{Database, dynamodb::DynamoDatabase},
+    matchmaking_pool::MatchmakingPool,
+};
+use std::sync::Arc;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const JWT_SECRET: &str = "test_secret_key_for_testing";
+
+// Each test changes the process-wide DynamoDB prefix, so this integration
+// binary must serialize its setup and database lifetime.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn isolated_state() -> Result<(AuthState, Arc<dyn Database>, Arc<JwtManager>)> {
+    let prefix = format!("test_auth_upgrade_{}", Uuid::new_v4().simple());
+    // SAFETY: every test in this binary holds TEST_LOCK for its full lifetime.
+    unsafe { std::env::set_var("DYNAMODB_TABLE_PREFIX", prefix) };
+
+    let db = Arc::new(DynamoDatabase::new().await?) as Arc<dyn Database>;
+    let jwt_manager = Arc::new(JwtManager::new(JWT_SECRET));
+    let state = AuthState {
+        db: db.clone(),
+        jwt_manager: jwt_manager.clone(),
+        user_cache: None,
+    };
+    Ok((state, db, jwt_manager))
+}
+
+async fn response_json(response: Response) -> Result<(StatusCode, Value)> {
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    Ok((status, serde_json::from_slice(&bytes)?))
+}
+
+async fn register_response(
+    state: AuthState,
+    bearer_token: Option<&str>,
+    username: &str,
+    password: &str,
+) -> Result<(StatusCode, Value)> {
+    let mut headers = HeaderMap::new();
+    if let Some(token) = bearer_token {
+        headers.insert(
+            header::AUTHORIZATION,
+            HeaderValue::from_str(&format!("Bearer {token}"))?,
+        );
+    }
+    let response = match register(
+        State(state),
+        headers,
+        Json(RegisterRequest {
+            username: username.to_string(),
+            password: password.to_string(),
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    };
+    response_json(response).await
+}
+
+async fn login_response(
+    state: AuthState,
+    username: &str,
+    password: &str,
+) -> Result<(StatusCode, Value)> {
+    let response = match login(
+        State(state),
+        Json(LoginRequest {
+            username: username.to_string(),
+            password: password.to_string(),
+        }),
+    )
+    .await
+    {
+        Ok(response) => response,
+        Err(error) => error.into_response(),
+    };
+    response_json(response).await
+}
+
+fn guest_token(jwt: &JwtManager, user_id: i32, username: &str) -> Result<String> {
+    jwt.generate_token_with_guest_and_pool(user_id, username, true, MatchmakingPool::Public)
+}
+
+#[tokio::test]
+async fn guest_upgrade_preserves_id_progress_and_owned_records() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let password = "careful-password";
+    let guest = db
+        .create_guest_user("KeepMySnake", "guest-record-token", 1_000, false)
+        .await?;
+    let original_created_at = guest.created_at;
+    let old_token = guest_token(&jwt_manager, guest.id, &guest.username)?;
+
+    db.update_user_mmr(guest.id, 1_234).await?;
+    assert_eq!(
+        db.update_user_mmr_by_mode(guest.id, 125, &QueueMode::Competitive)
+            .await?,
+        1_125
+    );
+    assert_eq!(
+        db.update_user_mmr_by_mode(guest.id, -50, &QueueMode::Quickmatch)
+            .await?,
+        950
+    );
+    assert_eq!(db.add_user_xp(guest.id, 77).await?, 77);
+
+    let ranked_game_type = GameType::TeamMatch { per_team: 1 };
+    db.upsert_ranking(
+        guest.id,
+        &guest.username,
+        1_125,
+        &QueueMode::Competitive,
+        &ranked_game_type,
+        "test-region",
+        0,
+        true,
+    )
+    .await?;
+    db.insert_high_score(
+        "guest-upgrade-score",
+        guest.id,
+        &guest.username,
+        42,
+        &GameType::Solo,
+        "test-region",
+        0,
+    )
+    .await?;
+    let game_id = db
+        .create_game(
+            1,
+            &serde_json::to_value(GameType::Solo)?,
+            "quickmatch",
+            false,
+            None,
+        )
+        .await?;
+    db.add_player_to_game(game_id, guest.id, 0).await?;
+
+    let (status, body) =
+        register_response(state.clone(), Some(&old_token), &guest.username, password).await?;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    assert_eq!(body["user"]["id"], json!(guest.id));
+    assert_eq!(body["user"]["isGuest"], json!(false));
+    assert_eq!(body["user"]["mmr"], json!(1_234));
+
+    let replacement_token = body["token"].as_str().expect("replacement token");
+    let replacement_claims = jwt_manager.verify_token(replacement_token)?;
+    assert_eq!(replacement_claims.sub, guest.id.to_string());
+    assert_eq!(replacement_claims.username, guest.username);
+    assert!(!replacement_claims.is_guest);
+    assert_eq!(replacement_claims.matchmaking_pool, MatchmakingPool::Public);
+
+    let upgraded = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("upgraded user remains present");
+    assert_eq!(upgraded.id, guest.id);
+    assert_eq!(upgraded.created_at, original_created_at);
+    assert_eq!(upgraded.mmr, 1_234);
+    assert_eq!(upgraded.ranked_mmr, 1_125);
+    assert_eq!(upgraded.casual_mmr, 950);
+    assert_eq!(upgraded.xp, 77);
+    assert!(!upgraded.is_guest);
+    assert!(upgraded.guest_token.is_none());
+    assert!(verify(password, &upgraded.password_hash)?);
+
+    // A guest socket that was already open before the HTTP conversion still
+    // carries guest metadata. The database boundary must reject its late
+    // nickname mutation rather than desynchronizing the username index.
+    assert!(
+        db.update_guest_username(guest.id, "StaleSocketRename")
+            .await
+            .is_err()
+    );
+    assert_eq!(
+        db.get_user_by_id(guest.id)
+            .await?
+            .expect("converted user remains present")
+            .username,
+        upgraded.username
+    );
+
+    let by_username = db
+        .get_user_by_username(&upgraded.username)
+        .await?
+        .expect("username index points to converted user");
+    assert_eq!(by_username.id, guest.id);
+    assert_eq!(by_username.ranked_mmr, 1_125);
+    assert_eq!(by_username.casual_mmr, 950);
+    assert_eq!(by_username.xp, 77);
+
+    let ranking = db
+        .get_user_ranking(
+            guest.id,
+            &QueueMode::Competitive,
+            &ranked_game_type,
+            "test-region",
+            0,
+        )
+        .await?
+        .expect("ranking remains attached to the same ID");
+    assert_eq!(ranking.user_id, guest.id);
+    assert_eq!(ranking.mmr, 1_125);
+    assert_eq!(ranking.games_played, 1);
+    assert_eq!(ranking.wins, 1);
+
+    let high_scores = db
+        .get_high_scores(&GameType::Solo, Some("test-region"), 0, 10)
+        .await?;
+    let score = high_scores
+        .iter()
+        .find(|score| score.user_id == guest.id)
+        .expect("high score remains attached to the same ID");
+    assert_eq!(score.score, 42);
+    assert!(
+        db.get_game_players(game_id)
+            .await?
+            .iter()
+            .any(|player| player.user_id == guest.id)
+    );
+
+    let (login_status, login_body) =
+        login_response(state.clone(), &upgraded.username, password).await?;
+    assert_eq!(login_status, StatusCode::OK, "{login_body}");
+    assert_eq!(login_body["user"]["id"], json!(guest.id));
+
+    // A lost-success retry can recover with the newly established password.
+    let (retry_status, retry_body) = register_response(
+        state.clone(),
+        Some(&old_token),
+        &upgraded.username,
+        password,
+    )
+    .await?;
+    assert_eq!(retry_status, StatusCode::OK, "{retry_body}");
+    assert_eq!(retry_body["user"]["id"], json!(guest.id));
+
+    // Exercise the real authentication middleware boundary: the old guest
+    // claim is revoked by the canonical account transition, while the
+    // replacement token remains valid for the same user ID.
+    let protected_auth = Router::new()
+        .route("/api/auth/me", get(get_current_user))
+        .layer(middleware::from_fn_with_state(
+            AuthMiddlewareState {
+                jwt_manager: jwt_manager.clone(),
+                db: db.clone(),
+            },
+            auth_middleware,
+        ))
+        .with_state(state);
+    let stale_response = protected_auth
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/me")
+                .header(header::AUTHORIZATION, format!("Bearer {old_token}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(stale_response.status(), StatusCode::UNAUTHORIZED);
+
+    let replacement_response = protected_auth
+        .oneshot(
+            Request::builder()
+                .uri("/api/auth/me")
+                .header(header::AUTHORIZATION, format!("Bearer {replacement_token}"))
+                .body(Body::empty())?,
+        )
+        .await?;
+    assert_eq!(replacement_response.status(), StatusCode::OK);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn taken_username_leaves_guest_unchanged() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let owner_hash = hash("owner-password", DEFAULT_COST)?;
+    let owner = db.create_user("AlreadyOwned", &owner_hash, 1_000).await?;
+    let guest = db
+        .create_guest_user("StillAGuest", "guest-conflict-token", 1_000, false)
+        .await?;
+    db.add_user_xp(guest.id, 19).await?;
+    let token = guest_token(&jwt_manager, guest.id, &guest.username)?;
+
+    let (status, body) =
+        register_response(state, Some(&token), &owner.username, "new-password").await?;
+    assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    assert_eq!(body["error"], json!("Username already exists"));
+
+    let unchanged = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("guest remains present");
+    assert!(unchanged.is_guest);
+    assert_eq!(unchanged.username, guest.username);
+    assert_eq!(unchanged.password_hash, guest.password_hash);
+    assert_eq!(unchanged.guest_token, guest.guest_token);
+    assert_eq!(unchanged.xp, 19);
+    assert_eq!(
+        db.get_user_by_username(&owner.username)
+            .await?
+            .expect("owner remains present")
+            .id,
+        owner.id
+    );
+    assert!(db.get_user_by_username(&guest.username).await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn stress_guest_cannot_be_upgraded() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let guest = db
+        .create_guest_user("StressGuest", "stress-guest-token", 1_000, true)
+        .await?;
+    let stress_token = jwt_manager.generate_token_with_guest_and_pool(
+        guest.id,
+        &guest.username,
+        true,
+        MatchmakingPool::Stress,
+    )?;
+    // The database check is a second boundary: even a public-pool claim for a
+    // stress record must not convert that synthetic identity into a real one.
+    let public_token = guest_token(&jwt_manager, guest.id, &guest.username)?;
+
+    for (token, username) in [
+        (stress_token.as_str(), "StressGuest"),
+        (public_token.as_str(), "StressPublicClaim"),
+    ] {
+        let (status, body) =
+            register_response(state.clone(), Some(token), username, "strong-password").await?;
+        assert_eq!(status, StatusCode::FORBIDDEN, "{body}");
+        assert_eq!(
+            body["error"],
+            json!("Stress-test guest accounts cannot be upgraded")
+        );
+        assert!(db.get_user_by_username(username).await?.is_none());
+    }
+
+    let unchanged = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("stress guest remains present");
+    assert!(unchanged.is_guest);
+    assert!(unchanged.is_stress_test);
+    assert_eq!(unchanged.username, guest.username);
+    assert_eq!(unchanged.password_hash, guest.password_hash);
+    assert_eq!(unchanged.guest_token, guest.guest_token);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn invalid_guest_tokens_fail_closed_and_signed_out_registration_still_works() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let now = Utc::now();
+    let expired_token = encode(
+        &Header::new(Algorithm::HS256),
+        &Claims {
+            sub: "999".to_string(),
+            username: "ExpiredGuest".to_string(),
+            exp: (now - Duration::hours(1)).timestamp(),
+            iat: (now - Duration::hours(2)).timestamp(),
+            is_guest: true,
+            matchmaking_pool: MatchmakingPool::Public,
+        },
+        &EncodingKey::from_secret(JWT_SECRET.as_bytes()),
+    )?;
+
+    for (token, username) in [
+        ("not-a-jwt", "InvalidBearer"),
+        (expired_token.as_str(), "ExpiredBearer"),
+    ] {
+        let (status, body) =
+            register_response(state.clone(), Some(token), username, "strong-password").await?;
+        assert_eq!(status, StatusCode::UNAUTHORIZED, "{body}");
+        assert_eq!(body["error"], json!("Invalid or expired guest session"));
+        assert!(db.get_user_by_username(username).await?.is_none());
+    }
+
+    let (status, body) =
+        register_response(state.clone(), None, "OrdinaryAccount", "strong-password").await?;
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let ordinary_id = body["user"]["id"].as_i64().expect("ordinary user ID") as i32;
+    assert!(!body["user"]["isGuest"].as_bool().unwrap());
+
+    let ordinary_token = body["token"].as_str().expect("ordinary token");
+    let claims = jwt_manager.verify_token(ordinary_token)?;
+    assert_eq!(claims.sub, ordinary_id.to_string());
+    assert!(!claims.is_guest);
+
+    let (full_user_status, full_user_body) = register_response(
+        state,
+        Some(ordinary_token),
+        "SecondAccount",
+        "strong-password",
+    )
+    .await?;
+    assert_eq!(full_user_status, StatusCode::CONFLICT, "{full_user_body}");
+    assert_eq!(
+        full_user_body["error"],
+        json!("Account is already registered")
+    );
+    assert!(db.get_user_by_username("SecondAccount").await?.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_guest_claims_create_exactly_one_account() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let guest = db
+        .create_guest_user("RaceGuest", "guest-race-token", 1_000, false)
+        .await?;
+    let token = guest_token(&jwt_manager, guest.id, &guest.username)?;
+
+    let first = register_response(
+        state.clone(),
+        Some(&token),
+        "RaceWinnerA",
+        "strong-password-a",
+    );
+    let second = register_response(
+        state.clone(),
+        Some(&token),
+        "RaceWinnerB",
+        "strong-password-b",
+    );
+    let (first_result, second_result) = tokio::join!(first, second);
+    let (first_status, first_body) = first_result?;
+    let (second_status, second_body) = second_result?;
+
+    let (winner_name, winner_password, winner_body, loser_name, loser_body) =
+        match (first_status, second_status) {
+            (StatusCode::OK, StatusCode::UNAUTHORIZED) => (
+                "RaceWinnerA",
+                "strong-password-a",
+                &first_body,
+                "RaceWinnerB",
+                &second_body,
+            ),
+            (StatusCode::UNAUTHORIZED, StatusCode::OK) => (
+                "RaceWinnerB",
+                "strong-password-b",
+                &second_body,
+                "RaceWinnerA",
+                &first_body,
+            ),
+            statuses => panic!(
+                "expected one success and one rejected stale claim, got {statuses:?}; \
+                 first={first_body}, second={second_body}"
+            ),
+        };
+    assert_eq!(winner_body["user"]["id"], json!(guest.id));
+    assert_eq!(winner_body["user"]["isGuest"], json!(false));
+    assert_eq!(
+        loser_body["error"],
+        json!("Invalid or expired guest session")
+    );
+
+    let converted = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("guest record remains present");
+    assert!(!converted.is_guest);
+    assert_eq!(converted.id, guest.id);
+    assert_eq!(converted.username, winner_name);
+    assert!(converted.guest_token.is_none());
+    assert!(verify(winner_password, &converted.password_hash)?);
+
+    let winner = db
+        .get_user_by_username(winner_name)
+        .await?
+        .expect("winning username mapping");
+    assert_eq!(winner.id, guest.id);
+    assert_eq!(winner.username, winner_name);
+    assert!(db.get_user_by_username(loser_name).await?.is_none());
+
+    let (login_status, login_body) =
+        login_response(state.clone(), winner_name, winner_password).await?;
+    assert_eq!(login_status, StatusCode::OK, "{login_body}");
+    assert_eq!(login_body["user"]["id"], json!(guest.id));
+    let (loser_login_status, loser_login_body) =
+        login_response(state, loser_name, "strong-password-a").await?;
+    assert_eq!(
+        loser_login_status,
+        StatusCode::UNAUTHORIZED,
+        "{loser_login_body}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn two_guests_racing_for_one_username_leave_one_guest_unclaimed() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, jwt_manager) = isolated_state().await?;
+    let first_guest = db
+        .create_guest_user("FirstGuest", "first-guest-token", 1_000, false)
+        .await?;
+    let second_guest = db
+        .create_guest_user("SecondGuest", "second-guest-token", 1_000, false)
+        .await?;
+    let first_token = guest_token(&jwt_manager, first_guest.id, &first_guest.username)?;
+    let second_token = guest_token(&jwt_manager, second_guest.id, &second_guest.username)?;
+    let target_username = "SharedClaim";
+
+    let first = register_response(
+        state.clone(),
+        Some(&first_token),
+        target_username,
+        "first-password",
+    );
+    let second = register_response(
+        state.clone(),
+        Some(&second_token),
+        target_username,
+        "second-password",
+    );
+    let (first_result, second_result) = tokio::join!(first, second);
+    let (first_status, first_body) = first_result?;
+    let (second_status, second_body) = second_result?;
+
+    let (winner, winner_password, winner_body, loser, loser_body) =
+        match (first_status, second_status) {
+            (StatusCode::OK, StatusCode::CONFLICT) => (
+                &first_guest,
+                "first-password",
+                &first_body,
+                &second_guest,
+                &second_body,
+            ),
+            (StatusCode::CONFLICT, StatusCode::OK) => (
+                &second_guest,
+                "second-password",
+                &second_body,
+                &first_guest,
+                &first_body,
+            ),
+            statuses => panic!(
+                "expected one success and one username conflict, got {statuses:?}; \
+                 first={first_body}, second={second_body}"
+            ),
+        };
+    assert_eq!(winner_body["user"]["id"], json!(winner.id));
+    assert_eq!(loser_body["error"], json!("Username already exists"));
+
+    let converted = db
+        .get_user_by_id(winner.id)
+        .await?
+        .expect("winning guest remains present");
+    assert!(!converted.is_guest);
+    assert_eq!(converted.username, target_username);
+    assert!(converted.guest_token.is_none());
+    assert!(verify(winner_password, &converted.password_hash)?);
+
+    let unchanged = db
+        .get_user_by_id(loser.id)
+        .await?
+        .expect("losing guest remains present");
+    assert!(unchanged.is_guest);
+    assert_eq!(unchanged.username, loser.username);
+    assert_eq!(unchanged.password_hash, loser.password_hash);
+    assert_eq!(unchanged.guest_token, loser.guest_token);
+
+    assert_eq!(
+        db.get_user_by_username(target_username)
+            .await?
+            .expect("target username has one owner")
+            .id,
+        winner.id
+    );
+    assert!(db.get_user_by_username(&loser.username).await?.is_none());
+
+    let (login_status, login_body) =
+        login_response(state.clone(), target_username, winner_password).await?;
+    assert_eq!(login_status, StatusCode::OK, "{login_body}");
+    assert_eq!(login_body["user"]["id"], json!(winner.id));
+    let losing_password = if loser.id == first_guest.id {
+        "first-password"
+    } else {
+        "second-password"
+    };
+    let (loser_login_status, loser_login_body) =
+        login_response(state, target_username, losing_password).await?;
+    assert_eq!(
+        loser_login_status,
+        StatusCode::UNAUTHORIZED,
+        "{loser_login_body}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_progress_writes_survive_in_place_upgrade() -> Result<()> {
+    const STEPS: i32 = 4;
+
+    let _guard = TEST_LOCK.lock().await;
+    let (state, db, _jwt_manager) = isolated_state().await?;
+    let password = "progress-password";
+    let password_hash = hash(password, DEFAULT_COST)?;
+    let guest = db
+        .create_guest_user("ProgressGuest", "progress-guest-token", 1_000, false)
+        .await?;
+    let guest_id = guest.id;
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+    let upgrade_db = db.clone();
+    let upgrade_barrier = barrier.clone();
+    let upgrade_username = guest.username.clone();
+    let upgrade_task = tokio::spawn(async move {
+        upgrade_barrier.wait().await;
+        upgrade_db
+            .upgrade_guest_to_account(guest_id, &upgrade_username, &password_hash)
+            .await
+    });
+
+    let progress_db = db.clone();
+    let progress_barrier = barrier.clone();
+    let progress_task = tokio::spawn(async move {
+        progress_barrier.wait().await;
+        for _ in 0..STEPS {
+            progress_db.add_user_xp(guest_id, 1).await?;
+            progress_db
+                .update_user_mmr_by_mode(guest_id, 3, &QueueMode::Competitive)
+                .await?;
+            progress_db
+                .update_user_mmr_by_mode(guest_id, -2, &QueueMode::Quickmatch)
+                .await?;
+            tokio::task::yield_now().await;
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+
+    barrier.wait().await;
+    let (upgrade_result, progress_result) = tokio::join!(upgrade_task, progress_task);
+    let upgraded = upgrade_result??;
+    progress_result??;
+    assert_eq!(upgraded.id, guest.id);
+
+    let persisted = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("converted user remains present after concurrent progress writes");
+    assert!(!persisted.is_guest);
+    assert_eq!(persisted.id, guest.id);
+    assert_eq!(persisted.username, guest.username);
+    assert_eq!(persisted.xp, STEPS);
+    assert_eq!(persisted.ranked_mmr, 1_000 + (STEPS * 3));
+    assert_eq!(persisted.casual_mmr, 1_000 - (STEPS * 2));
+    assert!(persisted.guest_token.is_none());
+    assert!(verify(password, &persisted.password_hash)?);
+    assert_eq!(
+        db.get_user_by_username(&guest.username)
+            .await?
+            .expect("converted username resolves after concurrent progress writes")
+            .id,
+        guest.id
+    );
+
+    let (login_status, login_body) = login_response(state, &guest.username, password).await?;
+    assert_eq!(login_status, StatusCode::OK, "{login_body}");
+    assert_eq!(login_body["user"]["id"], json!(guest.id));
+
+    Ok(())
+}

--- a/server/tests/common/mock_jwt.rs
+++ b/server/tests/common/mock_jwt.rs
@@ -42,12 +42,33 @@ impl MockJwtVerifier {
         user_id: i32,
         matchmaking_pool: MatchmakingPool,
     ) -> Self {
+        self = self.with_token_kind(token, user_id, false, matchmaking_pool);
+        self
+    }
+
+    pub fn with_guest_token_in_pool(
+        mut self,
+        token: &str,
+        user_id: i32,
+        matchmaking_pool: MatchmakingPool,
+    ) -> Self {
+        self = self.with_token_kind(token, user_id, true, matchmaking_pool);
+        self
+    }
+
+    fn with_token_kind(
+        mut self,
+        token: &str,
+        user_id: i32,
+        is_guest: bool,
+        matchmaking_pool: MatchmakingPool,
+    ) -> Self {
         self.expected_tokens.insert(
             token.to_string(),
             UserToken {
                 user_id,
                 username: format!("user_{}", user_id),
-                is_guest: false,
+                is_guest,
                 matchmaking_pool,
             },
         );

--- a/server/tests/common/test_client.rs
+++ b/server/tests/common/test_client.rs
@@ -38,14 +38,22 @@ impl TestClient {
         // boundary. Merely writing a token is not authentication.
         self.send_message(WSMessage::Token(token.to_string()))
             .await?;
-        let response = self.receive_message().await?;
-        match response {
-            WSMessage::Authenticated { .. } => Ok(()),
-            other => Err(anyhow::anyhow!(
-                "Expected Authenticated response, got {:?}",
-                other
-            )),
-        }
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                match self.receive_message().await? {
+                    WSMessage::Authenticated { .. } => return Ok(()),
+                    WSMessage::UserCountUpdate { .. } => {}
+                    other => {
+                        return Err(anyhow::anyhow!(
+                            "Expected Authenticated response, got {:?}",
+                            other
+                        ));
+                    }
+                }
+            }
+        })
+        .await
+        .map_err(|_| anyhow::anyhow!("Timeout waiting for Authenticated response"))?
     }
 
     /// Create and join an explicit matchmaking lobby.

--- a/server/tests/lobby_matchmaking_tests.rs
+++ b/server/tests/lobby_matchmaking_tests.rs
@@ -322,7 +322,7 @@ async fn websocket_lobby_joins_are_denied_across_both_pool_directions() -> Resul
     let verifier = self::common::MockJwtVerifier::new()
         .with_token("public-host", public_host_id)
         .with_token("public-joiner", public_joiner_id)
-        .with_token_in_pool("stress-host", stress_host_id, MatchmakingPool::Stress);
+        .with_guest_token_in_pool("stress-host", stress_host_id, MatchmakingPool::Stress);
     env.add_server_with_jwt_verifier(
         JwtManager::new("test_secret_key_for_testing"),
         Arc::new(verifier),


### PR DESCRIPTION
## Summary

- Redesign the Start Game, Join Game, Invite Friends, and authentication flows to match the main interface
- Add guest and signed-in account menus with modal Profile and History views
- Keep lobby joining on the current page and stabilize the leaderboard summary across modes and auth states
- Explicitly leave and clear lobby state when signing out
- Upgrade guest accounts in place so registration preserves the existing player ID, ratings, XP, rankings, scores, and game ownership
- Reject stale guest credentials and keep DynamoDB and Redis identity state consistent during upgrades

## Testing

- TypeScript type-check
- 53 client unit tests
- Production client build
- 3 focused account-modal browser tests
- WebSocket logout/lobby regression test
- Rust formatting check
- Rust test compilation
- 7 guest-account upgrade integration tests