### PR TITLE
Never block a player on a gameplay-protocol mismatch

### DIFF
--- a/client/web/App.tsx
+++ b/client/web/App.tsx
@@ -15,7 +15,7 @@ import { NewHome } from './components/NewHome';
 import { ArenaBackdrop, SHOW_BACKDROP_DURING_GAMEPLAY } from './components/ArenaBackdrop';
 import { Leaderboard } from './components/Leaderboard';
 import { MatchmakingBanner } from './components/MatchmakingBanner';
-import { WebSocketProvider, useWebSocket } from './contexts/WebSocketContext';
+import { WebSocketProvider } from './contexts/WebSocketContext';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { UIProvider } from './contexts/UIContext';
 import { LatencyProvider } from './contexts/LatencyContext';
@@ -23,7 +23,6 @@ import { LatencyProvider } from './contexts/LatencyContext';
 function AppContent() {
   const location = useLocation();
   const { user } = useAuth();
-  const { clientUpdateRequired } = useWebSocket();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [accountModalView, setAccountModalView] = useState<AccountModalView | null>(null);
   const isGameArenaActive = matchPath('/play/:gameId', location.pathname) !== null;
@@ -40,30 +39,6 @@ function AppContent() {
       setAccountModalView(null);
     }
   }, [user]);
