### PR TITLE
Stop anonymous visitors from killing their own WebSocket

### DIFF
--- a/client/web/components/ConnectionStatusRack.tsx
+++ b/client/web/components/ConnectionStatusRack.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { useConnectionBanner } from '../hooks/useConnectionBanner';
+
+interface ConnectionStatusRackProps {
+  /** From `isConnectionReady` — whether the client can act right now. */
+  isReady: boolean;
+  regionsLoading: boolean;
+  regionsError: string | null;
+  hasSelectedRegion: boolean;
+}
+
+/**
+ * The status badges above the home and leaderboard content.
+ *
+ * The rack itself is always mounted; only the badges inside it come and go. A
+ * live region has to be a stable node to announce reliably, and the rack is
+ * absolutely positioned with `pointer-events: none`, so an empty one costs
+ * nothing and shifts nothing.
+ */
+export const ConnectionStatusRack: React.FC<ConnectionStatusRackProps> = ({
+  isReady,
+  regionsLoading,
+  regionsError,
+  hasSelectedRegion,
+}) => {
+  const showConnecting = useConnectionBanner(isReady);
+  const showRegionError = Boolean(regionsError);
+  const showRegionReminder = !regionsLoading && !showRegionError && !hasSelectedRegion;
+
+  return (
+    <div className="home-status-rack" aria-live="polite" aria-label="Connection status">
+      {regionsLoading && (
+        <div className="home-status-badge">
+          <span className="home-status-spinner" aria-hidden="true" />
+          <span>Loading region data…</span>
+        </div>
+      )}
+      {showRegionError && !regionsLoading && (
+        <div className="home-status-badge is-warning">
+          <span className="home-status-spinner" aria-hidden="true" />
+          <span>Retrying region data…</span>
+        </div>
+      )}
+      {showRegionReminder && (
+        <div className="home-status-badge is-warning">
+          <span>Select a region to continue</span>
+        </div>
+      )}
+      {showConnecting && (
+        <div className="home-status-badge is-warning">
+          <span className="home-status-dot" aria-hidden="true" />
+          <span>Connecting to game server…</span>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/client/web/components/Leaderboard.tsx
+++ b/client/web/components/Leaderboard.tsx
@@ -7,9 +7,11 @@ import { LobbyChat } from './LobbyChat';
 import { RegionSelector } from './RegionSelector';
 import { InviteFriendsModal } from './InviteFriendsModal';
 import JoinGameModal from './JoinGameModal';
+import { ConnectionStatusRack } from './ConnectionStatusRack';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
 import { useRegions } from '../hooks/useRegions';
+import { isConnectionReady } from '../utils/connectionBanner';
 import { LobbyGameMode, RankTier, RankDivision, Rank, LeaderboardEntry, UserRankingResponse, isRankingEntry, isHighScoreEntry, GameType } from '../types';
 import { api } from '../services/api';
 import { useGameWebSocket } from '../hooks/useGameWebSocket';
@@ -588,6 +590,7 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
   const {
     connectToRegion,
     isConnected,
+    isSessionAuthenticated,
     onMessage,
     currentRegionUrl,
     currentLobby,
@@ -773,12 +776,11 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
     }
   };
 
-  const shouldShowRegionReminder = !regionsLoading && !regionsError && currentRegionId === '';
-  const shouldShowRegionError = Boolean(regionsError);
-  const shouldShowConnectionBanner = !isConnected;
-  const shouldShowRegionLoading = regionsLoading;
-  const shouldShowStatusBanner =
-    shouldShowRegionLoading || shouldShowRegionError || shouldShowRegionReminder || shouldShowConnectionBanner;
+  const isReady = isConnectionReady({
+    isConnected,
+    isSessionAuthenticated,
+    hasIdentity: user !== null,
+  });
 
   return (
     <>
@@ -797,33 +799,12 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
           onLogout={logout}
         />
 
-        {shouldShowStatusBanner && (
-          <div className="home-status-rack" aria-live="polite" aria-label="Connection status">
-            {shouldShowRegionLoading && (
-              <div className="home-status-badge">
-                <span className="home-status-spinner" aria-hidden="true" />
-                <span>Loading region data…</span>
-              </div>
-            )}
-            {shouldShowRegionError && !shouldShowRegionLoading && (
-              <div className="home-status-badge is-warning">
-                <span className="home-status-spinner" aria-hidden="true" />
-                <span>Retrying region data…</span>
-              </div>
-            )}
-            {shouldShowRegionReminder && (
-              <div className="home-status-badge is-warning">
-                <span>Select a region to continue</span>
-              </div>
-            )}
-            {shouldShowConnectionBanner && (
-              <div className="home-status-badge is-warning">
-                <span className="home-status-dot" aria-hidden="true" />
-                <span>Connecting to game server…</span>
-              </div>
-            )}
-          </div>
-        )}
+        <ConnectionStatusRack
+          isReady={isReady}
+          regionsLoading={regionsLoading}
+          regionsError={regionsError}
+          hasSelectedRegion={currentRegionId !== ''}
+        />
 
         <main className="leaderboard-main">
           <LeaderboardContent

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -8,10 +8,12 @@ import { LobbyChat } from './LobbyChat';
 import { RegionSelector } from './RegionSelector';
 import { InviteFriendsModal } from './InviteFriendsModal';
 import JoinGameModal from './JoinGameModal';
+import { ConnectionStatusRack } from './ConnectionStatusRack';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
 import { useRegions } from '../hooks/useRegions';
 import { useGameWebSocket } from '../hooks/useGameWebSocket';
+import { isConnectionReady } from '../utils/connectionBanner';
 import { LobbyGameMode } from '../types';
 
 const generateGuestNickname = () => `Guest${Math.floor(1000 + Math.random() * 9000)}`;
@@ -27,6 +29,7 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
   const {
     connectToRegion,
     isConnected,
+    isSessionAuthenticated,
     waitForSessionReady,
     onMessage,
     currentRegionUrl,
@@ -207,12 +210,11 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
     }
   };
 
-  const shouldShowRegionReminder = !regionsLoading && !regionsError && currentRegionId === '';
-  const shouldShowRegionError = Boolean(regionsError);
-  const shouldShowConnectionBanner = !isConnected;
-  const shouldShowRegionLoading = regionsLoading;
-  const shouldShowStatusBanner =
-    shouldShowRegionLoading || shouldShowRegionError || shouldShowRegionReminder || shouldShowConnectionBanner;
+  const isReady = isConnectionReady({
+    isConnected,
+    isSessionAuthenticated,
+    hasIdentity: user !== null,
+  });
 
   return (
     <>
@@ -231,33 +233,12 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
           onLogout={logout}
         />
 
-        {shouldShowStatusBanner && (
-          <div className="home-status-rack" aria-live="polite" aria-label="Connection status">
-            {shouldShowRegionLoading && (
-              <div className="home-status-badge">
-                <span className="home-status-spinner" aria-hidden="true" />
-                <span>Loading region data…</span>
-              </div>
-            )}
-            {shouldShowRegionError && !shouldShowRegionLoading && (
-              <div className="home-status-badge is-warning">
-                <span className="home-status-spinner" aria-hidden="true" />
-                <span>Retrying region data…</span>
-              </div>
-            )}
-            {shouldShowRegionReminder && (
-              <div className="home-status-badge is-warning">
-                <span>Select a region to continue</span>
-              </div>
-            )}
-            {shouldShowConnectionBanner && (
-              <div className="home-status-badge is-warning">
-                <span className="home-status-dot" aria-hidden="true" />
-                <span>Connecting to game server…</span>
-              </div>
-            )}
-          </div>
-        )}
+        <ConnectionStatusRack
+          isReady={isReady}
+          regionsLoading={regionsLoading}
+          regionsError={regionsError}
+          hasSelectedRegion={currentRegionId !== ''}
+        />
 
         <main className="home-main">
           <div className="home-center-stack">

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -39,6 +39,7 @@ import {
 } from '../utils/lobbyPreferencesStorage';
 import {
   advanceCandidateGameWatermark,
+  authenticationTimeoutMs,
   candidateDeadlineDelayMs,
   activeGameIdFromPath,
   isCommandOwner,
@@ -111,7 +112,6 @@ const MAX_CHAT_HISTORY = 200;
 const VALID_LOBBY_MODES: LobbyGameMode[] = ['duel', '2v2', 'solo', 'ffa'];
 const VALID_LOBBY_STATES: LobbyState[] = ['waiting', 'queued', 'matched'];
 const MAX_RECOVERY_METRIC_MS = 5 * 60 * 1000;
-const AUTHENTICATION_TIMEOUT_MS = 5_000;
 // RFC close codes in the 1001-2999 range are reserved for the protocol and
 // servers; browsers reject them when passed to WebSocket.close(). Preserve
 // their semantic suffixes in the application-private 4000 range whenever the
@@ -1227,6 +1227,31 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     shutdownForClientUpdate,
   ]);
 
+  // Arm the handshake watchdog for a socket that has just sent `Authenticate`.
+  // Every `Authenticate` send site must call this, and nothing else may: the
+  // deadline belongs to an in-flight handshake, not to the transport. Arming it
+  // where no frame was sent makes an anonymous visitor's healthy socket close
+  // itself every AUTHENTICATION_TIMEOUT_MS and reconnect forever.
+  const armAuthenticationTimeout = useCallback((slot: SocketSlot, token: string | null) => {
+    clearAuthenticationTimeout(slot);
+    const timeoutMs = authenticationTimeoutMs(token);
+    if (timeoutMs === null) {
+      return;
+    }
+    slot.authTimeoutId = setTimeout(() => {
+      if (
+        slot.authenticated ||
+        slot.role === 'retired' ||
+        (slot.role === 'active' && activeSlotRef.current !== slot) ||
+        (slot.role === 'candidate' && candidateSlotRef.current !== slot)
+      ) {
+        return;
+      }
+      slot.authTimeoutId = null;
+      slot.socket.close(CLIENT_RETRY_CLOSE_CODE, 'authentication timed out');
+    }, timeoutMs);
+  }, []);
+
   const attachSocketHandlers = useCallback((slot: SocketSlot, onConnect?: () => void) => {
     slot.socket.onopen = () => {
       if (
@@ -1239,23 +1264,12 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       }
       const token = getToken();
       clearAuthenticationTimeout(slot);
-      slot.authTimeoutId = setTimeout(() => {
-        if (
-          slot.authenticated ||
-          slot.role === 'retired' ||
-          (slot.role === 'active' && activeSlotRef.current !== slot) ||
-          (slot.role === 'candidate' && candidateSlotRef.current !== slot)
-        ) {
-          return;
-        }
-        slot.authTimeoutId = null;
-        slot.socket.close(CLIENT_RETRY_CLOSE_CODE, 'authentication timed out');
-      }, AUTHENTICATION_TIMEOUT_MS);
       if (token) {
         slot.authStartedAtMs = Date.now();
         slot.authTokenSent = token;
         slot.socket.send(JSON.stringify(buildGameplayAuthentication(token)));
         lastAuthTokenRef.current = token;
+        armAuthenticationTimeout(slot, token);
       }
 
       if (slot.role === 'active') {
@@ -1355,7 +1369,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         openActiveRef.current(slot.url, onConnect);
       }, delay);
     };
-  }, [configureClockSync, getToken, handleParsedMessage, promoteCandidate, recordPlannedHandoffFailure, recoverAfterCandidateFailure, setAuthHandshakeState]);
+  }, [armAuthenticationTimeout, configureClockSync, getToken, handleParsedMessage, promoteCandidate, recordPlannedHandoffFailure, recoverAfterCandidateFailure, setAuthHandshakeState]);
 
   const createSlot = useCallback((url: string, role: SocketRole): SocketSlot => {
     const socket = new WebSocket(url);
@@ -1667,9 +1681,14 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         return false;
       }
       lastAuthTokenRef.current = token;
+      // This is the handshake a visitor reaches by pressing Play: the socket
+      // was opened anonymously and only now has an identity to present. It is
+      // an in-flight `Authenticate` like any other, so it gets the same
+      // recovery deadline instead of hanging until a caller's own timeout.
+      armAuthenticationTimeout(slot, token);
     }
     return slot.authenticated;
