### PR TITLE
Add guest sign-in prompt under the nickname input

### DIFF
--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -264,10 +264,8 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
                 type="button"
                 onClick={onSignInClick}
                 className="
-                  text-[13px] whitespace-nowrap
-                  text-blue-500 underline underline-offset-2 decoration-blue-500/30
-                  transition-colors cursor-pointer
-                  hover:text-blue-600 hover:decoration-blue-600
+                  text-[13px] whitespace-nowrap text-blue-600 cursor-pointer
+                  hover:underline focus-visible:underline
                 "
               >
                 Sign in or create account

--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -37,6 +37,7 @@ interface GameStartFormProps {
   isLobbyQueued?: boolean;
   lobbyPreferences: LobbyPreferences | null;
   onPreferencesChange?: (preferences: LobbyPreferences) => void;
+  onSignInClick?: () => void;
   errorMessage?: string | null;
 }
 
@@ -48,6 +49,7 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
   isLobbyQueued = false,
   lobbyPreferences,
   onPreferencesChange,
+  onSignInClick,
   errorMessage = null,
 }) => {
   const [nickname, setNickname] = useState(currentUsername || '');
@@ -233,7 +235,7 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
 
       <div className="p-8">
         {/* Nickname Input */}
-        <div className="mb-8 relative">
+        <div className="mb-7 relative">
           <input
             ref={nicknameInputRef}
             type="text"
@@ -250,9 +252,35 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
             required
             readOnly={isAuthenticated}
           />
-          {/* Error message with absolute positioning and fade animation */}
+
+          {/* Guest notice + sign-in link. Hidden entirely once the player has
+              a real account, since neither half applies to them. */}
+          {!isAuthenticated && (
+            <div className="mt-2 px-1 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
+              <span className="text-[13px] text-gray-500 whitespace-nowrap">
+                Playing as guest
+              </span>
+              <button
+                type="button"
+                onClick={onSignInClick}
+                className="
+                  text-[13px] whitespace-nowrap
+                  text-blue-500 underline underline-offset-2 decoration-blue-500/30
+                  transition-colors cursor-pointer
+                  hover:text-blue-600 hover:decoration-blue-600
+                "
+              >
+                Sign in or create account
+              </button>
+            </div>
+          )}
+
+          {/* Error message with absolute positioning and fade animation. It is
+              anchored to the bottom of the whole block so it clears the guest
+              row when that is present, and sits right under the input when it
+              is not. */}
           <div className={`
-            absolute left-0 right-0 top-[calc(100%+4px)]
+            absolute left-0 right-0 top-[calc(100%+4px)] px-1
             transition-opacity duration-200
             ${showNicknameError ? 'opacity-100' : 'opacity-0 pointer-events-none'}
           `}>

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -263,6 +263,7 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
               isLobbyQueued={isLobbyQueued}
               lobbyPreferences={lobbyPreferences}
               onPreferencesChange={updateLobbyPreferences}
+              onSignInClick={onOpenAuth}
               errorMessage={startError}
             />
             <SocialFooter />


### PR DESCRIPTION
## What changed

Adds a row directly beneath the nickname input on the home screen:

```
Playing as guest              Sign in or create account
```

The link opens the existing auth modal — the same `onOpenAuth` handler the header's "Sign in" button already uses, and the modal's own title is verbatim "Sign in or create account". The whole row is omitted when the player is signed in with a real account (`isAuthenticated`), since neither half applies to them.

## Why

Guests had no in-form path to an account. The only sign-in entry point was in the header, well away from the nickname field they were already interacting with — which is exactly the moment the "you could keep this name" prompt is relevant.

## Reviewer notes

**The error-message re-anchor is the non-obvious part.** The nickname validation error ("Nickname must be at least 3 characters") is absolutely positioned so it doesn't shift layout. It was anchored to the input and rendered into the gap where the new row now sits, which would have forced ~28px of dead space to avoid an overlap. It's now anchored to the bottom of the whole block instead, so it falls *below* the row and the row can hug the input at 8px. When the row is absent (signed in), the error lands right under the input exactly as it did before — no visual change for that case.

Measured spacing with the error visible: input → 8px → row → 4px → error → 7.5px → mode grid.

**Link styling follows the app's existing convention** (second commit). Every live component sets `text-decoration: none` at rest and reveals the underline on hover or focus-visible — `.home-nav-link`, `.home-account-action`, `.home-social-actions`, `nav a`, `.main-menu-button`, and `.game-over-actions .is-primary`. The closest analog is Leaderboard's inline text button, `text-blue-600 hover:underline`, which this now matches. `UsernameAuth.tsx` does underline at rest, but it is never imported, so it isn't a live precedent. The only persistent underlines in the shipped UI are the `MobileHeader`/`Sidebar` active-page markers, where the underline means state rather than affordance.

Color is `blue-600` rather than `blue-500` for the same reason plus contrast: at 13px, blue-500 is 3.68:1 on white, under the 4.5:1 WCAG AA threshold for normal text; blue-600 is 5.17:1. The gray label is 4.84:1.

**Other details:**
- `onSignInClick` is an optional prop, so the component stays usable without a handler.
- `type="button"` on the link — it's inside the form and would otherwise submit it.
- `focus-visible:underline` so keyboard users get the same affordance as hover.
- The row and error carry a 4px horizontal inset (`px-1`) so the microcopy sits just inside the input's border rather than flush with it. Deliberately not matched to the input's 16px text inset, which read as a real indent.
- Typography is plain 13px sentence case — no caps/italics/letter-spacing, which the surrounding form uses heavily but reads as too loud for microcopy.

## Verification

Checked in the browser against the dev server:
- Link opens the auth modal; the form is not submitted.
- Row disappears and spacing collapses cleanly when `isAuthenticated` (verified by temporarily forcing the prop, then reverting).
- Computed styles confirmed: `none` at rest, `underline` on both hover and focus.
- No wrapping or overflow at 375px; the error clears the mode grid at both widths.
- `npm run type-check` clean. No new console errors — only pre-existing `ERR_CONNECTION_REFUSED` from the game server not running locally.

Rust/server code is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)