### PR TITLE
Bring the README in line with the actual stack, and fix dev.sh

### DIFF
--- a/.github/workflows/github-action-test-simple-game.yml
+++ b/.github/workflows/github-action-test-simple-game.yml
@@ -64,7 +64,10 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The full suite currently takes ~29-30 minutes on a good runner; recent
+    # green runs finished within seconds of a 30-minute limit, so slower
+    # runners were timing out. Keep real headroom here.
+    timeout-minutes: 45
 
     services:
       postgres:

--- a/README.md
+++ b/README.md
@@ -2,11 +2,22 @@
 
 A competitive online multiplayer Snake game built with Rust (backend + WebAssembly frontend).
 
+## Features
+
+- **Game modes**: Solo practice, Duel (1v1), 2v2 team matches, Free-for-All, and private Custom games with configurable arena size, tick rate, food spawn rate, and player limits
+- **Matchmaking**: casual Quickmatch and ranked Competitive queues, plus lobbies with chat and invite links
+- **Boost**: hold-to-boost speed bursts fueled by collectible Boost pads (unlimited fuel in Solo)
+- **Accounts**: register/login with JWT auth, or play instantly as a guest
+- **Progression**: seasonal MMR with leaderboards (`/api/leaderboard`, `/api/seasons`), plus lifetime XP
+- **Smooth multiplayer**: the game engine is shared between server and client, enabling client-side prediction with server authority
+
 ## Architecture
 
-- **Backend**: Rust server with WebSocket connections, gRPC for inter-server communication, and Raft consensus
-- **Frontend**: React + WebAssembly (compiled from Rust)
-- **Database**: PostgreSQL with automatic migrations
+- **Backend**: Rust server (Tokio + axum) serving the REST API and WebSocket connections on a single HTTP port
+- **Cluster coordination**: Redis (Valkey) — server membership and heartbeats, partition assignment with fenced leases, and Redis Streams as the game event/command bus. The server running a game's loop is not necessarily the WebSocket server its players are connected to.
+- **Persistence**: AWS DynamoDB — a single-table-style main table with GSIs, plus small auxiliary tables for username uniqueness and game codes; LocalStack stands in for it in local development
+- **Frontend**: React + TypeScript consuming a Rust game engine compiled to WebAssembly (wasm-pack), bundled with webpack
+- **Shared game logic**: the `common/` crate compiles to both native (server) and WASM (client)
 - **Infrastructure**: Docker containers, designed for AWS Fargate deployment
 
 ## Quick Start