-  }, [getToken, setAuthHandshakeState]);
+  }, [armAuthenticationTimeout, getToken, setAuthHandshakeState]);
 
   const waitForSessionReady = useCallback(async (timeoutMs = 10_000): Promise<void> => {
     const deadline = Date.now() + timeoutMs;

--- a/client/web/hooks/useConnectionBanner.ts
+++ b/client/web/hooks/useConnectionBanner.ts
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  CONNECTION_BANNER_SHOW_DELAY_MS,
+  connectionBannerHideDelayMs,
+} from '../utils/connectionBanner';
+
+/**
+ * Asymmetric hysteresis for the connection badge: appear only after the client
+ * has been unusable for a beat, then stay up long enough to be read.
+ *
+ * Deliberately not `useDebouncedValue`, which is a symmetric trailing-edge
+ * debounce — it would delay the badge in both directions and so keep it on
+ * screen for a fixed time after every recovery, however brief the outage.
+ */
+export function useConnectionBanner(isReady: boolean): boolean {
+  const [visible, setVisible] = useState<boolean>(false);
+  const shownAtRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!isReady && !visible) {
+      const timer = setTimeout(() => {
+        shownAtRef.current = Date.now();
+        setVisible(true);
+      }, CONNECTION_BANNER_SHOW_DELAY_MS);
+      return () => clearTimeout(timer);
+    }
+
+    if (isReady && visible) {
+      const timer = setTimeout(() => {
+        shownAtRef.current = null;
+        setVisible(false);
+      }, connectionBannerHideDelayMs(shownAtRef.current, Date.now()));
+      return () => clearTimeout(timer);
+    }
+
+    return undefined;
+  }, [isReady, visible]);
+
+  return visible;
+}