-
-  if (clientUpdateRequired) {
-    return (
-      <main
-        className="relative z-50 flex min-h-screen items-center justify-center bg-white px-6 text-center"
-        role="alert"
-        data-testid="client-update-required"
-      >
-        <div className="max-w-md border-4 border-black p-8 shadow-[8px_8px_0_#000]">
-          <h1 className="text-3xl font-black uppercase">Client update required</h1>
-          <p className="mt-4 text-sm font-semibold">
-            Snaketron was updated. Reload to use the current gameplay protocol.
-          </p>
-          <button
-            type="button"
-            className="mt-6 border-2 border-black bg-black px-5 py-3 font-black uppercase text-white"
-            onClick={() => window.location.reload()}
-          >
-            Reload now
-          </button>
-        </div>
-      </main>
-    );
-  }
 
   return (
     <div className="min-h-screen flex flex-col">

--- a/client/web/constants.ts
+++ b/client/web/constants.ts
@@ -4,16 +4,13 @@ export const DEFAULT_TICK_INTERVAL_MS = 100;
 // comes from GameProperties.tick_duration_ms, never from this poll cadence.
 export const EXECUTOR_POLL_INTERVAL_MS = 10;
 export const DEFAULT_CUSTOM_GAME_TICK_MS = 100;
-// Hard-cutover gameplay protocol. The server accepts this exact version only;
-// stale tabs receive "client update required" and must reload.
-// Must equal WS_PROTOCOL_VERSION in server/src/lifecycle.rs, which explains
-// why the readiness gate and the inactivity protocol share version 7.
+// Gameplay protocol version, reported to the server for observability only.
+// It is advisory on both ends: the server admits every version, and a client
+// is never blocked or asked to reload over a mismatch. A shipped build cannot
+// update itself — an itch.io bundle has no reload-to-upgrade path — so every
+// gameplay protocol change must stay backwards compatible instead.
+// Tracks WS_PROTOCOL_VERSION in server/src/lifecycle.rs.
 export const GAMEPLAY_PROTOCOL_VERSION = 7;
-export const CLIENT_UPDATE_REQUIRED_REASON = 'Client update required';
-export const isClientUpdateRequiredReason = (reason: unknown): boolean => (
-  typeof reason === 'string' &&
-  reason.trim().toLowerCase() === CLIENT_UPDATE_REQUIRED_REASON.toLowerCase()
-);
 export const buildGameplayAuthentication = (token: string) => ({
   Authenticate: {
     token,

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -20,7 +20,6 @@ import { clockSync } from '../utils/clockSync';
 import { record as recordTrace } from '../utils/syncTrace';
 import {
   buildGameplayAuthentication,
-  isClientUpdateRequiredReason,
   GAMEPLAY_PROTOCOL_VERSION,
 } from '../constants';
 import { useLatency } from './LatencyContext';
@@ -116,7 +115,6 @@ const AUTHENTICATION_TIMEOUT_MS = 5_000;
 // servers; browsers reject them when passed to WebSocket.close(). Preserve
 // their semantic suffixes in the application-private 4000 range whenever the
 // client initiates the equivalent shutdown.
-const CLIENT_PROTOCOL_CLOSE_CODE = 4002;
 const CLIENT_POLICY_CLOSE_CODE = 4008;
 const CLIENT_FAILURE_CLOSE_CODE = 4011;
 const CLIENT_RESTART_CLOSE_CODE = 4012;
@@ -263,8 +261,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const [lobbyPreferences, setLobbyPreferences] = useState<LobbyPreferences | null>(storedPreferences);
   const [matchmakingStatus, setMatchmakingStatus] = useState<MatchmakingStatus>('idle');
   const [isSessionAuthenticated, setIsSessionAuthenticated] = useState(false);
-  const [clientUpdateRequired, setClientUpdateRequired] = useState(false);
-  const clientUpdateRequiredRef = useRef(false);
   const [serverCapabilities, setServerCapabilities] = useState<ReadonlySet<string>>(new Set());
   const currentLobbyRef = useRef<Lobby | null>(null);
   const desiredLobbyPreferencesRef = useRef<LobbyPreferences | null>(storedPreferences);
@@ -845,55 +841,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     }
   }, []);
 
-  const shutdownForClientUpdate = useCallback((offendingSlot: SocketSlot) => {
-    clientUpdateRequiredRef.current = true;
-    reconnectEnabledRef.current = false;
-    setClientUpdateRequired(true);
-    clockSync.stop();
-    if (reconnectTimeout.current) {
-      clearTimeout(reconnectTimeout.current);
-      reconnectTimeout.current = null;
-    }
-    if (candidateRetryTimeoutRef.current) {
-      clearTimeout(candidateRetryTimeoutRef.current);
-      candidateRetryTimeoutRef.current = null;
-    }
-    if (candidateDeadlineTimeoutRef.current) {
-      clearTimeout(candidateDeadlineTimeoutRef.current);
-      candidateDeadlineTimeoutRef.current = null;
-    }
-
-    const slots = new Set<SocketSlot>([
-      offendingSlot,
-      ...(activeSlotRef.current ? [activeSlotRef.current] : []),
-      ...(candidateSlotRef.current ? [candidateSlotRef.current] : []),
-    ]);
-    activeSlotRef.current = null;
-    candidateSlotRef.current = null;
-    ws.current = null;
-    if (typeof window !== 'undefined') {
-      window.__wsInstance = undefined;
-    }
-    for (const slot of slots) {
-      slot.role = 'retired';
-      inFlightRequestsByGenerationRef.current.delete(slot.generation);
-      clearAuthenticationTimeout(slot);
-      clearGameWarmRetryTimeout(slot);
-      try {
-        slot.socket.close(CLIENT_PROTOCOL_CLOSE_CODE, 'client update required');
-      } catch (error) {
-        console.warn('Failed to close incompatible WebSocket:', error);
-      }
-    }
-
-    setIsConnected(false);
-    setAuthHandshakeState(false);
-    setServerCapabilities(new Set());
-    lastAuthTokenRef.current = null;
-    syncRequestTimes.current.clear();
-    clearPendingMatchmakingIntent();
-  }, [clearPendingMatchmakingIntent, setAuthHandshakeState]);
-
   const handleParsedMessage = useCallback((slot: SocketSlot, rawMessage: any, rawText: string) => {
     if (slot.role === 'retired') {
       return;
@@ -916,10 +863,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     const accessDeniedReason = typeof rawMessage?.AccessDenied?.reason === 'string'
       ? rawMessage.AccessDenied.reason
       : null;
-    if (isClientUpdateRequiredReason(accessDeniedReason)) {
-      shutdownForClientUpdate(slot);
-      return;
-    }
     if (
       pendingMatchmakingIntent &&
       messageMatchesPendingIdentity &&
@@ -1019,24 +962,29 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     if (rawMessage?.Authenticated) {
       const nowMs = Date.now();
       const payload = rawMessage.Authenticated;
+      // A protocol or capability mismatch is reported, never enforced. Blocking
+      // here would strand a shipped build that cannot update itself — an
+      // itch.io bundle has no reload-to-upgrade path — so we always play on and
+      // keep the gameplay protocol backwards compatible instead.
       if (Number(payload?.protocol_version) !== GAMEPLAY_PROTOCOL_VERSION) {
-        console.error(
-          'Server gameplay protocol mismatch:',
+        console.warn(
+          'Server gameplay protocol differs:',
           payload?.protocol_version,
-          'expected:',
+          'client speaks:',
           GAMEPLAY_PROTOCOL_VERSION,
+          '- continuing anyway',
         );
-        shutdownForClientUpdate(slot);
-        return;
       }
       slot.capabilities = Array.isArray(payload?.capabilities)
         ? payload.capabilities.filter((value: unknown): value is string => typeof value === 'string')
         : [];
       const missingCapabilities = missingRequiredServerCapabilities(slot.capabilities);
       if (missingCapabilities.length > 0) {
-        console.error('Server is missing required WebSocket capabilities:', missingCapabilities);
-        shutdownForClientUpdate(slot);
-        return;
+        console.warn(
+          'Server does not advertise every expected WebSocket capability:',
+          missingCapabilities,
+          '- continuing anyway',
+        );
       }
       clearAuthenticationTimeout(slot);
       slot.authenticated = true;
@@ -1224,7 +1172,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     recoverAfterCandidateFailure,
     restoreCandidateContext,
     setAuthHandshakeState,
-    shutdownForClientUpdate,
   ]);
 
   const attachSocketHandlers = useCallback((slot: SocketSlot, onConnect?: () => void) => {
@@ -1470,9 +1417,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   startCandidateRef.current = startCandidate;
 
   const connect = useCallback((url: string, onConnect?: () => void) => {
-    if (clientUpdateRequiredRef.current) {
-      return;
-    }
     reconnectEnabledRef.current = true;
     if (onConnect) {
       onConnectCallback.current = onConnect;
@@ -1528,9 +1472,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     wsUrl: string,
     options?: { regionId?: string; origin?: string; forceReconnect?: boolean },
   ) => {
-    if (clientUpdateRequiredRef.current) {
-      return;
-    }
     console.log('Switching to region:', wsUrl);
     if (options?.regionId) {
       saveRegionPreference({
@@ -1871,7 +1812,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     user,
     isConnected,
     isSessionAuthenticated,
-    clientUpdateRequired,
     currentRegionUrl,
     connect,
     connectToRegion,
@@ -2833,7 +2773,6 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const value: WebSocketContextType = {
     isConnected,
     isSessionAuthenticated,
-    clientUpdateRequired,
     serverCapabilities,
     sendMessage,
     waitForSessionReady,

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -3770,33 +3770,57 @@ test('window blur releases default Hold Boost once', async ({ page }) => {
   ]);
 });
 
-test('hard-cutover denial closes every socket and permanently suppresses reconnect', async ({ page }) => {
+// A shipped build cannot update itself — an itch.io bundle has no
+// reload-to-upgrade path at all — so no protocol disagreement may ever strand
+// the player behind a screen they have no way to act on. Every one of these
+// mismatches has to degrade to a console warning and keep playing.
+test('a mismatched server protocol and missing capabilities still authenticate', async ({ page }) => {
+  await page.goto('/');
+  await expect.poll(() => page.evaluate(() => (
+    window.__wsInstance ? window.__mockSockets.indexOf(window.__wsInstance) : -1
+  ))).toBeGreaterThanOrEqual(0);
+  const socketIndex = await page.evaluate(() => window.__mockSockets.indexOf(window.__wsInstance));
+  await expect.poll(() => socketMessages(page, socketIndex, 'Authenticate')).toHaveLength(1);
+
+  await emitServerMessage(page, socketIndex, {
+    Authenticated: {
+      task_boot_id: 'mismatched-task',
+      protocol_version: 999,
+      capabilities: [],
+      socket_generation: 1,
+    },
+  });
+
+  // Reaching JoinLobby proves the handshake was accepted despite both mismatches.
+  await expect.poll(() => socketMessages(page, socketIndex, 'JoinLobby')).toHaveLength(2);
+  await expect(page.getByTestId('client-update-required')).toHaveCount(0);
+  expect(await page.evaluate((index) => window.__mockSockets[index].closeCalls, socketIndex))
+    .toEqual([]);
+});
+
+test('a legacy client-update denial no longer strands the player', async ({ page }) => {
   const socketIndex = await establishAuthenticatedLobby(page);
   const socketCount = await page.evaluate(() => window.__mockSockets.length);
 
   await emitServerMessage(page, socketIndex, {
     AccessDenied: { reason: 'Client update required' },
   });
-
-  await expect(page.getByRole('alert')).toContainText('Client update required');
-  await expect.poll(() => page.evaluate((index) => ({
-    updateRequired: window.__wsContext?.clientUpdateRequired,
-    connected: window.__wsContext?.isConnected,
-    activeSocket: window.__wsInstance ?? null,
-    closeCalls: window.__mockSockets[index].closeCalls,
-  }), socketIndex)).toEqual({
-    updateRequired: true,
-    connected: false,
-    activeSocket: null,
-    closeCalls: [{ code: 4002, reason: 'client update required' }],
-  });
-
-  await page.evaluate(() => {
-    window.__wsContext.connect('ws://snaketron.test/ws');
-    window.__wsContext.connectToRegion('ws://another-region.test/ws', { forceReconnect: true });
-  });
   await page.waitForTimeout(250);
-  expect(await page.evaluate(() => window.__mockSockets.length)).toBe(socketCount);
+
+  await expect(page.getByTestId('client-update-required')).toHaveCount(0);
+  expect(await page.evaluate((index) => ({
+    connected: window.__wsContext?.isConnected,
+    activeSocketIndex: window.__wsInstance
+      ? window.__mockSockets.indexOf(window.__wsInstance)
+      : -1,
+    closeCalls: window.__mockSockets[index].closeCalls,
+    socketCount: window.__mockSockets.length,
+  }), socketIndex)).toEqual({
+    connected: true,
+    activeSocketIndex: socketIndex,
+    closeCalls: [],
+    socketCount,
+  });
 });
 
 test('terminal cutoff rejects a command crossed by buffered completion', async ({ page }) => {

--- a/client/web/tests/unit/gameplayProtocol.test.ts
+++ b/client/web/tests/unit/gameplayProtocol.test.ts
@@ -1,12 +1,12 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
+import * as constants from '../../constants.ts';
 import {
   buildGameplayAuthentication,
-  isClientUpdateRequiredReason,
   GAMEPLAY_PROTOCOL_VERSION,
 } from '../../constants.ts';
 
-test('gameplay authentication carries the exact hard-cutover protocol', () => {
+test('gameplay authentication reports the protocol version', () => {
   assert.equal(GAMEPLAY_PROTOCOL_VERSION, 7);
   assert.deepEqual(buildGameplayAuthentication('test-token'), {
     Authenticate: {
@@ -16,8 +16,10 @@ test('gameplay authentication carries the exact hard-cutover protocol', () => {
   });
 });
 
-test('the hard-cutover denial is recognized without reconnecting forever', () => {
-  assert.equal(isClientUpdateRequiredReason('Client update required'), true);
-  assert.equal(isClientUpdateRequiredReason(' client UPDATE required '), true);
-  assert.equal(isClientUpdateRequiredReason('Access denied'), false);
+// A shipped build cannot update itself — an itch.io bundle has no
+// reload-to-upgrade path at all — so a protocol mismatch must never produce a
+// dead end the player cannot act on. Nothing may reintroduce that gate.
+test('no client-update gate survives anywhere in the gameplay protocol constants', () => {
+  assert.equal('isClientUpdateRequiredReason' in constants, false);
+  assert.equal('CLIENT_UPDATE_REQUIRED_REASON' in constants, false);
 });

--- a/client/web/tests/unit/websocketLifecycle.test.ts
+++ b/client/web/tests/unit/websocketLifecycle.test.ts
@@ -58,7 +58,10 @@ test('matchmaking admission retries stop after the bounded delay schedule', () =
   assert.equal(matchmakingAdmissionRetryDelayMs(0.5), null);
 });
 
-test('the current websocket protocol fails closed when a capability is absent', () => {
+// Reports which capabilities a server did not advertise. The caller only warns
+// on the result — a missing capability never blocks the player, because a
+// shipped build cannot update itself to satisfy it.
+test('the current websocket protocol names each absent capability', () => {
   const current = [
     'explicit-auth-v1',
     'planned-drain-v1',

--- a/client/web/types/index.ts
+++ b/client/web/types/index.ts
@@ -115,7 +115,6 @@ export interface LobbyPreferences {
 export interface WebSocketContextType {
   isConnected: boolean;
   isSessionAuthenticated: boolean;
-  clientUpdateRequired: boolean;
   serverCapabilities: ReadonlySet<string>;
   sendMessage: (message: OutboundMessage) => boolean;
   waitForSessionReady: (timeoutMs?: number) => Promise<void>;

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -27,8 +27,6 @@ use futures_util::SinkExt;
 use redis::AsyncCommands;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
-use std::error::Error as StdError;
-use std::fmt;
 use std::future::{Future, pending};
 use std::pin::Pin;
 use std::sync::Arc;
@@ -40,39 +38,22 @@ use tokio_tungstenite::tungstenite::Message;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
 
-const CLIENT_UPDATE_REQUIRED_REASON: &str = "Client update required";
-
-#[derive(Debug)]
-struct ClientProtocolMismatch {
-    detail: String,
-}
-
-impl fmt::Display for ClientProtocolMismatch {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(&self.detail)
+/// The gameplay protocol version a client reports is advisory. No client is
+/// ever turned away for reporting an old, newer, or missing version: a shipped
+/// build cannot update itself — an itch.io bundle has no reload-to-upgrade
+/// path at all — so an "update required" dead end would strand the player with
+/// nothing to do. Every gameplay protocol change must therefore stay backwards
+/// compatible, and a mismatch is only ever logged so a rollout stays visible.
+fn log_client_protocol_version(protocol_version: Option<u16>) {
+    match protocol_version {
+        Some(version) if version == WS_PROTOCOL_VERSION => {}
+        Some(version) => warn!(
+            "Admitting client on gameplay protocol version {version}; this server speaks {WS_PROTOCOL_VERSION}"
+        ),
+        None => warn!(
+            "Admitting legacy client that reported no gameplay protocol version; this server speaks {WS_PROTOCOL_VERSION}"
+        ),
     }
-}
-
-impl StdError for ClientProtocolMismatch {}
-
-async fn queue_client_update_required(ws_tx: &mpsc::Sender<Message>) -> Result<()> {
-    let denial = WSMessage::AccessDenied {
-        reason: CLIENT_UPDATE_REQUIRED_REASON.to_owned(),
-    };
-    ws_tx
-        .send(Message::Text(serde_json::to_string(&denial)?.into()))
-        .await
-        .context("WebSocket closed before protocol rejection")?;
-    // FIFO after the denial. The connection cleanup waits for the forwarding
-    // task to send this close frame instead of aborting that task immediately.
-    ws_tx
-        .send(Message::Close(None))
-        .await
-        .context("WebSocket closed before protocol close frame")
-}
-
-fn ws_protocol_version_is_supported(protocol_version: u16) -> bool {
-    protocol_version == WS_PROTOCOL_VERSION
 }
 
 // Snapshot-bearing messages are serialized envelopes; boxing would add churn without a win.
@@ -81,12 +62,11 @@ fn ws_protocol_version_is_supported(protocol_version: u16) -> bool {
 #[cfg_attr(feature = "ts-gen", derive(ts_rs::TS))]
 #[cfg_attr(feature = "ts-gen", ts(export))]
 pub enum WSMessage {
-    /// Legacy authentication shape retained only so the server can return a
-    /// clear update-required error before closing a stale client's socket.
+    /// Legacy authentication shape. Still honored: it authenticates exactly
+    /// like `Authenticate`, just without a reported protocol version.
     Token(String),
-    /// Client -> server authentication. The version is checked before token
-    /// verification so a maintenance cutover cannot admit an old gameplay
-    /// protocol into a current executor fleet.
+    /// Client -> server authentication. The reported version is advisory —
+    /// see `log_client_protocol_version`; it never gates admission.
     Authenticate {
         token: String,
         protocol_version: u16,
@@ -696,7 +676,6 @@ async fn handle_websocket_connection(
     let shutdown_timeout = tokio::time::sleep(Duration::from_secs(u64::MAX));
     tokio::pin!(shutdown_timeout);
     let mut shutdown_started = false;
-    let mut graceful_protocol_close = false;
 
     // Will be used to track Redis stream subscription for game events
     let mut game_event_handle: Option<JoinHandle<()>> = None;
@@ -716,7 +695,7 @@ async fn handle_websocket_connection(
     let mut game_chat_handle: Option<JoinHandle<()>> = None;
 
     // Spawn task to forward messages from channel to WebSocket
-    let mut forward_task = tokio::spawn(async move {
+    let forward_task = tokio::spawn(async move {
         let mut drain_open = true;
         let mut ws_open = true;
         while let Some(msg) = next_outbound_message(
@@ -1258,9 +1237,6 @@ async fn handle_websocket_connection(
                                         Err(e) => {
                                             crate::resilience_metrics::record_websocket_process_error(1);
                                             error!("Error processing message: {}", e);
-                                            graceful_protocol_close = e
-                                                .downcast_ref::<ClientProtocolMismatch>()
-                                                .is_some();
                                             // State was consumed, need to reset
                                             state = ConnectionState::Unauthenticated;
                                             break;
@@ -1316,16 +1292,7 @@ async fn handle_websocket_connection(
     if let Some(handle) = game_chat_handle {
         handle.abort();
     }
-    if graceful_protocol_close {
-        if tokio::time::timeout(Duration::from_secs(1), &mut forward_task)
-            .await
-            .is_err()
-        {
-            forward_task.abort();
-        }
-    } else {
-        forward_task.abort();
-    }
+    forward_task.abort();
 
     info!("WebSocket connection closed");
     Ok(())
@@ -3318,6 +3285,105 @@ async fn subscribe_to_lobby_chat(
     Ok(())
 }
 
+/// Shared admission path for both authentication shapes. `protocol_version` is
+/// `None` for the legacy `Token` shape and is never a reason to refuse the
+/// connection — see `log_client_protocol_version`.
+#[allow(clippy::too_many_arguments)]
+async fn authenticate_ws_connection(
+    jwt_token: String,
+    protocol_version: Option<u16>,
+    jwt_verifier: &Arc<dyn JwtVerifier>,
+    db: &Arc<dyn Database>,
+    ws_tx: &mpsc::Sender<Message>,
+    game_bus: &Arc<GameBus>,
+    matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
+    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    websocket_id: &str,
+    lifecycle: &TaskLifecycle,
+    socket_generation: u64,
+    cluster_namespace: &ClusterNamespace,
+) -> Result<ConnectionState> {
+    log_client_protocol_version(protocol_version);
+    debug!("Received WebSocket authentication request");
+    match jwt_verifier.verify(&jwt_token).await {
+        Ok(user_token) => {
+            info!(
+                "Token verified successfully, user_id: {}",
+                user_token.user_id
+            );
+
+            let user = db
+                .get_user_by_id(user_token.user_id)
+                .await?
+                .ok_or_else(|| anyhow::anyhow!("User not found"))?;
+
+            if user.is_guest != user_token.is_guest {
+                return Err(anyhow::anyhow!(
+                    "Authentication failed: guest claim does not match user record"
+                ));
+            }
+
+            let database_pool = if user.is_stress_test {
+                MatchmakingPool::Stress
+            } else {
+                MatchmakingPool::Public
+            };
+            if database_pool != user_token.matchmaking_pool {
+                return Err(anyhow::anyhow!(
+                    "Authentication failed: matchmaking pool claim does not match user record"
+                ));
+            }
+
+            let metadata = PlayerMetadata {
+                user_id: user_token.user_id,
+                username: user.username.clone(),
+                token: jwt_token.clone(),
+                is_guest: user.is_guest,
+                matchmaking_pool: database_pool,
+            };
+
+            info!(
+                "User authenticated: {} (id: {})",
+                metadata.username, metadata.user_id
+            );
+
+            let authenticated = WSMessage::Authenticated {
+                task_boot_id: lifecycle.task_boot_id().to_owned(),
+                protocol_version: WS_PROTOCOL_VERSION,
+                capabilities: lifecycle.protocol_capabilities(),
+                socket_generation,
+            };
+            ws_tx
+                .send(Message::Text(serde_json::to_string(&authenticated)?.into()))
+                .await
+                .context("WebSocket closed before authentication acknowledgement")?;
+            if let Ok(user_id) = u32::try_from(metadata.user_id) {
+                notify_durable_active_game_after_auth(
+                    user_id,
+                    metadata.matchmaking_pool,
+                    ws_tx,
+                    matchmaking_manager,
+                    replication_manager,
+                    game_bus,
+                    cluster_namespace,
+                    db,
+                )
+                .await?;
+            }
+            Ok(ConnectionState::Authenticated {
+                metadata,
+                lobby_handle: None,
+                game_id: None,
+                websocket_id: websocket_id.to_string(),
+            })
+        }
+        Err(e) => {
+            error!("Failed to verify token: {}", e);
+            Err(anyhow::anyhow!("Authentication failed"))
+        }
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn process_ws_message(
     state: ConnectionState,
@@ -3381,104 +3447,42 @@ async fn process_ws_message(
     match state {
         ConnectionState::Unauthenticated => {
             match ws_message {
-                WSMessage::Token(_) => {
-                    queue_client_update_required(ws_tx).await?;
-                    Err(anyhow::Error::new(ClientProtocolMismatch {
-                        detail: "legacy WebSocket authentication protocol rejected".into(),
-                    }))
+                WSMessage::Token(jwt_token) => {
+                    authenticate_ws_connection(
+                        jwt_token,
+                        None,
+                        jwt_verifier,
+                        db,
+                        ws_tx,
+                        game_bus,
+                        matchmaking_manager,
+                        replication_manager,
+                        websocket_id,
+                        lifecycle,
+                        socket_generation,
+                        cluster_namespace,
+                    )
+                    .await
                 }
                 WSMessage::Authenticate {
                     token: jwt_token,
                     protocol_version,
                 } => {
-                    if !ws_protocol_version_is_supported(protocol_version) {
-                        queue_client_update_required(ws_tx).await?;
-                        return Err(anyhow::Error::new(ClientProtocolMismatch {
-                            detail: format!(
-                                "WebSocket protocol version {protocol_version} rejected; expected {WS_PROTOCOL_VERSION}"
-                            ),
-                        }));
-                    }
-                    debug!("Received WebSocket authentication request");
-                    match jwt_verifier.verify(&jwt_token).await {
-                        Ok(user_token) => {
-                            info!(
-                                "Token verified successfully, user_id: {}",
-                                user_token.user_id
-                            );
-
-                            let user = db
-                                .get_user_by_id(user_token.user_id)
-                                .await?
-                                .ok_or_else(|| anyhow::anyhow!("User not found"))?;
-
-                            if user.is_guest != user_token.is_guest {
-                                return Err(anyhow::anyhow!(
-                                    "Authentication failed: guest claim does not match user record"
-                                ));
-                            }
-
-                            let database_pool = if user.is_stress_test {
-                                MatchmakingPool::Stress
-                            } else {
-                                MatchmakingPool::Public
-                            };
-                            if database_pool != user_token.matchmaking_pool {
-                                return Err(anyhow::anyhow!(
-                                    "Authentication failed: matchmaking pool claim does not match user record"
-                                ));
-                            }
-
-                            let metadata = PlayerMetadata {
-                                user_id: user_token.user_id,
-                                username: user.username.clone(),
-                                token: jwt_token.clone(),
-                                is_guest: user.is_guest,
-                                matchmaking_pool: database_pool,
-                            };
-
-                            info!(
-                                "User authenticated: {} (id: {})",
-                                metadata.username, metadata.user_id
-                            );
-
-                            let authenticated = WSMessage::Authenticated {
-                                task_boot_id: lifecycle.task_boot_id().to_owned(),
-                                protocol_version: WS_PROTOCOL_VERSION,
-                                capabilities: lifecycle.protocol_capabilities(),
-                                socket_generation,
-                            };
-                            ws_tx
-                                .send(Message::Text(serde_json::to_string(&authenticated)?.into()))
-                                .await
-                                .context(
-                                    "WebSocket closed before authentication acknowledgement",
-                                )?;
-                            if let Ok(user_id) = u32::try_from(metadata.user_id) {
-                                notify_durable_active_game_after_auth(
-                                    user_id,
-                                    metadata.matchmaking_pool,
-                                    ws_tx,
-                                    matchmaking_manager,
-                                    replication_manager,
-                                    game_bus,
-                                    cluster_namespace,
-                                    db,
-                                )
-                                .await?;
-                            }
-                            Ok(ConnectionState::Authenticated {
-                                metadata,
-                                lobby_handle: None,
-                                game_id: None,
-                                websocket_id: websocket_id.to_string(),
-                            })
-                        }
-                        Err(e) => {
-                            error!("Failed to verify token: {}", e);
-                            Err(anyhow::anyhow!("Authentication failed"))
-                        }
-                    }
+                    authenticate_ws_connection(
+                        jwt_token,
+                        Some(protocol_version),
+                        jwt_verifier,
+                        db,
+                        ws_tx,
+                        game_bus,
+                        matchmaking_manager,
+                        replication_manager,
+                        websocket_id,
+                        lifecycle,
+                        socket_generation,
+                        cluster_namespace,
+                    )
+                    .await
                 }
                 WSMessage::Ping { client_time } => {
                     // Respond with Pong even in unauthenticated state to keep connection alive
@@ -4712,17 +4716,16 @@ fn ensure_custom_game_access(matchmaking_pool: MatchmakingPool) -> Result<()> {
 #[cfg(test)]
 mod lifecycle_protocol_tests {
     use super::{
-        CLIENT_UPDATE_REQUIRED_REASON, CommandOutcomeReplay, GameJoinAuthorizationError,
-        GameSubscriptionInput, TERMINAL_COMMAND_REJECTION_REASON, WSMessage,
-        abort_and_join_game_event_forwarder, canonical_command_identity, command_outcomes_for_user,
-        ensure_custom_game_access, game_join_denied, game_join_failure_message,
+        CommandOutcomeReplay, GameJoinAuthorizationError, GameSubscriptionInput,
+        TERMINAL_COMMAND_REJECTION_REASON, WSMessage, abort_and_join_game_event_forwarder,
+        canonical_command_identity, command_outcomes_for_user, ensure_custom_game_access,
+        game_join_denied, game_join_failure_message, log_client_protocol_version,
         missing_game_join_failure, next_game_subscription_input, next_outbound_message,
-        queue_client_update_required, queue_planned_drain_notice, recovery_bridge_snapshot,
-        require_game_command_publication, send_command_outcomes_from_resolved,
-        send_completed_game_snapshot_from_resolved, send_recovery_bridge_snapshot,
-        slow_command_publish_wait_ms, snapshot_requires_command_outcomes,
-        subscribe_to_lobby_match_notifications, take_lobby_update_receiver, unsent_lobby_match,
-        validate_game_matchmaking_pool, ws_protocol_version_is_supported,
+        queue_planned_drain_notice, recovery_bridge_snapshot, require_game_command_publication,
+        send_command_outcomes_from_resolved, send_completed_game_snapshot_from_resolved,
+        send_recovery_bridge_snapshot, slow_command_publish_wait_ms,
+        snapshot_requires_command_outcomes, subscribe_to_lobby_match_notifications,
+        take_lobby_update_receiver, unsent_lobby_match, validate_game_matchmaking_pool,
     };
     use crate::lifecycle::{DrainNotice, WS_PROTOCOL_VERSION};
     use crate::lobby_manager::{Lobby, LobbyPreferences};
@@ -4912,7 +4915,7 @@ mod lifecycle_protocol_tests {
     }
 
     #[test]
-    fn authentication_request_requires_the_exact_protocol_version() {
+    fn authentication_request_reports_an_advisory_protocol_version() {
         let value = serde_json::to_value(WSMessage::Authenticate {
             token: "jwt".to_owned(),
             protocol_version: WS_PROTOCOL_VERSION,
@@ -4923,29 +4926,29 @@ mod lifecycle_protocol_tests {
             value["Authenticate"]["protocol_version"],
             WS_PROTOCOL_VERSION
         );
-        assert!(ws_protocol_version_is_supported(WS_PROTOCOL_VERSION));
-        assert!(!ws_protocol_version_is_supported(
-            WS_PROTOCOL_VERSION.saturating_sub(1)
-        ));
-        assert_eq!(CLIENT_UPDATE_REQUIRED_REASON, "Client update required");
     }
 
-    #[tokio::test]
-    async fn protocol_mismatch_queues_denial_before_close() {
-        let (tx, mut rx) = mpsc::channel(2);
-        queue_client_update_required(&tx).await.unwrap();
+    /// A stale, newer, or version-less client must never be refused: a shipped
+    /// build (an itch.io bundle above all) cannot update itself, so refusing it
+    /// would strand the player. Reporting a version only produces a log line.
+    #[test]
+    fn every_reported_protocol_version_is_admitted() {
+        log_client_protocol_version(Some(WS_PROTOCOL_VERSION));
+        log_client_protocol_version(Some(WS_PROTOCOL_VERSION.saturating_sub(1)));
+        log_client_protocol_version(Some(WS_PROTOCOL_VERSION.saturating_add(1)));
+        log_client_protocol_version(Some(0));
+        log_client_protocol_version(None);
+    }
 
-        let denial = rx.recv().await.expect("denial frame");
-        let Message::Text(text) = denial else {
-            panic!("first protocol-mismatch frame must be text");
-        };
-        let parsed: WSMessage = serde_json::from_str(&text).unwrap();
-        assert!(matches!(
-            parsed,
-            WSMessage::AccessDenied { reason }
-                if reason == CLIENT_UPDATE_REQUIRED_REASON
-        ));
-        assert!(matches!(rx.recv().await, Some(Message::Close(_))));
+    /// The legacy version-less shape still authenticates rather than being
+    /// answered with a denial the player cannot act on.
+    #[test]
+    fn the_legacy_token_shape_is_still_accepted() {
+        let value = serde_json::to_value(WSMessage::Token("jwt".to_owned())).unwrap();
+        assert_eq!(value["Token"], "jwt");
+
+        let parsed: WSMessage = serde_json::from_value(value).unwrap();
+        assert!(matches!(parsed, WSMessage::Token(token) if token == "jwt"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The Snaketron itch.io build shows **"Client update required"** — a dead end. The screen asks the player to reload, but an itch.io bundle has no reload-to-upgrade path at all, so there is nothing they can do. Per product direction this screen should never appear, on itch or on the web: play continues on a mismatched protocol, and gameplay-protocol changes stay backwards compatible instead.

## The gate had two independent halves

Either one could strand a player, so both had to go:

**Server** (`server/src/ws_server.rs`) — rejected any `Authenticate` whose `protocol_version` was not the current one, and refused the legacy `Token` shape outright, replying `AccessDenied("Client update required")` and closing the socket.

**Client** (`client/web/contexts/WebSocketContext.tsx`) — refused the *server* in turn. It closed every socket with code 4002 and permanently suppressed reconnect when the server reported a different `protocol_version` **or** did not advertise all 7 expected capabilities, then rendered the blocking page in `App.tsx`.

## Changes

Both directions are now advisory — a mismatch logs a warning and play continues.

- The server admits every reported version. The legacy `Token` shape now authenticates normally instead of being refused; both shapes share one extracted `authenticate_ws_connection` path (a pure move of the existing logic plus the version log).
- The client warns on a version or capability mismatch instead of shutting down.
- Removed the blocking screen, `shutdownForClientUpdate`, the `clientUpdateRequired` state, and the now-dead `graceful_protocol_close` machinery on the server.

`GAMEPLAY_PROTOCOL_VERSION` is still reported on both sides — it is now observability only.

## Deploy note

The **server** half is what rescues the already-uploaded itch bundle: that shipped client still carries the old blocking logic, and only stays safe because the server no longer sends the denial. It also still self-blocks on its own `protocol_version` check, so **rebuild and re-upload the itch zip before `WS_PROTOCOL_VERSION` is ever bumped past 7.** Only clients built from this change onward are fully immune.

Paired with the deployment-repo PR that bumps the submodule pointer and corrects the docs that described the gate as a hard constraint.

## Testing

Tests now assert the opposite guarantee, including two new e2e cases verified in a real browser: a server reporting `protocol_version: 999` with zero capabilities still authenticates and proceeds to `JoinLobby`, and a stray `AccessDenied: "Client update required"` leaves the connection fully intact.

- 253 server lib tests + all 20 integration binaries pass
- 155 client unit tests pass
- 43 drain e2e tests pass (including the 2 new ones)
- `cargo clippy --all-targets --all-features` clean; `tsc --noEmit` shows only the 4 pre-existing errors (confirmed identical against a stashed tree)

🤖 Generated with [Claude Code](https://claude.com/claude-code)