@@ -15,7 +26,7 @@ A competitive online multiplayer Snake game built with Rust (backend + WebAssemb
 
 #### For Development (with hot reloading):
 ```bash
-# Start database and server with auto-reload on code changes
+# Start LocalStack (DynamoDB), Valkey (Redis), and the server with auto-reload on code changes
 ./dev.sh
 
 # In another terminal, build and start the client
@@ -28,26 +39,26 @@ npm start
 
 #### For Production-like environment:
 ```bash
-# Start database and server (rebuilds on each change)
+# Start LocalStack (DynamoDB), Valkey (Redis), and the server (full rebuild each time)
 docker-compose up --build
 ```
 
 The game will be available at:
 - Frontend: http://localhost:3000 (webpack dev server)
-- WebSocket Server: ws://localhost:8080 (Docker container)
-- gRPC Server: localhost:50051 (Docker container)
-- Database: localhost:5432 (Docker container)
+- HTTP API + WebSocket: localhost:8080 (WebSocket endpoint at ws://localhost:8080/ws)
+- DynamoDB (LocalStack): http://localhost:4566
+- Redis (Valkey): localhost:6379
 
 ### Manual Setup
 
-1. Start PostgreSQL:
+1. Start the data services (LocalStack + Redis) and create the DynamoDB tables:
    ```bash
-   docker-compose up -d db
+   ./test-deps.sh
    ```
 
-2. Run the server:
+2. Run the server (`.cargo/config.toml` supplies the LocalStack/Redis defaults; only the region must be set explicitly):
    ```bash
-   cargo run --bin server
+   SNAKETRON_REGION=us cargo run --bin server
    ```
 
 3. Build and run the client:
@@ -63,14 +74,57 @@ The game will be available at:
 
 ### Running Tests
 
+Server integration tests need Redis and LocalStack DynamoDB running — start them with `./test-deps.sh` first (it also creates the DynamoDB tables).
+
 ```bash
-# Run all tests
+# Run all Rust tests
 cargo test
 
 # Run server tests with logging
 RUST_LOG=info cargo test -p server -- --nocapture
+
+# Curated serial suites (set up their own env, run single-threaded)
+./run_matchmaking_tests.sh
+./run_quickmatch_tests.sh
 ```
 
+Client tests and checks:
+
+```bash
+cd client/web
+npm test            # Playwright end-to-end tests
+npm run test:unit   # Node unit tests
+npm run type-check  # TypeScript type check
+```
+
+### Code Quality
+
+CI requires formatting and a warning-free clippy pass on every PR (mirrored as a deploy gate):
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
+
+### Generated TypeScript Types
+
+TypeScript types for everything crossing the WebSocket are generated from the Rust source of truth with ts-rs. After changing any wire type, regenerate them and commit the diff:
+
+```bash
+./scripts/gen-types.sh
+```
+
+### Game Replays
+
+The repo includes replay-recording infrastructure (`server/src/replay/`) and sample `.replay` captures in `replays/`, though recording is not currently wired into the running server. Play the samples back in the terminal viewer:
+
+```bash
+cargo run --bin snaketron -- replays/
+```
+
+### itch.io Build
+
+`ITCH_BUILD=true npm run build:prod` (in `client/web`) produces a relative-path HTML5 bundle suitable for uploading to itch.io.
 
 ### Run a coordinated autoscaling load test
 ```bash
@@ -87,11 +141,22 @@ The load runner supports Solo, Duel, 2v2, and FFA; creates deterministic full-pa
 ### Project Structure
 
 - `common/` - Shared game logic (compiled to both native and WASM)
-- `server/` - Game server with WebSocket and gRPC support
-- `client/` - WebAssembly client module
+- `server/` - Game server: WebSocket sessions, matchmaking, game executors, persistence
+- `client/` - WebAssembly client module and the React/TypeScript web app (`client/web/`)
+- `bot/` - CLI that runs one or more AI bots against a live server over WebSocket
+- `macros/` - Proc-macro crate (`serde_wasm_bindgen` attribute for Rust-to-WASM bindings)
 - `terminal/` - Terminal-based game viewer and replay player
 - `loadtest/` - Coordinated AI load generator and aggregate reporting
-- `specs/` - TLA+ specifications for distributed systems design
+- `replays/` - Sample `.replay` game captures for the terminal viewer
+- `scripts/` - Development helpers (type generation, DynamoDB init, test dependencies)
+- `specs/` - Design documents and PRDs (matchmaking, Boost, autoscaling resilience, ...)
+- `tla_specs/` - TLA+ specifications (checked with `tla2tools.jar` at the repo root)
+- `docs/` - Screenshots and assets referenced from pull-request descriptions
+
+### Further Documentation
+
+- [DEBUGGING.md](DEBUGGING.md) - Runbook for diagnosing state-synchronization bugs (traces, TickHash, replaying to a local repro)
+- [loadtest/README.md](loadtest/README.md) - Load test profiles, safety controls, and report semantics
 
 ## Production Deployment
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
-# SnakeTron
+<p align="center">
+  <a href="https://snaketron.io">
+    <img src="client/web/SnaketronLogo.png" alt="SnakeTron" width="500">
+  </a>
+</p>
 
-A competitive online multiplayer Snake game built with Rust (backend + WebAssembly frontend).
+<p align="center">
+  <a href="https://snaketron.io"><b>▶ Play now at snaketron.io</b></a>
+</p>
+
+SnakeTron is a competitive online multiplayer Snake game. Jump in as a guest or make an account, queue up for casual or ranked matches, and outmaneuver other players in real time — solo practice, 1v1 duels, 2v2 team battles, and free-for-alls. The backend is Rust; the browser client runs the same Rust game engine compiled to WebAssembly, so what you see is exactly what the server simulates.
 
 ## Features
 
 - **Game modes**: Solo practice, Duel (1v1), 2v2 team matches, Free-for-All, and private Custom games with configurable arena size, tick rate, food spawn rate, and player limits
-- **Matchmaking**: casual Quickmatch and ranked Competitive queues, plus lobbies with chat and invite links
+- **Matchmaking**: casual Quickmatch and ranked Competitive queues, plus lobbies with server-moderated chat and invite links
 - **Boost**: hold-to-boost speed bursts fueled by collectible Boost pads (unlimited fuel in Solo)
 - **Accounts**: register/login with JWT auth, or play instantly as a guest
 - **Progression**: seasonal MMR with leaderboards (`/api/leaderboard`, `/api/seasons`), plus lifetime XP
@@ -126,6 +134,10 @@ cargo run --bin snaketron -- replays/
 
 `ITCH_BUILD=true npm run build:prod` (in `client/web`) produces a relative-path HTML5 bundle suitable for uploading to itch.io.
 
+### CrazyGames Build
+
+`CRAZYGAMES_BUILD=true npm run build:prod` (in `client/web`) produces a relative-path HTML5 bundle that loads the CrazyGames v3 SDK before the game bundle and omits third-party analytics. Ads and CrazyGames cloud-data storage stay off unless `CRAZYGAMES_ADS_ENABLED=true` / `CRAZYGAMES_DATA_ENABLED=true` are also set at build time. See [CRAZYGAMES.md](CRAZYGAMES.md) for portal settings and the QA checklist.
+
 ### Run a coordinated autoscaling load test
 ```bash
 cargo run --release -p loadtest -- \
@@ -156,6 +168,7 @@ The load runner supports Solo, Duel, 2v2, and FFA; creates deterministic full-pa
 ### Further Documentation
 
 - [DEBUGGING.md](DEBUGGING.md) - Runbook for diagnosing state-synchronization bugs (traces, TickHash, replaying to a local repro)
+- [CRAZYGAMES.md](CRAZYGAMES.md) - CrazyGames portal integration: build flags, pilot scope, and QA checklist
 - [loadtest/README.md](loadtest/README.md) - Load test profiles, safety controls, and report semantics
 
 ## Production Deployment

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,7 @@ services:
       - ./client:/usr/src/app/client:delegated
       - ./terminal:/usr/src/app/terminal:delegated
       - ./bot:/usr/src/app/bot:delegated
+      - ./loadtest:/usr/src/app/loadtest:delegated
       - ./Cargo.toml:/usr/src/app/Cargo.toml:delegated
       - ./Cargo.lock:/usr/src/app/Cargo.lock:delegated
       # Named volume for target directory to avoid rebuilding dependencies

--- a/server/Dockerfile.dev
+++ b/server/Dockerfile.dev
@@ -22,9 +22,10 @@ COPY macros/Cargo.toml ./macros/
 COPY client/Cargo.toml ./client/
 COPY terminal/Cargo.toml ./terminal/
 COPY bot/Cargo.toml ./bot/
+COPY loadtest/Cargo.toml ./loadtest/
 
 # Create dummy source files to build dependencies
-RUN mkdir -p server/src common/src macros/src client/src terminal/src bot/src && \
+RUN mkdir -p server/src common/src macros/src client/src terminal/src bot/src loadtest/src && \
     echo "fn main() {}" > server/src/main.rs && \
     echo "fn main() {}" > server/src/lib.rs && \
     echo "fn main() {}" > common/src/lib.rs && \
@@ -32,13 +33,14 @@ RUN mkdir -p server/src common/src macros/src client/src terminal/src bot/src &&
     echo "fn main() {}" > client/src/lib.rs && \
     echo "fn main() {}" > terminal/src/main.rs && \
     echo "fn main() {}" > terminal/src/lib.rs && \
-    echo "fn main() {}" > bot/src/main.rs
+    echo "fn main() {}" > bot/src/main.rs && \
+    echo "fn main() {}" > loadtest/src/main.rs
 
 # Build dependencies only
 RUN cargo build --release --bin server
 
 # Remove dummy source files
-RUN rm -rf server/src common/src macros/src client/src terminal/src bot/src
+RUN rm -rf server/src common/src macros/src client/src terminal/src bot/src loadtest/src
 
 # The actual source will be mounted as volumes
 


### PR DESCRIPTION
## What changed

Rewrote `README.md` so it matches the codebase, and fixed the dev toolchain gap the rewrite's verification uncovered (`server/Dockerfile.dev` + `docker-compose.dev.yml`).

### README corrections (each verified against code/config)

- **Raft consensus → Redis/Valkey coordination.** Raft is gone (no crate, no module; `RAFT_REMOVAL_COMPLETED.md`). The real stack is cluster membership + heartbeats, partition assignment with fenced leases, and Redis Streams as the game event bus (`server/src/cluster_membership.rs`, `partition_lease.rs`, `game_bus.rs`).
- **PostgreSQL → DynamoDB.** No Postgres/sqlx/refinery anywhere; persistence is `aws-sdk-dynamodb` with LocalStack in dev. The old Quick Start's `docker-compose up -d db` referenced a service that doesn't exist and "Database: localhost:5432" pointed at nothing — replaced with `./test-deps.sh` and the real ports (LocalStack 4566, Valkey 6379).
- **Dropped the gRPC server claim.** `main.rs` sets `grpc_addr = String::new()` ("gRPC is currently not used") and `GrpcServer` is never constructed, so the README no longer advertises port 50051.
- **Manual setup that actually works:** `SNAKETRON_REGION=us cargo run --bin server` — the only required env var not defaulted by `.cargo/config.toml`.
- **`specs/` vs `tla_specs/`:** `specs/` holds design docs/PRDs; the TLA+ specs live in `tla_specs/`.

### README additions

- Features section: game modes (Solo/Duel/2v2/FFA/Custom), Quickmatch + Competitive queues, Boost, guest play + JWT auth, seasonal MMR leaderboards with lifetime XP.
- Test prerequisites (`./test-deps.sh`), curated serial suites (`run_matchmaking_tests.sh`, `run_quickmatch_tests.sh`), and client tests (Playwright e2e, unit, type-check).
- CI gates (`cargo fmt --check`, `clippy -D warnings`), ts-rs type generation (`scripts/gen-types.sh`), the itch.io build variant, and the terminal replay viewer.
- Project Structure now covers all relevant top-level directories (`bot/`, `macros/`, `scripts/`, `replays/`, `docs/`, `tla_specs/` were undocumented), plus a link to `DEBUGGING.md`.

### dev.sh fix

Verification found `./dev.sh` could not start at all: `Dockerfile.dev`'s dependency-caching layer copies every workspace member's `Cargo.toml` **except `loadtest`'s**, so cargo fails with "failed to load manifest for workspace member .../loadtest" before any container starts. Added the manifest copy + dummy source for `loadtest` and its source mount in `docker-compose.dev.yml`. Confirmed by replicating the image's file layout and running `cargo metadata`: the old layout reproduces the exact failure, the fixed one loads the workspace cleanly.

## Notes for the reviewer

- The README keeps the existing **MIT** license claim, but there is no `LICENSE` file in the repo and `client/web/package.json` says `(MIT OR Apache-2.0)` — worth settling separately.
- Replay recording is described as "not currently wired in": the server reads `SNAKETRON_REPLAY_DIR` but discards it (`replay_dir: _` in `game_server.rs`), and `ReplayListener` has no call sites. The viewer and sample replays work.
- `CLAUDE.md`, `server/docker-readme.md`, and `PORT_CONFIGURATION.md` still describe the old Postgres/gRPC stack — left for a follow-up so this PR stays reviewable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Second commit (after rebase on master)

- **Logo header**: centered wordmark (`client/web/SnaketronLogo.png`) linking to https://snaketron.io, with a short intro paragraph.
- **CI fix**: the `Run Tests` job was timing out at its 30-minute limit — the two most recent *green* runs finished at 29m29s and 29m54s, so the suite now rides the limit and slower runners get canceled mid-suite (that's what failed this PR's first run; no test actually failed). Raised `timeout-minutes` to 45.
- **Covers the two merges that landed since the first draft**: documents the CrazyGames build variant (`CRAZYGAMES_BUILD=true npm run build:prod`, ads/data flags off by default) with a link to `CRAZYGAMES.md`, and notes that lobby/game chat is now server-moderated (`rustrict` on the single chat publish path). The continent-names merge (#54) required no README changes.
- Note: `CRAZYGAMES.md` references a `./scripts/build-crazygames.sh` that doesn't exist in the repo — the README documents the verified env-var build instead; doc fix left as a follow-up.