--- a/client/web/index.css
+++ b/client/web/index.css
@@ -2876,6 +2876,7 @@ a.home-social-icon:hover {
   font-weight: 700;
   letter-spacing: 0.45px;
   text-transform: uppercase;
+  animation: home-status-badge-in 180ms ease-out both;
 }
 
 .home-status-badge.is-error {
@@ -3229,6 +3230,19 @@ a.home-social-icon:hover {
   }
 }
 
+/* Enter only: React unmounts the badge on recovery, and after the hysteresis
+   floor an instant disappearance reads as the connection snapping back. */
+@keyframes home-status-badge-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
 /* Players-online tag --------------------------------------------------------
    A tag notched into a break in the nickname field's top border, the way a
    legend sits in a fieldset, binding the live population to the form as one
@@ -3563,6 +3577,7 @@ a.home-social-icon:hover {
 
   .home-social-trigger svg,
   .home-account-trigger svg,
+  .home-status-badge,
   .home-status-dot,
   .home-status-spinner,
   .players-online-readout,

--- a/client/web/services/websocketLifecycle.ts
+++ b/client/web/services/websocketLifecycle.ts
@@ -1,5 +1,6 @@
 export const RECONNECT_BASE_MS = 100;
 export const RECONNECT_MAX_MS = 2000;
+export const AUTHENTICATION_TIMEOUT_MS = 5_000;
 export const MATCHMAKING_ADMISSION_RETRY_DELAYS_MS = [250, 500, 1000] as const;
 export const PLANNED_HANDOFF_MAX_MS = 20_000;
 export const PLANNED_HANDOFF_MIN_MS = 2_000;
@@ -64,6 +65,22 @@ export function reconnectDelayMs(attempt: number, random: () => number = Math.ra
   const exponential = Math.min(RECONNECT_MAX_MS, RECONNECT_BASE_MS * (2 ** (attempt - 1)));
   const jitter = 0.5 + Math.max(0, Math.min(1, random()));
   return Math.min(RECONNECT_MAX_MS, Math.round(exponential * jitter));
+}
+
+/**
+ * How long to wait for `Authenticated` after sending `Authenticate`, or `null`
+ * when no handshake is in flight.
+ *
+ * The watchdog exists to recover a socket that *asked* to authenticate and got
+ * no answer. A socket that never sent `Authenticate` — an anonymous visitor
+ * with no token — has nothing to wait for: the server keeps unauthenticated
+ * sockets open by design (it answers `Ping` with `Pong` before authentication
+ * and applies no auth deadline), and still pushes `UserCountUpdate` over them.
+ * Arming a watchdog there makes the client kill its own healthy socket every
+ * five seconds and reconnect forever.
+ */
+export function authenticationTimeoutMs(token: string | null): number | null {
+  return typeof token === 'string' && token.length > 0 ? AUTHENTICATION_TIMEOUT_MS : null;
 }
 
 /** Decide recovery without ever leaving a connectionless client idle. */

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -13,6 +13,15 @@ const REQUIRED_CAPABILITIES = [
 const RETRYABLE_MATCHMAKING_ADMISSION_REASON =
   'Failed to queue lobby: Failed to add lobby to matchmaking queue';
 
+// Comfortably past the 5s authentication watchdog plus a saturated 2s back-off,
+// so a socket that survives this window is not merely between churn cycles.
+const ANONYMOUS_SOCKET_OBSERVATION_MS = 8_000;
+
+// Mirrors utils/connectionBanner.ts, which this CommonJS spec cannot import.
+// The values themselves are pinned by tests/unit/connectionBanner.test.ts.
+const CONNECTION_BANNER_SHOW_DELAY_MS = 800;
+const CONNECTION_BANNER_MIN_VISIBLE_MS = 1_200;
+
 const gameState = (tick = 5) => ({
   tick,
   status: { Started: { server_id: 1 } },
@@ -737,6 +746,149 @@ test('logout explicitly leaves the lobby before retiring the authenticated socke
       typeof message === 'object' &&
       ('Authenticate' in message || 'JoinLobby' in message)
     )).length, socketCountBeforeLogout)).toBe(0);
+
+  // The post-logout socket carries no token, so it is the same shape as an
+  // anonymous visitor's. It must simply stay open rather than being torn down
+  // by a handshake deadline for a handshake it never started.
+  const socketCountAfterLogout = await page.evaluate(() => window.__mockSockets.length);
+  await page.waitForTimeout(ANONYMOUS_SOCKET_OBSERVATION_MS);
+  expect(await page.evaluate((index) => ({
+    socketsOpenedSince: window.__mockSockets.length - index,
+    lastSocketCloseCalls: window.__mockSockets[index - 1].closeCalls,
+    lastSocketReadyState: window.__mockSockets[index - 1].readyState,
+  }), socketCountAfterLogout)).toEqual({
+    socketsOpenedSince: 0,
+    lastSocketCloseCalls: [],
+    lastSocketReadyState: 1,
+  });
+});
+
+// Regression: the client armed its 5s authentication watchdog on every socket
+// but sent `Authenticate` only when a token existed, so a visitor with no
+// account waited for a reply to a message it never sent, closed its own healthy
+// socket with 4013, reconnected, and flashed the connecting banner forever.
+test('an anonymous visitor keeps one socket open and never shows the connecting banner', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('snaketron:lastLobby');
+  });
+
+  await page.goto('/');
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(true);
+  // Startup opens more than one socket while region detection settles. That
+  // race is separate and pre-existing; what matters here is that it settles.
+  const settledSocketCount = await page.evaluate(() => window.__mockSockets.length);
+
+  // Long enough to have covered the old 5s watchdog plus a full back-off cycle.
+  await page.waitForTimeout(ANONYMOUS_SOCKET_OBSERVATION_MS);
+
+  expect(await page.evaluate((baseline) => {
+    const live = window.__mockSockets[baseline - 1];
+    return {
+      socketsOpenedSince: window.__mockSockets.length - baseline,
+      closeCalls: live.closeCalls,
+      readyState: live.readyState,
+      authenticateFrames: live.sent
+        .map((raw) => JSON.parse(raw))
+        .filter((message) => message && typeof message === 'object' && 'Authenticate' in message)
+        .length,
+      connected: window.__wsContext?.isConnected,
+    };
+  }, settledSocketCount)).toEqual({
+    socketsOpenedSince: 0,
+    closeCalls: [],
+    readyState: 1,
+    authenticateFrames: 0,
+    connected: true,
+  });
+  await expect(page.getByText('Connecting to game server…')).toHaveCount(0);
+});
+
+// The badge explains a problem the player can act on. A gap short enough to be
+// invisible is not one, and painting it is the flicker itself.
+test('a brief transport gap stays silent while a sustained one is announced', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('snaketron:lastLobby');
+  });
+
+  await page.goto('/');
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(true);
+  const banner = page.getByText('Connecting to game server…');
+  await expect(banner).toHaveCount(0);
+
+  // Watch continuously: a badge that appears and vanishes between polls is
+  // exactly the flicker being fixed, so sampling from the test is not enough.
+  await page.evaluate(() => {
+    window.__bannerEverShown = false;
+    new MutationObserver(() => {
+      if (document.body.innerText.toUpperCase().includes('CONNECTING TO GAME SERVER')) {
+        window.__bannerEverShown = true;
+      }
+    }).observe(document.body, { childList: true, subtree: true, characterData: true });
+  });
+
+  // A real gap, held open below the show delay, then closed.
+  await page.evaluate(() => {
+    window.__autoOpenSockets = false;
+    window.__mockSockets[window.__mockSockets.length - 1].serverClose(1012, 'brief blip');
+  });
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(false);
+  await page.waitForTimeout(CONNECTION_BANNER_SHOW_DELAY_MS / 2);
+  await page.evaluate(() => {
+    window.__autoOpenSockets = true;
+    window.__mockSockets[window.__mockSockets.length - 1].serverOpen();
+  });
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(true);
+
+  await page.waitForTimeout(CONNECTION_BANNER_SHOW_DELAY_MS + 400);
+  expect(await page.evaluate(() => window.__bannerEverShown)).toBe(false);
+  await expect(banner).toHaveCount(0);
+
+  // A gap that does not close: the replacement socket is left connecting.
+  await page.evaluate(() => {
+    window.__autoOpenSockets = false;
+    window.__mockSockets[window.__mockSockets.length - 1].serverClose(1012, 'sustained outage');
+  });
+  await expect(banner).toHaveCount(1, { timeout: 5_000 });
+
+  // Recovery takes the badge down, but only after it has been readable.
+  const shownAtMs = Date.now();
+  await page.evaluate(() => {
+    window.__autoOpenSockets = true;
+    window.__mockSockets[window.__mockSockets.length - 1].serverOpen();
+  });
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(true);
+  await expect(banner).toHaveCount(0, { timeout: 5_000 });
+  expect(Date.now() - shownAtMs).toBeGreaterThanOrEqual(CONNECTION_BANNER_MIN_VISIBLE_MS);
+});
+
+// The watchdog still has to cover the handshake a visitor reaches by pressing
+// Play: an anonymous socket that only now has an identity to present.
+test('an identity acquired on an open anonymous socket still gets a handshake deadline', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.removeItem('token');
+    localStorage.removeItem('snaketron:lastLobby');
+  });
+
+  await page.goto('/');
+  await expect.poll(() => page.evaluate(() => window.__wsContext?.isConnected)).toBe(true);
+  const liveSocketIndex = await page.evaluate(() => window.__mockSockets.length - 1);
+  expect(await socketMessages(page, liveSocketIndex, 'Authenticate')).toHaveLength(0);
+
+  // A guest session appears while the socket is already open.
+  await page.evaluate(() => {
+    localStorage.setItem('token', 'late-guest-token');
+    window.__wsContext?.waitForSessionReady().catch(() => {});
+  });
+  await expect.poll(() => socketMessages(page, liveSocketIndex, 'Authenticate')).toHaveLength(1);
+
+  // The server never answers, so the socket must be retired for retry rather
+  // than left hanging on a handshake that will never complete.
+  await expect.poll(
+    () => page.evaluate((index) => window.__mockSockets[index].closeCalls, liveSocketIndex),
+    { timeout: 10_000 },
+  ).toEqual([{ code: 4013, reason: 'authentication timed out' }]);
 });
 
 test('the pre-match guide reveals one animated real-arena step at a time', async ({ page }) => {

--- a/client/web/tests/unit/connectionBanner.test.ts
+++ b/client/web/tests/unit/connectionBanner.test.ts
@@ -1,0 +1,66 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  CONNECTION_BANNER_MIN_VISIBLE_MS,
+  connectionBannerHideDelayMs,
+  isConnectionReady,
+} from '../../utils/connectionBanner.ts';
+
+test('an anonymous visitor is ready as soon as the transport is open', () => {
+  // Nothing to authenticate: the socket carries player counts, so an open
+  // transport is the whole of readiness. Requiring a session here would pin
+  // the banner on screen forever for every visitor who has not pressed Play.
+  assert.equal(
+    isConnectionReady({ isConnected: true, isSessionAuthenticated: false, hasIdentity: false }),
+    true,
+  );
+  assert.equal(
+    isConnectionReady({ isConnected: false, isSessionAuthenticated: false, hasIdentity: false }),
+    false,
+  );
+});
+
+test('a player with an identity is ready only once the session is authenticated', () => {
+  // An open but unauthenticated socket cannot carry lobby or matchmaking
+  // commands, so reporting it as connected would be a lie.
+  assert.equal(
+    isConnectionReady({ isConnected: true, isSessionAuthenticated: false, hasIdentity: true }),
+    false,
+  );
+  assert.equal(
+    isConnectionReady({ isConnected: true, isSessionAuthenticated: true, hasIdentity: true }),
+    true,
+  );
+  assert.equal(
+    isConnectionReady({ isConnected: false, isSessionAuthenticated: true, hasIdentity: true }),
+    false,
+  );
+});
+
+test('a hidden badge has nothing to hold', () => {
+  assert.equal(connectionBannerHideDelayMs(null, 1_000), 0);
+});
+
+test('a badge that just appeared is held for its full minimum', () => {
+  assert.equal(
+    connectionBannerHideDelayMs(1_000, 1_000),
+    CONNECTION_BANNER_MIN_VISIBLE_MS,
+  );
+  assert.equal(
+    connectionBannerHideDelayMs(1_000, 1_000 + CONNECTION_BANNER_MIN_VISIBLE_MS / 2),
+    CONNECTION_BANNER_MIN_VISIBLE_MS / 2,
+  );
+});
+
+test('a badge past its minimum comes down immediately', () => {
+  assert.equal(connectionBannerHideDelayMs(1_000, 1_000 + CONNECTION_BANNER_MIN_VISIBLE_MS), 0);
+  assert.equal(connectionBannerHideDelayMs(1_000, 60_000), 0);
+});
+
+test('a clock jump can neither pin the badge nor take it down early', () => {
+  // Clamped to the floor rather than trusting a negative elapsed time.
+  assert.equal(connectionBannerHideDelayMs(60_000, 1_000), CONNECTION_BANNER_MIN_VISIBLE_MS);
+  assert.equal(connectionBannerHideDelayMs(Number.NaN, 1_000), 0);
+  assert.equal(connectionBannerHideDelayMs(1_000, Number.POSITIVE_INFINITY), 0);
+});

--- a/client/web/tests/unit/websocketLifecycle.test.ts
+++ b/client/web/tests/unit/websocketLifecycle.test.ts
@@ -2,11 +2,13 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 
 import {
+  AUTHENTICATION_TIMEOUT_MS,
   MATCHMAKING_ADMISSION_RETRY_DELAYS_MS,
   PLANNED_HANDOFF_MAX_MS,
   RECONNECT_MAX_MS,
   advanceCandidateGameWatermark,
   activeGameIdFromPath,
+  authenticationTimeoutMs,
   candidateDeadlineDelayMs,
   candidateCoversActiveWatermark,
   isFreshSnapshotForGame,
@@ -362,4 +364,13 @@ test('an authoritative completed snapshot can replace a higher live watermark', 
     expectsGame: true,
     gameStreamWatermark: 0,
   }, 900), true);
+});
+
+// A socket that never sent `Authenticate` has no reply to wait for. Arming the
+// watchdog there made every anonymous visitor close its own healthy socket
+// after five seconds and reconnect forever, flashing the connecting banner.
+test('the authentication watchdog is armed only when Authenticate is sent', () => {
+  assert.equal(authenticationTimeoutMs(null), null);
+  assert.equal(authenticationTimeoutMs(''), null);
+  assert.equal(authenticationTimeoutMs('a.jwt.token'), AUTHENTICATION_TIMEOUT_MS);
 });

--- a/client/web/utils/connectionBanner.ts
+++ b/client/web/utils/connectionBanner.ts
@@ -1,0 +1,61 @@
+/**
+ * Timing and predicate rules for the "Connecting to game server…" badge.
+ *
+ * Kept pure and DOM-free so the behaviour is unit-testable: the badge's whole
+ * job is to be honest about whether the player can act, and to be calm enough
+ * that a momentary transport gap never reads as a fault.
+ */
+
+/**
+ * How long the client must look unusable before the badge appears.
+ *
+ * A healthy socket opens well inside this window, so a normal page load and a
+ * normal reconnect both stay silent.
+ */
+export const CONNECTION_BANNER_SHOW_DELAY_MS = 800;
+
+/**
+ * How long the badge stays up once shown, even if the client recovers
+ * immediately. Without a floor, a recovery landing just after the badge
+ * appears produces exactly the blink the badge is meant to explain.
+ */
+export const CONNECTION_BANNER_MIN_VISIBLE_MS = 1200;
+
+export interface ConnectionReadinessInput {
+  /** The transport is open. */
+  isConnected: boolean;
+  /** The server has answered `Authenticate` for the current identity. */
+  isSessionAuthenticated: boolean;
+  /** There is a player identity to authenticate (a guest or a real account). */
+  hasIdentity: boolean;
+}
+
+/**
+ * Whether the client is ready for what the player can do right now.
+ *
+ * An anonymous visitor has nothing to authenticate — the socket exists to carry
+ * player counts — so an open transport is ready. Once there is an identity, an
+ * open-but-unauthenticated socket cannot carry lobby or matchmaking commands,
+ * so it is not ready and saying otherwise would be a lie.
+ */
+export function isConnectionReady(input: ConnectionReadinessInput): boolean {
+  return input.hasIdentity
+    ? input.isConnected && input.isSessionAuthenticated
+    : input.isConnected;
+}
+
+/**
+ * Remaining hold time before a visible badge may be taken down. Returns 0 when
+ * the badge is not showing or its minimum has already elapsed, and is clamped
+ * so a backwards clock jump cannot pin the badge for longer than the floor.
+ */
+export function connectionBannerHideDelayMs(shownAtMs: number | null, nowMs: number): number {
+  if (shownAtMs === null || !Number.isFinite(shownAtMs) || !Number.isFinite(nowMs)) {
+    return 0;
+  }
+  const elapsedMs = nowMs - shownAtMs;
+  return Math.max(
+    0,
+    Math.min(CONNECTION_BANNER_MIN_VISIBLE_MS, CONNECTION_BANNER_MIN_VISIBLE_MS - elapsedMs),
+  );
+}


### PR DESCRIPTION
## The bug

The home page flashes "Connecting to game server…" every few seconds for anyone who is not signed in. The Network tab shows a WebSocket connecting, disconnecting, and reconnecting on a loop.

It is a bug, not a lurker optimization.

`WebSocketContext` arms a 5-second authentication watchdog on **every** socket it opens, but sends the `Authenticate` frame only `if (token)`. A visitor with no account therefore waits for a reply to a message it never sent — the watchdog fires against a perfectly healthy connection, closes it with 4013, and the reconnect loop starts over.

Measured on production with `localStorage` cleared:

```
t=1.0s  OPEN     t=6.0s  CLOSED   (exactly 5.0s later)
t=8.0s  OPEN     t=14.0s CLOSED
```

A two-second disconnected window every ~7 seconds, forever.

Three things confirm it was never intentional:

- The server deliberately keeps unauthenticated sockets alive — it answers `Ping` with `Pong` before authentication and applies no auth deadline. Every close here is client-initiated.
- The anonymous socket is *useful*: `UserCountUpdate` frames arrive on it, which is what feeds the live "players online" count. Killing it every 5s lost that data between cycles.
- The watchdog arrived with the make-before-break drain machinery and was placed *above* the pre-existing `if (token)` guard. The anonymous case was simply not considered.

So the churn cost roughly 7× the connection setup rather than saving anything.

## The fix

The watchdog belongs to an in-flight handshake, not to the transport. Arm it exactly where an `Authenticate` frame goes out, and nowhere else.

That is **two** call sites, not one. `authenticateConnection` sends the frame for a socket that was opened anonymously and only now has an identity to present — the path a visitor reaches by pressing Play — and had no deadline of its own. Fixing only `onopen` would have quietly stripped recovery from guest creation. There is a test for exactly that mistake.

The change is a literal no-op on every path where a token exists: same delay, same guards.

## Hardening the badge, separately

The banner had zero hysteresis, so *any* sub-second gap painted it. Now it appears only after the client has been unusable for 800ms, then holds for 1200ms so a recovery landing mid-blink cannot strobe.

It also tells the truth about readiness. An anonymous visitor needs no session, so an open transport is ready — but a signed-in player whose socket is open and unauthenticated genuinely cannot send lobby or matchmaking commands, and the old `!isConnected` called that connected.

The 26-line rack was duplicated verbatim across `NewHome` and `Leaderboard`; it is now one `ConnectionStatusRack` whose `aria-live` region stays mounted, so it announces once per real outage instead of every ~7 seconds. Enter-only fade, registered with the existing `prefers-reduced-motion` block.

`isConnected` itself is untouched — it is asserted at ~20 e2e sites and feeds the stress canary's disruption budget.

## Verification

| Gate | Result |
|---|---|
| `npm run type-check` | clean |
| `npm run test:unit` | 162/162 |
| `npx playwright test --config playwright.drain.config.js` | 45/45 |

The drain suite runs in no CI workflow today, so it was run by hand.

Four new e2e tests plus unit coverage for `authenticationTimeoutMs` and the banner timing (the two CI-gated client checks are `type-check` and `test:unit`, so the pure decisions live in `websocketLifecycle.ts` / `connectionBanner.ts` where CI can reach them).

- *an anonymous visitor keeps one socket open and never shows the connecting banner* — **fails on the pre-fix tree**
- *logout … socket count does not grow* (strengthened existing test) — **fails on the pre-fix tree**
- *an identity acquired on an open anonymous socket still gets a handshake deadline* — guards new code; verified by deleting the second call site, which makes it fail
- *a brief transport gap stays silent while a sustained one is announced* — guards new code; verified by stubbing the hysteresis hook to `!isReady`, which makes it fail

## Deliberately out of scope

- **A reconnect-backoff reset.** Considered and rejected: backoff already caps at 2s, so it buys nothing and would touch recovery logic.
- **A pre-existing startup race** where the client opens two sockets and discards one. Present before and after this change, unrelated to the churn; the new test baselines the socket count rather than asserting 1. Tracked separately.
- **A stale/invalid token** still produces a genuinely *server*-closed loop. Different cause, not addressed here; the hysteresis only softens the symptom.

## Notes for the deploy

"Players online" will read slightly higher and much steadier — `connection_count` is the raw open-socket count, and today it dips every time the anonymous sockets vanish mid-cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
