### PR TITLE
Add full CrazyGames account integration

### DIFF
--- a/CRAZYGAMES.md
+++ b/CRAZYGAMES.md
@@ -1,98 +1,312 @@
-# CrazyGames integration
+# CrazyGames release and account-integration runbook
 
-Snaketron's CrazyGames target is a deliberately fail-open HTML5 build. The
-ordinary web build never loads or calls the CrazyGames SDK, and an unavailable
-or disabled SDK never blocks the game.
+Snaketron uses CrazyGames as an additive identity provider. A verified
+CrazyGames identity maps to the same internal Snaketron user on every device;
+XP, MMR, rankings, high scores, match history, and preferences remain
+server-authoritative. The ordinary website and itch builds retain their
+existing guest, email, and password behavior.
 
-## Build and preview
+The release target is the CrazyGames **in-game account (full)** integration,
+even if the first portal release is still classified as a Basic Launch. The
+CrazyGames package does not use the Data Module for authoritative progress.
 
-From the outer repository root:
+## Account and progress contract
+
+| CrazyGames state | Snaketron behavior |
+| --- | --- |
+| Signed in, first visit | Verify a fresh CrazyGames JWT on the server, create a durable Snaketron user, and log in automatically. |
+| Signed in, returning visit or another device | Verify a fresh JWT, resolve the immutable CrazyGames `userId`, restore the same internal user and all server progress, then log in automatically. |
+| Signed out | Allow immediate guest play. Do not show the CrazyGames authentication prompt automatically. Keep guest preferences in tab-scoped browser storage. |
+| Guest signs in during play | Detect the CrazyGames auth event, leave transient lobby/match state safely, reload, verify a fresh JWT, and ask with CrazyGames' standard account-link prompt only if the server confirms that this eligible guest could be promoted into a new CrazyGames identity. Promote atomically only after `yes`; `no` starts the new account without guest data. |
+| Known CrazyGames identity signs in over a browser guest | Restore the known CrazyGames account without an unnecessary link prompt. Do not merge unrelated guest progression into it. |
+| CrazyGames profile is renamed | Update the active account/lobby display name and avatar from newer verified claims while retaining the same internal user and progress. Historical leaderboard rows remain immutable snapshots. |
+| Multiple CrazyGames accounts share a device | Resolve the current portal JWT on every launch; never select an account from a stale browser token. |
+
+Only the server-verified JWT `userId` identifies a CrazyGames account. The
+client-only `__dangerousUserId`, username, and avatar must never authorize an
+account. CrazyGames JWTs are short-lived exchange credentials and must not be
+persisted or logged.
+
+For verified CrazyGames users, Snaketron stores tutorial, lobby, and input
+preferences on its own backend alongside server-owned progression. For signed-
+out guests those preferences remain local. Local settings are imported only
+when the same tab proves ownership of an eligible Snaketron guest session and
+the player accepts CrazyGames' standard account-link prompt. Declining does not
+attach the guest or its settings. A new provider account never inherits
+unscoped settings from a shared browser.
+The CrazyGames Data Module is not a dependency and is disabled in the standard
+package.
+
+An existing Snaketron email/password account and a CrazyGames identity are
+intentionally separate accounts. This release does not guess that they belong
+to the same person or automatically merge/link their progression. Players use
+their portal-linked account inside CrazyGames and their password account on the
+ordinary website; any future cross-provider linking needs an explicit,
+authenticated account-linking design.
+
+## Isolation from other builds
+
+These are release invariants:
+
+- `CRAZYGAMES_BUILD` is compile-time isolation for the CrazyGames UI and SDK.
+- Website and itch clients never initialize the CrazyGames SDK or call the
+  CrazyGames token-exchange endpoint.
+- `/login`, `/register`, `/guest`, password-account upgrades, and their token
+  storage remain unchanged outside a CrazyGames build.
+- CrazyGames identities do not enter the password username index and do not
+  expose email/password or other external login controls in the portal build.
+- An unavailable CrazyGames public-key service can fail the CrazyGames exchange
+  without affecting health checks, normal authentication, matchmaking, or itch.
+- The expected portal `gameId` is explicit deployment configuration and not a
+  secret; release workflows pin the reviewed value rather than accepting an
+  ambient runtime default.
+
+## Other SDK behavior retained
+
+The account work does not remove the previously integrated portal behavior:
+
+| Area | CrazyGames behavior |
+| --- | --- |
+| SDK/bootstrap | Initialize the HTML5 v3 SDK before React; treat `local`, `crazygames`, and `disabled` environments explicitly. |
+| Loading/gameplay | Report loading around WASM/match loading and gameplay start/stop around controllable play, menus, countdowns, disconnects, and completion. |
+| Rooms/friends | Mirror the real server lobby through `updateRoom`/`leftRoom`, invite parameters, invite links, live joins, and Instant Multiplayer. Keep a party together across rounds and report queued/in-progress rooms as non-joinable. |
+| Chat/audio | Honor live `disableChat` and `muteAudio` settings; keep server profanity filtering in place. |
+| Ads | Keep ads disabled for Basic Launch. A later ad-enabled package must use only CrazyGames SDK ads and pass filled, unfilled, error, and ad-block tests. |
+| Optional APIs | Do not expose IAP or native leaderboard UI until CrazyGames grants and configures those capabilities. |
+
+## Backend deployment configuration
+
+The ECS task receives these variables only when account exchange is explicitly
+enabled:
+
+```text
+SNAKETRON_CRAZYGAMES_AUTH_ENABLED=true
+SNAKETRON_CRAZYGAMES_GAME_ID=60112
+```
+
+CDK exposes them through two matching contexts. Enabling authentication without
+a valid game ID fails synthesis; omitting both leaves the task definition free
+of CrazyGames account configuration.
+
+The Snaketron game ID was verified from the CrazyGames QA wrapper metadata as
+`60112`. The development and production workflows pin that exact string. Do
+not substitute a developer ID, user ID, game slug, or the example ID from
+CrazyGames documentation.
+
+Development synthesis/deployment adds:
+
+```bash
+CRAZYGAMES_GAME_ID=60112
+
+--context crazyGamesAuthEnabled=true \
+--context crazyGamesGameId="$CRAZYGAMES_GAME_ID"
+```
+
+Production `cdk diff` and `cdk deploy` must add the same two contexts to their
+existing `environment=production` and immutable `imageTag` contexts. The
+reviewed non-secret ID is pinned as `CRAZYGAMES_GAME_ID: '60112'` in both
+workflow files; do not replace it with an ambient repository/environment value
+or secret. Both production regions must receive that same pinned value.
+
+After deployment, inspect the active ECS task definition and confirm that the
+Snaketron container has exactly these two names, that authentication is `true`,
+and that the game ID exactly matches Preview. Then exercise the exchange route
+with a real Preview token; a malformed or wrong-game token must be rejected.
+
+The backend contract is:
+
+| Route | Authentication | Purpose |
+| --- | --- | --- |
+| `POST /api/auth/crazygames/exchange` | CrazyGames JWT in the request; optional existing Snaketron bearer token is considered only as an eligible guest-promotion candidate | Verify the provider identity; perform a read-only `check`, an explicitly approved `allow`, or a non-linking `decline`; atomically create/restore/promote the internal user; return a normal Snaketron session and preferences |
+| `PUT /api/auth/crazygames/preferences` | Linked Snaketron bearer token | Validate and automatically persist the linked user's CrazyGames-build preferences |
+
+The exchange request's `guestPromotion` field defaults to `decline`; an absent
+decision can never claim a guest. `check` returns `409` with the stable code
+`guestLinkConsentRequired` only when the verified identity is new and the
+attached bearer resolves to an eligible guest, and it writes nothing. The
+client then uses CrazyGames' standard prompt and retries with `allow` or
+`decline`. Initial guest preferences are considered only with `allow`.
+
+The routes remain installed while the feature is disabled and return a bounded
+`503` response. Verification uses only RS256, the fixed official public-key
+URL, 2-second connect/5-second total fetch timeouts, a 32 KiB response limit, a
+15-minute in-memory cache, single-flight fetches, one rotation check after an
+invalid signature, a 30-second forced-refresh cooldown, and a 5-second failed-
+fetch backoff. The cooldown prevents forged JWTs from causing one outbound key
+request each while limiting real rotation delay. Do not add the key URL or
+cache settings as user-controlled deployment inputs.
+
+The current DynamoDB item contract is:
+
+```text
+IDENTITY#CRAZYGAMES#<sha256 userId> / META
+USER#<internal user id> / META
+USER#<internal user id> / PREFERENCES#CRAZYGAMES
+```
+
+The user metadata identifies `authProvider=crazygames` and holds verified
+profile metadata; the preferences record carries a schema/version and update
+time. Identity creation and guest promotion must remain transaction-owned so
+concurrent first launches cannot create duplicate accounts.
+
+## Build the portal package
+
+From the outer repository root, after backend and frontend tests pass:
 
 ```bash
 ./scripts/build-crazygames.sh
 ```
 
-The upload artifact is `dist-crazygames/snaketron-crazygames.zip`. It contains
-`index.html` at the zip root, relative asset URLs, the v3 SDK script before the
-game bundle, and no third-party analytics script. The build script enforces the
-CrazyGames 1,500-file and 250 MB uncompressed limits.
+The default release flags are:
 
-Portal settings for the pilot:
+```text
+ITCH_BUILD=false
+CRAZYGAMES_BUILD=true
+CRAZYGAMES_ADS_ENABLED=false
+CRAZYGAMES_DATA_ENABLED=false
+```
 
-- Launch phase: **Basic Launch**
-- Progress Save: **CrazyGames Data Module**
-- Ads: disabled (the default `CRAZYGAMES_ADS_ENABLED=false` build flag)
+`CRAZYGAMES_DATA_ENABLED=true` is an explicit exceptional build. Do not use it
+unless a later feature has a separately documented Data Module contract and the
+matching portal toggle is enabled. Account identity, XP, MMR, results, and
+preferences must never depend on that flag.
+
+The build produces three reviewable artifacts:
+
+```text
+dist-crazygames/snaketron-crazygames.zip
+dist-crazygames/snaketron-crazygames.zip.sha256
+dist-crazygames/snaketron-crazygames-build.txt
+```
+
+The script fails unless all of these package checks pass:
+
+- the ZIP is structurally valid and has `index.html` at its root;
+- ZIP paths contain no traversal, absolute entries, `.DS_Store`, or `__MACOSX`;
+- `index.html` uses a relative base and no root-relative bundled asset URLs;
+- every local asset referenced by `index.html` exists;
+- the CrazyGames HTML5 v3 SDK loads before the local Snaketron bundle;
+- Google Tag Manager/Google Analytics are absent from the embedded package;
+- the bundle contains at most 1,500 files and no more than exactly 250,000,000
+  extracted bytes (the portal's decimal-byte ceiling);
+- because this is currently one eager package, the script conservatively treats
+  the entire extracted package as the initial bundle and limits both that total
+  and the ZIP to 50,000,000 bytes;
+- the compiled bundle contains the `gameplayStart` lifecycle marker as well as
+  the CrazyGames token exchange, standard guest-link consent, and preference-
+  save markers;
+- the production API endpoint is compiled into the bundle (regional WebSocket
+  endpoints are returned by the production region-discovery API); and
+- a SHA-256 checksum, outer/submodule source commits, source-tree cleanliness,
+  clean-build enforcement flag, build flags, endpoint values, file count,
+  exact byte sizes, and build-tool versions are recorded beside the ZIP.
+
+Before upload, independently verify the recorded checksum:
+
+```bash
+cd dist-crazygames
+shasum -a 256 -c snaketron-crazygames.zip.sha256
+unzip -tq snaketron-crazygames.zip
+```
+
+Drag **`dist-crazygames/snaketron-crazygames.zip`** into the CrazyGames
+Developer Portal Preview upload area. Keep the checksum and build report as the
+submission record; do not upload those two sidecar files. A report that records
+either source tree as dirty is suitable for local testing only—rebuild from the
+exact committed source used by the backend deployment before submission.
+Set `RELEASE_REQUIRE_CLEAN=true` to make either dirty state a build-stopping
+error; the default remains `false` so local review packages can still be made.
+
+## Developer Portal settings
+
+Use these values for the account-integrated package:
+
+- Progress Save: **Yes, linked to a game account on the game's backend, which
+  is associated with the CrazyGames User**
+- CrazyGames Data Module: **disabled**
+- External/email login in the CrazyGames build: **disabled**
+- CrazyGames account login: user-initiated secondary action; never an automatic
+  prompt or gameplay gate
+- Ads for the initial Basic Launch: **disabled**
 - Lobby sizes: **1, 2, 4**
-- Multiplayer: enabled / Online with Friends
-- Chat: enabled, with the SDK `disableChat` switch honored dynamically
-- Orientation: **landscape** (responsive HTML5 iframe)
+- Multiplayer: **enabled / Online with Friends**
+- Chat: **enabled**, with the SDK `disableChat` preference honored live
+- Orientation: **landscape**, responsive HTML5 iframe
 
-For a later Full Launch ad build, set `CRAZYGAMES_ADS_ENABLED=true`. Do not turn
-that flag on for Basic Launch.
+The backend-linked Progress Save choice and the Data Module choice are mutually
+exclusive descriptions of Snaketron's authoritative progress path. Enabling a
+Data Module preference experiment later does not change the fact that account
+progress is linked through Snaketron's backend.
 
-## Implemented pilot surface
+## Rollout order
 
-| Area | Basic Launch behavior |
-| --- | --- |
-| SDK/bootstrap | Initializes the HTML5 v3 SDK before React and treats `local`, `crazygames`, and `disabled` environments explicitly. |
-| Loading/gameplay | Reports loading around WASM/match loading and gameplay start/stop around actual controllable play, menus, countdowns, disconnects, and match completion. |
-| Game context | Sends non-sensitive match, mode, queue, and lobby context for actionable player feedback, then clears it on exit. |
-| Account UX | Hides Snaketron email/external login in the CrazyGames build. Both CrazyGames guests and signed-in CrazyGames players enter as Snaketron guests; signed-in players' CrazyGames name/avatar are displayed. The CrazyGames auth prompt is only opened by an explicit user click. |
-| Data | Uses the CrazyGames Data module for tutorial and gameplay/lobby preferences, with LocalStorage fallback. Tokens, reconnect state, MMR, XP, and server-authoritative state are never copied into SDK storage. |
-| Rooms/friends | Mirrors the real server lobby into `updateRoom`, using the globally unique region-prefixed lobby code as its stable room ID, joinability, and invite parameters. It calls `leftRoom`, consumes initial and live room joins, creates an immediate private lobby for Instant Multiplayer, and uses the SDK invite link for copy-link UX. CrazyGames' native friends UI can join/invite from this room state. |
-| Round continuity | Existing parties stay together after a match and one Play Again action queues the entire lobby. Per-member acknowledged match handoffs survive missed notifications and fast round cleanup, and play-to-play routes render immediately even in throttled portal tabs. A queued or in-progress room is reported non-joinable. |
-| Chat/UGC | Dynamically hides and blocks client chat when `disableChat` is true. Lobby and game chat are also profanity-filtered on the server before publish/history storage. |
-| Audio | Dynamically enforces `muteAudio` over current and newly-created HTML media and mutes while an ad is actually playing. |
-| Ads | A complete midgame/rewarded/banner adapter is present. UI is blocked from request through finish/error and ad failures fail open. The only midgame seam is the natural post-match break. Basic Launch makes every ad request a no-op and exposes no ineffective rewarded-ad button. |
-| Engagement | `happytime()` is reserved for a competitive win. Completion percentage is intentionally not reported because a replayable PvP match is not meaningful persistent game completion. |
-| Unsupported/invite-only SDKs | IAP and native leaderboards are explicitly capability-disabled for the pilot; no misleading UI is exposed. |
+1. Configure the verified portal game ID `60112` and both CDK contexts in the
+   development certification workflow.
+2. Deploy the backend exchange and persistence support before uploading a
+   client that depends on it.
+3. Verify forged, expired, wrong-algorithm, and wrong-game JWT rejection; key
+   fetch/cache/rotation; concurrent first login; and same-user restoration on
+   two devices.
+4. Verify guest play, guest-to-new-account promotion, known-account restoration,
+   portal profile rename, in-session login/reload, and two accounts sharing one
+   browser in CrazyGames Preview.
+5. Verify XP, both MMR values, rankings, high scores, match history, and
+   preferences survive reload and a second device.
+6. Run website and itch authentication regressions and confirm neither build
+   calls the CrazyGames exchange route.
+7. Keep the same pinned game ID contexts in both production CDK diff and
+   deploy, deploy the certified immutable server image, and verify the active
+   task definitions in both regions.
+8. Build the ZIP from that same reviewed source commit, verify its checksum,
+   upload it to Preview, and rerun the account matrix against production.
+9. Confirm the in-game `#/privacy` notice and monitored deletion contact,
+   select backend-linked Progress Save, keep Data Module off, and submit after
+   the manual checks below are complete.
 
-## Full Launch follow-up
+Do not disable backend exchange after account-linked users have launched except
+for an emergency. That makes returning players appear to lose progress. A
+client rollback should use the prior known-good account-linked package; identity
+mappings and progression records should be retained.
 
-These items are intentionally not presented as complete in the pilot:
+## Manual release checks
 
-1. Verify CrazyGames JWTs server-side with the published RS256 key, key backend
-   accounts by the immutable CrazyGames `userId`, auto-create/restore those
-   accounts, and handle auth-listener account changes. Never trust
-   `__dangerousUserId` from the browser.
-2. Define a server-authoritative rewarded-ad benefit before adding any rewarded
-   button. Keep the continue-without-ad action equally prominent.
-3. Add spectator/late-join support if CrazyGames QA requires joining rooms while
-   a round is in progress. The pilot accurately reports those rooms as closed.
-4. Add native leaderboard and IAP adapters only after CrazyGames grants access;
-   reconcile purchases and rewards on the server.
-5. Revisit player progression persistence when CrazyGames identity is linked;
-   MMR, XP, entitlements, and match results must remain server-authoritative.
-
-## Manual QA checklist
-
-- Load through the Developer Portal Preview at every advertised iframe size;
-  verify no horizontal scrollbars, clipped controls, custom fullscreen prompt,
-  or broken back navigation.
+- Load Preview at every advertised iframe size and verify no horizontal
+  scrollbar, clipped controls, custom fullscreen prompt, or broken back action.
 - Play Solo, 1v1, 2v2, and FFA; verify keyboard, touch, countdown, reconnect,
-  game-over, menu, and play-again flows.
-- Use `?disableChat=true` and confirm no chat UI/messages are available; remove
-  it and confirm censored lobby/game chat still works.
-- Use `?muteAudio=true` and confirm platform mute cannot be overridden.
-- Test signed-out and signed-in CrazyGames states, the user-initiated login
-  prompt, avatar/name rendering, and multi-tab/account-switch refresh behavior.
-- Test copied invite links, the CrazyGames friends drawer, joining while already
-  in another lobby, a full/queued lobby, and Instant Multiplayer launch.
-- Keep Basic Launch ads disabled and verify post-match does not freeze. In the
-  Full Launch sandbox, test filled, unfilled, error, and adblock paths.
-- Check the browser console/network log for SDK, CORS, mixed-content, WebSocket,
-  missing asset, and third-party tracker errors.
+  game-over, menu, and Play Again behavior.
+- Test `disableChat` and `muteAudio`, copied invite links, friends joining,
+  full/queued lobbies, Instant Multiplayer, and continuing as one party across
+  rounds.
+- Confirm signed-out play has no automatic login popup. Trigger login manually
+  and confirm the account resolves before matchmaking, invites, or WebSocket
+  identity-sensitive actions resume. For a new identity with an eligible guest,
+  exercise both answers to the standard account-link prompt: `yes` preserves
+  guest progress and settings, while `no` leaves them unattached. Confirm a
+  known CrazyGames identity does not receive an unnecessary link prompt.
+- In two clean browser profiles signed into the same CrazyGames account, confirm
+  the same Snaketron identity, progression, and preferences. Then switch one
+  browser to another CrazyGames account and confirm no old identity or lobby
+  state leaks.
+- Inspect the browser console/network log for SDK, CORS, mixed-content,
+  WebSocket, missing-asset, and third-party-tracker failures.
+- Confirm the portal displays the correct username/avatar and the privacy notice
+  is reachable from the game without blocking guest play.
 
-## Source requirements
+## Privacy and operations
 
-- <https://docs.crazygames.com/sdk/intro/>
-- <https://docs.crazygames.com/sdk/game/>
-- <https://docs.crazygames.com/sdk/video-ads/>
-- <https://docs.crazygames.com/sdk/banners/>
-- <https://docs.crazygames.com/sdk/user/>
-- <https://docs.crazygames.com/sdk/data/>
-- <https://docs.crazygames.com/requirements/gameplay/>
+The data inventory, player-facing notice, retention/deletion checklist, and
+incident guidance live in [CRAZYGAMES_PRIVACY.md](./CRAZYGAMES_PRIVACY.md). The
+CrazyGames-only footer links to the packaged `#/privacy` page, which lists the
+monitored contact `alerts@snaketron.io`; neither is shown in ordinary web/itch
+builds or blocks guest play.
+
+## Authoritative CrazyGames references
+
 - <https://docs.crazygames.com/requirements/account-integration/>
+- <https://docs.crazygames.com/sdk/user/>
+- <https://docs.crazygames.com/sdk/user-linking/user-linking-html5-v3/>
+- <https://docs.crazygames.com/sdk/data/>
+- <https://docs.crazygames.com/sdk/game/>
 - <https://docs.crazygames.com/requirements/multiplayer/>
-- <https://docs.crazygames.com/requirements/ads/>
 - <https://docs.crazygames.com/requirements/technical/>
+- <https://docs.crazygames.com/requirements/ads/>

--- a/CRAZYGAMES_PRIVACY.md
+++ b/CRAZYGAMES_PRIVACY.md
@@ -1,0 +1,110 @@
+# CrazyGames privacy and data-operations record
+
+This file is the release-owner record for Snaketron's CrazyGames account
+integration. It supplies the source-of-truth copy and operational data map for
+the packaged CrazyGames-only `#/privacy` page.
+
+CrazyGames requires a Terms and Conditions and/or Privacy Policy notice when a
+game collects personal data beyond SDK events. The notice should be visible to
+new players without turning sign-in into a blocking popup:
+<https://docs.crazygames.com/requirements/technical/#user-consent>
+
+## Player-facing notice copy
+
+The CrazyGames footer gives new players a concise notice and links to the
+packaged `#/privacy` page containing the following substance:
+
+> Snaketron uses your CrazyGames account ID, username, and profile picture to
+> sign you in automatically and keep your game progress available across
+> devices. We store your Snaketron profile, match results, XP, ratings, scores,
+> and game preferences on Snaketron's servers. Your CrazyGames sign-in token is
+> used only to verify your account and is not saved. Guests can play without
+> signing in; guest preferences are stored only in the current browser tab.
+> If an eligible guest later signs in to a new CrazyGames-linked account,
+> CrazyGames asks permission before Snaketron attaches that guest's progress
+> and settings. Declining leaves the guest data unattached. See our Privacy
+> Policy for retention, deletion requests, and contact information.
+
+Do not claim that CrazyGames itself stores Snaketron's XP, MMR, history, or
+preferences. Those records are stored by Snaketron and linked to a verified
+CrazyGames identity.
+
+## Data inventory
+
+| Data | Source | Purpose | Storage/handling |
+| --- | --- | --- | --- |
+| Immutable CrazyGames `userId` | Server-verified CrazyGames JWT | Stable account mapping and automatic login | Stored in the CrazyGames identity mapping; never accepted from `getUser()` or `__dangerousUserId` |
+| CrazyGames username and profile-picture URL | Server-verified JWT | Portal-consistent player identity | Stored as mutable profile metadata and refreshed only from newer verified claims |
+| CrazyGames JWT, `iat`, and `exp` | CrazyGames User module | One-time server authentication and freshness checks | JWT is held only long enough to exchange; never persist or log it. Minimal timestamps may be stored for profile update ordering |
+| Internal Snaketron user ID | Snaketron backend | Own all gameplay records independent of provider details | Durable server record linked one-to-one with the verified CrazyGames identity |
+| XP, MMR, rankings, high scores, results, and match ownership | Snaketron gameplay services | Progression, matchmaking, history, and competitive features | Durable, server-authoritative Snaketron records |
+| Tutorial, lobby, and input preferences | Player actions | Restore experience across devices | Snaketron backend for linked users; tab-scoped browser storage for signed-out guests |
+| Guest session and transient lobby/reconnect state | Snaketron client/server | Guest play and session continuity | Isolated from linked-account selection and cleared when identity changes require it |
+
+Snaketron does not need a CrazyGames player's email address or password. Do not
+add either to this flow. Do not put user IDs, usernames, JWTs, or profile URLs
+in metric dimensions. Authentication logs should contain bounded result classes
+such as `created`, `returning`, `guest_claimed`, `invalid_token`, `wrong_game`,
+`mapping_conflict`, `key_refresh`, and `provider_unavailable`, not credentials or
+raw provider identifiers.
+
+## Retention and deletion operations
+
+Before submission, the public policy must state a defensible retention period
+or criterion for account mappings, profile metadata, progression, match
+history, preferences, security logs, and backups. “Indefinitely” should not be
+used accidentally simply because no cleanup job exists.
+
+The public notice must provide one monitored deletion/contact route. A release
+owner must record each request, authenticate it without requesting a password
+Snaketron never collected, and identify every item keyed by either the internal
+Snaketron user ID or the CrazyGames identity mapping.
+
+Until an automated deletion flow exists, use this controlled procedure:
+
+1. Authenticate the requester through an approved support process and capture
+   the immutable CrazyGames identity only through a newly verified token or
+   CrazyGames-supported account evidence.
+2. Resolve the identity mapping to the internal Snaketron user ID without
+   copying raw identifiers into tickets, chat, or metrics.
+3. Enumerate the mapping, user profile, preferences, progression, rankings,
+   high scores, match/history ownership, active sessions, and applicable
+   backups before mutation.
+4. Apply the public retention policy and any record-preservation obligation.
+   Delete or anonymize all eligible records consistently; never delete only the
+   identity mapping and leave an unreachable personal profile.
+5. Revoke active Snaketron sessions, verify the mapping can no longer restore
+   the account, and record completion without retaining the deleted raw ID.
+
+This procedure is intentionally descriptive rather than a copy-paste database
+command: deleting only part of the DynamoDB record graph can corrupt rankings,
+history, or ownership. Add and test a transaction-aware deletion tool before
+processing deletion directly in production.
+
+## Security and incident checks
+
+- Accept only the configured JWT algorithm and validate signature, expiry,
+  issued-at time, claim types, and exact `gameId` on the server.
+- Cache CrazyGames' public key only with bounded freshness and retry a
+  single-flight refresh on signature failure, subject to the 30-second
+  forced-refresh cooldown and 5-second failed-fetch backoff, so key rotation
+  does not require a deployment and forged tokens cannot trigger unbounded
+  outbound requests.
+- Never log request bodies or authorization headers on the exchange route.
+- Rate-limit exchange attempts independently from gameplay APIs.
+- Alert on sustained invalid-token, wrong-game, mapping-conflict, public-key
+  refresh, and provider-unavailable rates without adding personal identifiers.
+- If a mapping collision or cross-account exposure is suspected, stop new
+  exchanges, preserve audit evidence, keep existing progression records, and
+  do not “repair” it by merging users automatically.
+
+## Release values required before submission
+
+Record these in the private release record, not in this repository:
+
+- CrazyGames portal game ID `60112`, verified against production/QA wrapper
+  metadata;
+- packaged `#/privacy` route and its CrazyGames-only footer notice;
+- monitored `alerts@snaketron.io` privacy/deletion contact and responsible owner;
+- approved retention periods and backup behavior; and
+- the uploaded ZIP's source commit and SHA-256 from the generated build report.

--- a/client/web/App.tsx
+++ b/client/web/App.tsx
@@ -21,14 +21,21 @@ import { UIProvider } from './contexts/UIContext';
 import { LatencyProvider } from './contexts/LatencyContext';
 import { CrazyGamesProvider, useCrazyGames } from './contexts/CrazyGamesContext';
 import { CrazyGamesAdOverlay, CrazyGamesBridge } from './components/CrazyGamesBridge';
+import { CrazyGamesPrivacy } from './components/CrazyGamesPrivacy';
 
 function AppContent() {
   const location = useLocation();
-  const { user } = useAuth();
+  const {
+    user,
+    crazyGamesSessionStatus,
+    crazyGamesSessionError,
+    retryCrazyGamesSession,
+  } = useAuth();
   const { isCrazyGamesBuild, showAuthPrompt } = useCrazyGames();
   const [isAuthModalOpen, setIsAuthModalOpen] = useState(false);
   const [accountModalView, setAccountModalView] = useState<AccountModalView | null>(null);
   const isGameArenaActive = matchPath('/play/:gameId', location.pathname) !== null;
+  const isCrazyGamesPrivacyPage = isCrazyGamesBuild && location.pathname === '/privacy';
   const showBackdrop = SHOW_BACKDROP_DURING_GAMEPLAY || !isGameArenaActive;
 
   const handleOpenAuth = useCallback(() => {
@@ -50,6 +57,51 @@ function AppContent() {
       setAccountModalView(null);
     }
   }, [user]);
+
+  if (
+    isCrazyGamesBuild &&
+    !isCrazyGamesPrivacyPage &&
+    crazyGamesSessionStatus === 'resolving'
+  ) {
+    return (
+      <main className="min-h-screen flex items-center justify-center px-6" aria-busy="true">
+        <div className="max-w-md border-2 border-black bg-white p-8 text-center shadow-[8px_8px_0_#000]">
+          <div
+            className="mx-auto mb-4 h-7 w-7 animate-spin rounded-full border-4 border-black/20 border-t-black"
+            aria-hidden="true"
+          />
+          <h1 className="text-xl font-black uppercase tracking-1">Connecting your account</h1>
+          <p className="mt-3 text-sm text-gray-600">
+            Restoring your Snaketron progress from CrazyGames…
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  if (
+    isCrazyGamesBuild &&
+    !isCrazyGamesPrivacyPage &&
+    crazyGamesSessionStatus === 'error'
+  ) {
+    return (
+      <main className="min-h-screen flex items-center justify-center px-6">
+        <div className="max-w-md border-2 border-black bg-white p-8 text-center shadow-[8px_8px_0_#000]" role="alert">
+          <h1 className="text-xl font-black uppercase tracking-1">Progress connection failed</h1>
+          <p className="mt-3 text-sm text-gray-600">
+            {crazyGamesSessionError ?? 'Your CrazyGames account could not be connected safely.'}
+          </p>
+          <button
+            type="button"
+            onClick={() => void retryCrazyGamesSession()}
+            className="mt-6 border-2 border-black bg-yellow-300 px-5 py-3 text-sm font-black uppercase tracking-1 hover:bg-yellow-200"
+          >
+            Retry account sync
+          </button>
+        </div>
+      </main>
+    );
+  }
 
   return (
     <div className="min-h-screen flex flex-col">
@@ -77,6 +129,10 @@ function AppContent() {
         />
         <Route path="/profile" element={<Navigate to="/" replace />} />
         <Route path="/history" element={<Navigate to="/" replace />} />
+        <Route
+          path="/privacy"
+          element={isCrazyGamesBuild ? <CrazyGamesPrivacy /> : <Navigate to="/" replace />}
+        />
         <Route
           path="/game-modes/:category"
           element={isCrazyGamesBuild ? <Navigate to="/" replace /> : <GameModeSelector />}

--- a/client/web/bootstrap.ts
+++ b/client/web/bootstrap.ts
@@ -1,14 +1,14 @@
 // A dependency graph that contains any wasm must all be imported
-// asynchronously. Initialize the portal SDK first so its cloud data and
-// settings are ready before React reads any persisted preferences.
+// asynchronously. Initialize the portal SDK first so account availability and
+// settings are resolved before React selects its session/storage path.
 import('./services/crazyGames')
   .then(async ({ crazyGames }) => {
     await crazyGames.init();
     crazyGames.loadingStart();
   })
   .catch((error) => {
-    // The game deliberately remains playable if the SDK script is blocked or
-    // the build is hosted outside an enabled CrazyGames environment.
+    // Continue to the React shell so it can expose the deterministic account
+    // error/guest path instead of leaving a blank iframe.
     console.error('CrazyGames initialization failed:', error);
   })
   .then(() => import('./main'))

--- a/client/web/components/CrazyGamesBridge.tsx
+++ b/client/web/components/CrazyGamesBridge.tsx
@@ -23,11 +23,18 @@ export const CrazyGamesBridge: React.FC = () => {
     isInstantMultiplayer,
     inviteParams,
     inviteSequence,
+    authChangeSequence,
     portalUser,
     settings: { muteAudio },
     adState,
   } = useCrazyGames();
-  const { user, loading: authLoading, createGuest, updateGuestNickname } = useAuth();
+  const {
+    user,
+    loading: authLoading,
+    ensurePlayableSession,
+    beginCrazyGamesAccountTransition,
+    crazyGamesAccountTransitionSequence,
+  } = useAuth();
   const {
     isConnected,
     isSessionAuthenticated,
@@ -36,13 +43,19 @@ export const CrazyGamesBridge: React.FC = () => {
     lobbyMembers,
     createLobby,
     leaveLobby,
-    sendMessage,
     waitForSessionReady,
+    clearSessionForAccountChange,
   } = useWebSocket();
   const reportedRoomRef = useRef<string | null>(null);
   const handledInviteSequenceRef = useRef(0);
   const instantMultiplayerCompleteRef = useRef(false);
   const instantMultiplayerInFlightRef = useRef(false);
+  const observedAuthChangeSequenceRef = useRef(authChangeSequence);
+  // Provider-owned transitions start at zero and remain observable even when
+  // one was recorded on the render boundary immediately before this bridge
+  // mounted. SDK sequence itself may legitimately predate AuthProvider.
+  const observedAccountTransitionSequenceRef = useRef(0);
+  const accountReloadInFlightRef = useRef(false);
   const [instantRetry, setInstantRetry] = useState(0);
 
   useEffect(() => {
@@ -84,32 +97,48 @@ export const CrazyGamesBridge: React.FC = () => {
   }, [adState, isCrazyGamesBuild, muteAudio]);
 
   useEffect(() => {
-    if (
-      !isCrazyGamesBuild ||
-      !portalUser ||
-      !user?.isGuest ||
-      !isSessionAuthenticated
-    ) {
+    if (!isCrazyGamesBuild) {
       return;
     }
-
-    const portalNickname = crazyGamesGuestNickname(portalUser.username);
-    if (portalNickname === user.username) {
+    const sdkIdentityChanged = authChangeSequence > observedAuthChangeSequenceRef.current;
+    const backendIdentityChanged = crazyGamesAccountTransitionSequence >
+      observedAccountTransitionSequenceRef.current;
+    if (!sdkIdentityChanged && !backendIdentityChanged) {
       return;
     }
-
-    if (sendMessage({ UpdateNickname: { nickname: portalNickname } })) {
-      // Keep every same-page roster/chat action aligned while the server
-      // durably updates the guest and refreshes this socket's metadata.
-      updateGuestNickname(portalNickname);
+    observedAuthChangeSequenceRef.current = authChangeSequence;
+    observedAccountTransitionSequenceRef.current = crazyGamesAccountTransitionSequence;
+    if (accountReloadInFlightRef.current) {
+      return;
     }
+    accountReloadInFlightRef.current = true;
+    beginCrazyGamesAccountTransition();
+
+    const completeAccountChange = async () => {
+      if (currentLobby && isSessionAuthenticated) {
+        try {
+          await Promise.race([
+            leaveLobby(),
+            new Promise<void>((resolve) => setTimeout(resolve, 1500)),
+          ]);
+        } catch (error) {
+          console.warn('Could not leave the current lobby before switching accounts', error);
+        }
+      }
+      crazyGames.leftRoom();
+      clearSessionForAccountChange();
+      window.location.reload();
+    };
+    void completeAccountChange();
   }, [
+    authChangeSequence,
+    beginCrazyGamesAccountTransition,
+    clearSessionForAccountChange,
+    crazyGamesAccountTransitionSequence,
+    currentLobby,
     isCrazyGamesBuild,
     isSessionAuthenticated,
-    portalUser,
-    sendMessage,
-    updateGuestNickname,
-    user,
+    leaveLobby,
   ]);
 
   useEffect(() => {
@@ -208,7 +237,9 @@ export const CrazyGamesBridge: React.FC = () => {
     const createInstantRoom = async () => {
       try {
         if (!user) {
-          await createGuest(crazyGamesGuestNickname(portalUser?.username));
+          await ensurePlayableSession(crazyGamesGuestNickname(portalUser?.username));
+        } else {
+          await ensurePlayableSession();
         }
         await waitForSessionReady();
         await createLobby();
@@ -230,7 +261,7 @@ export const CrazyGamesBridge: React.FC = () => {
   }, [
     authLoading,
     available,
-    createGuest,
+    ensurePlayableSession,
     createLobby,
     currentLobby,
     instantRetry,

--- a/client/web/components/CrazyGamesPrivacy.tsx
+++ b/client/web/components/CrazyGamesPrivacy.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+export const CrazyGamesPrivacy: React.FC = () => (
+  <main className="min-h-screen px-5 py-10 text-gray-900">
+    <article className="mx-auto max-w-2xl border-2 border-black bg-white p-6 shadow-[8px_8px_0_#000] sm:p-10">
+      <Link to="/" className="text-sm font-bold text-blue-700 hover:underline">
+        ← Back to Snaketron
+      </Link>
+      <h1 className="mt-6 text-3xl font-black uppercase tracking-1">Privacy on CrazyGames</h1>
+      <p className="mt-5 leading-7">
+        Snaketron uses your CrazyGames account ID, username, and profile picture to sign you in
+        automatically and keep your game progress available across devices.
+      </p>
+
+      <h2 className="mt-8 text-lg font-black uppercase">What Snaketron stores</h2>
+      <ul className="mt-3 list-disc space-y-2 pl-6 leading-6">
+        <li>Your verified CrazyGames account ID and current profile name and picture.</li>
+        <li>Your Snaketron profile, XP, ratings, rankings, scores, match results, and history.</li>
+        <li>Your tutorial, lobby, and control preferences.</li>
+      </ul>
+
+      <h2 className="mt-8 text-lg font-black uppercase">How sign-in works</h2>
+      <p className="mt-3 leading-7">
+        CrazyGames gives Snaketron a short-lived sign-in token. Snaketron sends it directly to its
+        server for verification and does not save it. We do not receive your CrazyGames password or
+        email address. After verification, a separate Snaketron session token and a local preference
+        mirror are kept only in the current browser tab, including across reloads; the server remains
+        the source of truth for linked-account progress and settings. Signed-out guests can play
+        without an account and keep their settings in that tab. When the current authenticated guest
+        later signs in to a new CrazyGames-linked account, CrazyGames asks for permission before the
+        server attaches eligible guest progress and settings in one verified transaction. If you
+        decline, the CrazyGames-linked account starts without that guest data.
+      </p>
+
+      <h2 className="mt-8 text-lg font-black uppercase">Retention and deletion</h2>
+      <p className="mt-3 leading-7">
+        Account mappings and gameplay records are retained while needed to provide your Snaketron
+        account, progression, multiplayer history, integrity, and security. You may request deletion
+        or ask what is stored by emailing{' '}
+        <a className="font-bold text-blue-700 hover:underline" href="mailto:alerts@snaketron.io">
+          alerts@snaketron.io
+        </a>.
+        We will verify the request through your CrazyGames account, revoke active sessions, and
+        delete or anonymize eligible account, profile, preference, and gameplay records. Records that
+        must temporarily remain for security, legal obligations, or backup expiry are isolated and
+        removed when that period ends.
+      </p>
+
+      <p className="mt-8 border-t border-gray-300 pt-5 text-sm text-gray-600">
+        Last updated August 9, 2026.
+      </p>
+    </article>
+  </main>
+);

--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { useDebouncedValue } from '../hooks/useDebouncedValue';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
@@ -10,7 +10,6 @@ import {
   persistStoredLobbyPreferences,
 } from '../utils/lobbyPreferencesStorage';
 import { useCrazyGames } from '../contexts/CrazyGamesContext';
-import { crazyGamesGuestNickname } from '../services/crazyGames';
 import { useInputSurface } from '../hooks/useInputSurface';
 
 const areModeSetsEqual = (a: Set<LobbyGameMode> | null, b: Set<LobbyGameMode> | null) => {
@@ -59,24 +58,18 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
   errorMessage = null,
   playersOnline = null,
 }) => {
-  const { isCrazyGamesBuild, portalUser, userAccountAvailable } = useCrazyGames();
-  const portalNickname = useMemo(
-    () => portalUser ? crazyGamesGuestNickname(portalUser.username) : '',
-    [portalUser?.username],
-  );
-  // A signed-in CrazyGames profile is the recognizable multiplayer identity.
-  // If an existing backend guest was restored, the debounced update below
-  // renames that guest to the latest portal display name.
-  const effectiveUsername = portalNickname || currentUsername || '';
-  const hasPlatformIdentity = Boolean(isCrazyGamesBuild && portalUser);
-  const locksNickname = isAuthenticated || hasPlatformIdentity;
+  const { isCrazyGamesBuild, userAccountAvailable } = useCrazyGames();
+  const effectiveUsername = currentUsername || '';
   const [nickname, setNickname] = useState(effectiveUsername);
   const [hasAutoSetNickname, setHasAutoSetNickname] = useState(false);
   const [selectedModes, setSelectedModes] = useState<Set<LobbyGameMode> | null>(null);
   const [isCompetitive, setIsCompetitive] = useState<boolean | null>(null);
   const nicknameInputRef = useRef<HTMLInputElement>(null);
   const lastSubmittedNicknameRef = useRef<string | null>(null);
-  const { user, updateGuestNickname } = useAuth();
+  const { user, updateGuestNickname, crazyGamesSessionStatus } = useAuth();
+  const locksNickname = isAuthenticated || (
+    isCrazyGamesBuild && crazyGamesSessionStatus === 'linked'
+  );
   const { sendMessage } = useWebSocket();
   const prevUsernameRef = useRef<string | null>(null);
   const canEdit = !isLobbyQueued;
@@ -152,14 +145,12 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
 
     if (prevUsernameRef.current !== effectiveUsername) {
       setNickname(effectiveUsername);
-      // CrazyGamesBridge owns the server rename for portal identities so it
-      // works on invite/game routes too; do not duplicate that WS command here.
-      lastSubmittedNicknameRef.current = hasPlatformIdentity || effectiveUsername === currentUsername
+      lastSubmittedNicknameRef.current = effectiveUsername === currentUsername
         ? effectiveUsername
         : null;
       prevUsernameRef.current = effectiveUsername;
     }
-  }, [currentUsername, effectiveUsername, hasAutoSetNickname, hasPlatformIdentity]);
+  }, [currentUsername, effectiveUsername, hasAutoSetNickname]);
 
   useEffect(() => {
     if (!user || !user.isGuest) {
@@ -301,6 +292,12 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
                   {isCrazyGamesBuild ? 'Sign in with CrazyGames' : 'Sign in or create account'}
                 </button>
               )}
+            </div>
+          )}
+
+          {locksNickname && isCrazyGamesBuild && crazyGamesSessionStatus === 'linked' && (
+            <div className="mt-2 px-1 text-[13px] font-semibold text-green-700">
+              CrazyGames account linked · progress saves automatically
             </div>
           )}
 

--- a/client/web/components/HomeHeader.tsx
+++ b/client/web/components/HomeHeader.tsx
@@ -42,7 +42,7 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
   onOpenAccount,
   onLogout,
 }) => {
-  const { isCrazyGamesBuild, portalUser, userAccountAvailable } = useCrazyGames();
+  const { isCrazyGamesBuild, userAccountAvailable } = useCrazyGames();
   const fullscreen = useFullscreen();
   const inputSurface = useInputSurface();
   // The CrazyGames portal owns fullscreen chrome, and desktop users have F11;
@@ -212,18 +212,21 @@ export const HomeHeader: React.FC<HomeHeaderProps> = ({
             </button>
           )}
           {isCrazyGamesBuild ? (
-            portalUser ? (
+            currentUser?.authSource === 'crazygames' ? (
               <div
                 className="home-account-action flex items-center gap-2"
-                aria-label={`Playing as ${portalUser.username} through CrazyGames`}
+                aria-label={`Playing as ${currentUser.username} through CrazyGames; progress saves automatically`}
+                title="CrazyGames account linked · progress saves automatically"
               >
-                <img
-                  src={portalUser.profilePictureUrl}
-                  alt=""
-                  className="h-7 w-7 rounded-full border border-black/20 object-cover"
-                  referrerPolicy="no-referrer"
-                />
-                <span className="home-account-username">{portalUser.username}</span>
+                {currentUser.avatarUrl && (
+                  <img
+                    src={currentUser.avatarUrl}
+                    alt=""
+                    className="h-7 w-7 rounded-full border border-black/20 object-cover"
+                    referrerPolicy="no-referrer"
+                  />
+                )}
+                <span className="home-account-username">{currentUser.username}</span>
               </div>
             ) : (
               <button

--- a/client/web/components/JoinGameModal.tsx
+++ b/client/web/components/JoinGameModal.tsx
@@ -2,6 +2,7 @@ import React, { useId, useRef, useState } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
 import { FormEventHandler, JoinGameModalProps } from '../types';
+import { gameStorage } from '../services/gameStorage';
 import {
   getLobbyCodeValidationError,
   normalizeLobbyCodeInput,
@@ -13,7 +14,7 @@ const generateGuestNickname = (): string =>
 
 const guestNickname = (): string => {
   try {
-    const savedNickname = window.localStorage.getItem('savedUsername')?.trim();
+    const savedNickname = gameStorage.getItem('savedUsername')?.trim();
     if (savedNickname && savedNickname.length >= 3) {
       return savedNickname;
     }
@@ -55,7 +56,7 @@ const joinErrorMessage = (error: unknown): string => {
 };
 
 function JoinGameModal({ isOpen, onClose }: JoinGameModalProps) {
-  const { user, createGuest, loading: isAuthLoading } = useAuth();
+  const { user, ensurePlayableSession, loading: isAuthLoading } = useAuth();
   const { isConnected, joinLobby } = useWebSocket();
   const [codeInput, setCodeInput] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -97,8 +98,8 @@ function JoinGameModal({ isOpen, onClose }: JoinGameModalProps) {
     try {
       if (!user) {
         setJoinStatus('creating-guest');
-        await createGuest(guestNickname());
       }
+      await ensurePlayableSession(guestNickname());
 
       setJoinStatus('joining');
       await joinLobby(lobbyCode);

--- a/client/web/components/LobbyInvitePage.tsx
+++ b/client/web/components/LobbyInvitePage.tsx
@@ -1,9 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { useCrazyGames } from '../contexts/CrazyGamesContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
-import { crazyGamesGuestNickname } from '../services/crazyGames';
 import { User } from '../types';
 
 const generateGuestNickname = (lobbyCode: string) => {
@@ -16,8 +14,7 @@ const LobbyInvitePage: React.FC = () => {
   const { lobbyCode: rawCode } = useParams<{ lobbyCode: string }>();
   const lobbyCode = (rawCode ?? '').toUpperCase();
   const navigate = useNavigate();
-  const { isCrazyGamesBuild, portalUser } = useCrazyGames();
-  const { user, createGuest, loading: authLoading, getToken } = useAuth();
+  const { user, ensurePlayableSession, loading: authLoading, getToken } = useAuth();
   const { isConnected, joinLobby, waitForSessionReady } = useWebSocket();
 
   const inFlightRef = useRef(false);
@@ -33,19 +30,11 @@ const LobbyInvitePage: React.FC = () => {
   }, [user]);
 
   const ensureAuthenticatedSession = useCallback(async () => {
-    let activeUser = latestUserRef.current;
-    let resolvedToken: string | null = getToken();
-
-    if (!activeUser) {
-      setStatusMessage('Creating guest profile…');
-      const guestNickname = isCrazyGamesBuild
-        ? crazyGamesGuestNickname(portalUser?.username)
-        : generateGuestNickname(lobbyCode);
-      const { user: guestUser, token } = await createGuest(guestNickname);
-      latestUserRef.current = guestUser;
-      activeUser = guestUser;
-      resolvedToken = token;
-    }
+    setStatusMessage(latestUserRef.current ? 'Verifying player session…' : 'Creating player profile…');
+    const { user: activeUser, token: resolvedToken } = await ensurePlayableSession(
+      generateGuestNickname(lobbyCode),
+    );
+    latestUserRef.current = activeUser;
 
     setStatusMessage('Authenticating session…');
     const token = resolvedToken ?? getToken();
@@ -55,11 +44,9 @@ const LobbyInvitePage: React.FC = () => {
 
     await waitForSessionReady();
   }, [
-    createGuest,
+    ensurePlayableSession,
     getToken,
-    isCrazyGamesBuild,
     lobbyCode,
-    portalUser?.username,
     waitForSessionReady,
   ]);
 

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -25,7 +25,7 @@ interface NewHomeProps {
 
 export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) => {
   const navigate = useNavigate();
-  const { user, createGuest, logout } = useAuth();
+  const { user, ensurePlayableSession, logout } = useAuth();
   const {
     connectToRegion,
     isConnected,
@@ -114,10 +114,9 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
     setIsLoading(true);
     setStartError(null);
     try {
-      // If not logged in, create guest user
-      if (!user) {
-        await createGuest(nickname);
-      }
+      // In CrazyGames this waits for verified account restoration before it
+      // may create a guest. In other builds it preserves the existing flow.
+      await ensurePlayableSession(nickname);
 
       // Wait for the active regional socket to acknowledge this exact session
       // before issuing lobby or matchmaking commands.
@@ -177,13 +176,11 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
 
     setIsCreatingInvite(true);
     try {
-      if (!user) {
-        try {
-          await createGuest(generateGuestNickname());
-        } catch (error) {
-          console.error('Guest creation failed for lobby invite:', error);
-          return;
-        }
+      try {
+        await ensurePlayableSession(generateGuestNickname());
+      } catch (error) {
+        console.error('Player session creation failed for lobby invite:', error);
+        return;
       }
 
       await waitForSessionReady();

--- a/client/web/components/SocialFooter.tsx
+++ b/client/web/components/SocialFooter.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
+import { useCrazyGames } from '../contexts/CrazyGamesContext';
 
 export const SocialFooter: React.FC = () => {
   const currentYear = new Date().getFullYear();
+  const { isCrazyGamesBuild } = useCrazyGames();
 
   return (
     <footer className="home-social-footer">
@@ -42,6 +45,14 @@ export const SocialFooter: React.FC = () => {
         </span>
 
       </div>
+      {isCrazyGamesBuild && (
+        <p className="mx-auto mb-2 max-w-md px-4 text-center text-xs text-gray-600">
+          Signed-in play uses your CrazyGames profile and saves progress on Snaketron servers.{' '}
+          <Link to="/privacy" className="font-semibold text-blue-700 hover:underline">
+            Privacy &amp; data deletion
+          </Link>
+        </p>
+      )}
       <p className="home-copyright">© {currentYear} Snaketron</p>
     </footer>
   );

--- a/client/web/contexts/AuthContext.tsx
+++ b/client/web/contexts/AuthContext.tsx
@@ -1,9 +1,55 @@
-import React, { createContext, useContext, useState, useEffect, useCallback } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { api, AUTH_TOKEN_STORAGE_KEY, isApiError } from '../services/api';
-import { AuthContextType, User } from '../types';
+import {
+  CRAZY_GAMES_PREFERENCE_KEYS,
+  applyCrazyGamesPreferences,
+  clearLinkedCrazyGamesPreferences,
+  crazyGamesPreferenceOwner,
+  markCrazyGamesPreferencesOwnedBy,
+  readCrazyGamesPreferences,
+} from '../services/crazyGamesPreferences';
+import { gameStorage, subscribeGameStorage } from '../services/gameStorage';
+import { CrazyGamesAccountException } from '../services/crazyGames';
+import { useCrazyGames } from './CrazyGamesContext';
+import {
+  AuthContextType,
+  CrazyGamesSessionStatus,
+  User,
+} from '../types';
 
 const AuthContext = createContext<AuthContextType | null>(null);
+const IS_CRAZY_GAMES_BUILD = process.env.CRAZYGAMES_BUILD === 'true';
+const SESSION_RENEWAL_LEAD_MS = 5 * 60 * 1000;
+const MIN_RENEWAL_DELAY_MS = 30 * 1000;
+const PREFERENCE_SAVE_DELAY_MS = 750;
+const PREFERENCE_RETRY_MAX_MS = 30 * 1000;
+const ACCOUNT_REQUEST_TIMEOUT_MS = 15 * 1000;
+
+const withTimeout = async <T,>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  label: string,
+): Promise<T> => {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_resolve, reject) => {
+        timer = setTimeout(() => reject(new Error(`${label} timed out`)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+};
 
 export const useAuth = (): AuthContextType => {
   const context = useContext(AuthContext);
@@ -17,90 +63,658 @@ interface AuthProviderProps {
   children: React.ReactNode;
 }
 
-export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-  const navigate = useNavigate();
+const accountErrorMessage = (error: unknown): string => {
+  if (error instanceof CrazyGamesAccountException) {
+    if (error.code === 'sdkUnavailable' || error.code === 'userAccountUnavailable') {
+      return 'CrazyGames account services are unavailable. Retry before playing.';
+    }
+    if (error.code === 'invalidToken') {
+      return 'CrazyGames could not verify this account. Please retry.';
+    }
+  }
+  if (isApiError(error)) {
+    if (error.response.status === 401 || error.response.status === 403) {
+      return 'CrazyGames could not verify this account. Please retry.';
+    }
+    if (error.response.status >= 500) {
+      return 'Account progress is temporarily unavailable. Retry before playing.';
+    }
+  }
+  return 'We could not connect your CrazyGames account. Retry before playing.';
+};
 
-  // Check if user is logged in on mount
-  useEffect(() => {
-    const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
-    if (token) {
-      fetchCurrentUser();
-    } else {
-      setLoading(false);
+const isGuestLinkConsentRequired = (error: unknown): boolean => {
+  if (!isApiError(error) || error.response.status !== 409) {
+    return false;
+  }
+  const data = error.response.data;
+  return Boolean(
+    data &&
+    typeof data === 'object' &&
+    (data as Record<string, unknown>).code === 'guestLinkConsentRequired',
+  );
+};
+
+const fallbackGuestNickname = (): string =>
+  `CGPlayer${Math.floor(1000 + Math.random() * 9000)}`;
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const {
+    getUserToken,
+    showAccountLinkPrompt,
+    authChangeSequence,
+    accountError: crazyGamesSdkAccountError,
+  } = useCrazyGames();
+  const [user, setUserState] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [crazyGamesSessionStatus, setCrazyGamesSessionStatusState] =
+    useState<CrazyGamesSessionStatus>(
+      IS_CRAZY_GAMES_BUILD ? 'resolving' : 'not-applicable',
+    );
+  const [crazyGamesSessionError, setCrazyGamesSessionError] = useState<string | null>(null);
+  const [sessionExpiresAt, setSessionExpiresAt] = useState<number | null>(null);
+  const [initialResolutionComplete, setInitialResolutionComplete] = useState(
+    !IS_CRAZY_GAMES_BUILD,
+  );
+  const [crazyGamesAccountTransitionSequence, setCrazyGamesAccountTransitionSequence] =
+    useState(0);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const isCrazyGamesPrivacyPage =
+    IS_CRAZY_GAMES_BUILD && location.pathname === '/privacy';
+
+  const userRef = useRef<User | null>(null);
+  const statusRef = useRef<CrazyGamesSessionStatus>(crazyGamesSessionStatus);
+  const generationRef = useRef(0);
+  const resolutionFlightRef = useRef<Promise<void> | null>(null);
+  const guestFlightRef = useRef<Promise<{ user: User; token: string }> | null>(null);
+  const expiresAtRef = useRef<number | null>(null);
+  const renewalRetryTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preferenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preferenceRetryRef = useRef(0);
+  const applyingPreferencesRef = useRef(false);
+  const resolveAccountRef = useRef<((background?: boolean) => Promise<void>) | null>(null);
+  const observedInitialAuthChangeRef = useRef(authChangeSequence);
+  const preferenceSaveInFlightRef = useRef(false);
+  const preferenceDirtyRef = useRef(false);
+  const preferenceRevisionRef = useRef(0);
+
+  const setUser = useCallback((next: User | null) => {
+    userRef.current = next;
+    setUserState(next);
+  }, []);
+
+  const setCrazyGamesSessionStatus = useCallback((next: CrazyGamesSessionStatus) => {
+    statusRef.current = next;
+    setCrazyGamesSessionStatusState(next);
+  }, []);
+
+  const clearRenewalRetry = useCallback(() => {
+    if (renewalRetryTimerRef.current) {
+      clearTimeout(renewalRetryTimerRef.current);
+      renewalRetryTimerRef.current = null;
     }
   }, []);
 
-  const fetchCurrentUser = async () => {
-    try {
-      const userInfo = await api.getCurrentUser();
-      setUser(userInfo);
-    } catch (err) {
-      console.error('Failed to fetch current user:', err);
-      const status = isApiError(err) ? err.response.status : undefined;
-      const isAuthError = status === 401 || status === 403;
-      const isAbortError = err instanceof Error && err.name === 'AbortError';
-
-      // Only clear the token for real auth failures, not for transient/aborted requests
-      if (isAuthError) {
-        api.setAuthToken(null);
-      } else if (isAbortError) {
-        console.debug('Fetch aborted while loading user; keeping existing auth token');
+  const becomeCrazyGamesGuest = useCallback(async (expectedGeneration: number) => {
+    // A portal sign-out must never resurrect a linked account from storage.
+    // A server-verified guest token may be restored for same-tab
+    // continuity; every other cached identity is discarded.
+    const cachedToken = api.getAuthToken();
+    let cachedGuest: User | null = null;
+    let shouldClearToken = false;
+    let shouldClearPreferences = false;
+    if (cachedToken) {
+      try {
+        const cachedUser = await withTimeout(
+          api.getCurrentUser(),
+          ACCOUNT_REQUEST_TIMEOUT_MS,
+          'Guest session check',
+        );
+        if (cachedUser.isGuest) {
+          cachedGuest = { ...cachedUser, isGuest: true };
+        } else {
+          shouldClearToken = true;
+          shouldClearPreferences = true;
+        }
+      } catch (error) {
+        // A timeout, offline browser, or 5xx response is not evidence that a
+        // stored guest belongs to a different person. Keep its token and
+        // preferences dormant, fail closed, and let Retry verify it later.
+        if (
+          !isApiError(error) ||
+          (error.response.status !== 401 && error.response.status !== 403)
+        ) {
+          throw error;
+        }
+        shouldClearToken = true;
+        // An expired guest JWT is also unauthorized. Preserve ownerless
+        // browser settings; only a recorded linked owner proves the snapshot
+        // must be removed before guest play.
+        shouldClearPreferences = crazyGamesPreferenceOwner() !== null;
       }
-    } finally {
-      setLoading(false);
     }
-  };
+
+    if (expectedGeneration !== generationRef.current) {
+      return;
+    }
+    clearRenewalRetry();
+    expiresAtRef.current = null;
+    setSessionExpiresAt(null);
+    clearLinkedCrazyGamesPreferences(shouldClearPreferences);
+    if (shouldClearToken) api.setAuthToken(null);
+    setUser(cachedGuest);
+
+    setCrazyGamesSessionError(null);
+    setCrazyGamesSessionStatus('guest');
+    setLoading(false);
+    setInitialResolutionComplete(true);
+  }, [clearRenewalRetry, setCrazyGamesSessionStatus, setUser]);
+
+  const scheduleRenewalRetry = useCallback(() => {
+    clearRenewalRetry();
+    renewalRetryTimerRef.current = setTimeout(() => {
+      renewalRetryTimerRef.current = null;
+      void resolveAccountRef.current?.(true);
+    }, MIN_RENEWAL_DELAY_MS);
+  }, [clearRenewalRetry]);
+
+  const eligibleGuestInitialPreferences = useCallback(() => {
+    // The exchange transaction is the authoritative guest eligibility gate:
+    // the backend imports this optional snapshot only for GuestClaimed and
+    // ignores it for Created/Returning. Avoid a preliminary /me request that
+    // could fail transiently and silently drop a valid guest's settings.
+    if (crazyGamesPreferenceOwner() !== null || !api.getAuthToken()) {
+      return undefined;
+    }
+    const preferences = readCrazyGamesPreferences();
+    return Object.keys(preferences).length > 0 ? preferences : undefined;
+  }, []);
+
+  const resolveCrazyGamesAccount = useCallback((background = false): Promise<void> => {
+    if (!IS_CRAZY_GAMES_BUILD) {
+      return Promise.resolve();
+    }
+    if (resolutionFlightRef.current) {
+      return resolutionFlightRef.current;
+    }
+
+    const generation = ++generationRef.current;
+    if (!background) {
+      setLoading(true);
+      setCrazyGamesSessionStatus('resolving');
+      setCrazyGamesSessionError(null);
+      setUser(null);
+    }
+
+    const flight = (async () => {
+      try {
+        // Always ask the SDK. portalUser is intentionally not consulted:
+        // getUser() is display-only and can finish after token retrieval.
+        const crazyGamesToken = await withTimeout(
+          getUserToken(),
+          ACCOUNT_REQUEST_TIMEOUT_MS,
+          'CrazyGames sign-in',
+        );
+        const hasAttachedInternalSession = api.getAuthToken() !== null;
+        let response;
+        try {
+          response = await withTimeout(
+            api.exchangeCrazyGamesToken(
+              crazyGamesToken,
+              hasAttachedInternalSession ? 'check' : 'decline',
+            ),
+            ACCOUNT_REQUEST_TIMEOUT_MS,
+            'CrazyGames account exchange',
+          );
+        } catch (error) {
+          if (!hasAttachedInternalSession || !isGuestLinkConsentRequired(error)) {
+            throw error;
+          }
+
+          const consent = await showAccountLinkPrompt();
+          if (consent === null) {
+            throw new Error('CrazyGames account linking was not completed');
+          }
+
+          if (consent === 'no') {
+            response = await withTimeout(
+              api.exchangeCrazyGamesToken(crazyGamesToken, 'decline'),
+              ACCOUNT_REQUEST_TIMEOUT_MS,
+              'CrazyGames account exchange',
+            );
+          } else if (consent === 'yes') {
+            const initialPreferences = eligibleGuestInitialPreferences();
+            try {
+              response = await withTimeout(
+                api.exchangeCrazyGamesToken(
+                  crazyGamesToken,
+                  'allow',
+                  initialPreferences,
+                ),
+                ACCOUNT_REQUEST_TIMEOUT_MS,
+                'CrazyGames account exchange',
+              );
+            } catch (preferenceError) {
+              // Optional legacy preferences must never brick a consented
+              // guest claim. Retry the same credential and consent without
+              // the optional snapshot when only that payload is rejected.
+              if (
+                !initialPreferences ||
+                !isApiError(preferenceError) ||
+                preferenceError.response.status !== 400
+              ) {
+                throw preferenceError;
+              }
+              response = await withTimeout(
+                api.exchangeCrazyGamesToken(crazyGamesToken, 'allow'),
+                ACCOUNT_REQUEST_TIMEOUT_MS,
+                'CrazyGames account exchange',
+              );
+            }
+          } else {
+            throw new Error('CrazyGames returned an invalid account-link decision');
+          }
+        }
+
+        if (generation !== generationRef.current) {
+          return;
+        }
+        if (
+          !response ||
+          typeof response.token !== 'string' ||
+          response.token.length === 0 ||
+          !response.user ||
+          !Number.isSafeInteger(response.user.id) ||
+          response.user.authSource !== 'crazygames' ||
+          !Number.isFinite(response.expiresAt) ||
+          !response.preferences ||
+          typeof response.preferences !== 'object' ||
+          Array.isArray(response.preferences)
+        ) {
+          throw new Error('CrazyGames exchange returned an invalid session');
+        }
+
+        if (
+          background &&
+          userRef.current &&
+          response.user.id !== userRef.current.id
+        ) {
+          // Do not replace identity inside an active game if the SDK event was
+          // delayed or absent. The mounted bridge performs leave/clear/reload.
+          setCrazyGamesAccountTransitionSequence((value) => value + 1);
+          return;
+        }
+
+        if (!background) {
+          applyingPreferencesRef.current = true;
+          try {
+            applyCrazyGamesPreferences(response.preferences, true);
+            markCrazyGamesPreferencesOwnedBy(response.user.id);
+          } finally {
+            applyingPreferencesRef.current = false;
+          }
+        }
+
+        // The portal token is now out of scope and is never written to any
+        // browser store. Only the ordinary internal Snaketron JWT is retained.
+        api.setAuthToken(response.token);
+        setUser({
+          ...response.user,
+          isGuest: false,
+          authSource: 'crazygames',
+          avatarUrl: response.user.avatarUrl ?? null,
+        });
+        expiresAtRef.current = response.expiresAt;
+        setSessionExpiresAt(response.expiresAt);
+        clearRenewalRetry();
+        setCrazyGamesSessionError(null);
+        setCrazyGamesSessionStatus('linked');
+        setLoading(false);
+        setInitialResolutionComplete(true);
+      } catch (error) {
+        if (generation !== generationRef.current) {
+          return;
+        }
+
+        if (
+          error instanceof CrazyGamesAccountException &&
+          (error.code === 'userNotAuthenticated' || error.code === 'userAccountUnavailable')
+        ) {
+          try {
+            await becomeCrazyGamesGuest(generation);
+          } catch (guestError) {
+            if (generation !== generationRef.current) {
+              return;
+            }
+            setUser(null);
+            expiresAtRef.current = null;
+            setSessionExpiresAt(null);
+            setCrazyGamesSessionError(
+              'We could not safely restore your saved guest session. Retry account sync.',
+            );
+            setCrazyGamesSessionStatus('error');
+            setLoading(false);
+            setInitialResolutionComplete(true);
+            console.warn('CrazyGames saved guest verification failed:', guestError);
+          }
+          return;
+        }
+
+        const expiryMs = (expiresAtRef.current ?? 0) * 1000;
+        if (background && userRef.current && expiryMs > Date.now() + MIN_RENEWAL_DELAY_MS) {
+          // Keep the still-valid internal session usable and retry well before
+          // expiry. Once it is no longer valid, the next attempt fails closed.
+          scheduleRenewalRetry();
+          return;
+        }
+
+        // Keep the cached internal token dormant while the UI is fail-closed.
+        // If it is an eligible guest, a manual retry can still promote it in
+        // place; if it belongs to another linked user, the server ignores it
+        // as a migration candidate and the verified portal identity wins.
+        setUser(null);
+        expiresAtRef.current = null;
+        setSessionExpiresAt(null);
+        setCrazyGamesSessionError(accountErrorMessage(error));
+        setCrazyGamesSessionStatus('error');
+        setLoading(false);
+        setInitialResolutionComplete(true);
+      }
+    })();
+
+    resolutionFlightRef.current = flight;
+    const clearResolutionFlight = () => {
+      if (resolutionFlightRef.current === flight) {
+        resolutionFlightRef.current = null;
+      }
+    };
+    void flight.then(clearResolutionFlight, clearResolutionFlight);
+    return flight;
+  }, [
+    becomeCrazyGamesGuest,
+    clearRenewalRetry,
+    eligibleGuestInitialPreferences,
+    getUserToken,
+    scheduleRenewalRetry,
+    showAccountLinkPrompt,
+    setCrazyGamesSessionStatus,
+    setUser,
+  ]);
+
+  useEffect(() => {
+    resolveAccountRef.current = resolveCrazyGamesAccount;
+  }, [resolveCrazyGamesAccount]);
+
+  // The multiplayer bridge is intentionally not mounted during the initial
+  // account gate. If login/logout changes in that narrow window, invalidate
+  // the pending result and restart so the new provider identity always wins.
+  useEffect(() => {
+    if (authChangeSequence <= observedInitialAuthChangeRef.current) {
+      return;
+    }
+    observedInitialAuthChangeRef.current = authChangeSequence;
+    if (!IS_CRAZY_GAMES_BUILD) {
+      return;
+    }
+    if (!initialResolutionComplete) {
+      generationRef.current += 1;
+      window.location.reload();
+      return;
+    }
+    // The bridge may not exist yet on the exact render boundary where the
+    // initial exchange finishes. Record a durable provider-owned transition;
+    // its observer starts at zero so an event cannot disappear during mount.
+    setCrazyGamesAccountTransitionSequence((value) => value + 1);
+  }, [authChangeSequence, initialResolutionComplete]);
+
+  // Resolve the platform identity before gameplay components may connect.
+  useEffect(() => {
+    if (IS_CRAZY_GAMES_BUILD) {
+      // A direct privacy-policy visit must remain a passive document: do not
+      // retrieve a portal token or open consent UI behind it. Navigating back
+      // changes this dependency and starts the ordinary account gate.
+      if (isCrazyGamesPrivacyPage) {
+        return;
+      }
+      void resolveCrazyGamesAccount();
+      return;
+    }
+
+    const fetchCurrentUser = async () => {
+      const token = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+      if (!token) {
+        setLoading(false);
+        return;
+      }
+      try {
+        setUser(await api.getCurrentUser());
+      } catch (error) {
+        console.error('Failed to fetch current user:', error);
+        const status = isApiError(error) ? error.response.status : undefined;
+        const isAbortError = error instanceof Error && error.name === 'AbortError';
+        if (status === 401 || status === 403) {
+          api.setAuthToken(null);
+        } else if (isAbortError) {
+          console.debug('Fetch aborted while loading user; keeping existing auth token');
+        }
+      } finally {
+        setLoading(false);
+      }
+    };
+    void fetchCurrentUser();
+  }, [isCrazyGamesPrivacyPage, resolveCrazyGamesAccount, setUser]);
+
+  // Renew the internal session while the platform can still mint a fresh
+  // CrazyGames token. Token changes for the same user preserve lobby state.
+  useEffect(() => {
+    if (!IS_CRAZY_GAMES_BUILD || crazyGamesSessionStatus !== 'linked' || !sessionExpiresAt) {
+      return;
+    }
+    const delay = Math.max(
+      MIN_RENEWAL_DELAY_MS,
+      sessionExpiresAt * 1000 - Date.now() - SESSION_RENEWAL_LEAD_MS,
+    );
+    const timer = setTimeout(() => {
+      void resolveCrazyGamesAccount(true);
+    }, delay);
+    return () => clearTimeout(timer);
+  }, [crazyGamesSessionStatus, resolveCrazyGamesAccount, sessionExpiresAt]);
+
+  const flushPreferences = useCallback(async () => {
+    preferenceTimerRef.current = null;
+    if (
+      preferenceSaveInFlightRef.current ||
+      statusRef.current !== 'linked' ||
+      !userRef.current
+    ) {
+      return;
+    }
+    preferenceSaveInFlightRef.current = true;
+    preferenceDirtyRef.current = false;
+    const requestedRevision = preferenceRevisionRef.current;
+    const requestedUserId = userRef.current.id;
+    let retryDelay: number | null = null;
+    try {
+      // Keep the actual fetch serialized until it settles. A synthetic timeout
+      // would permit an older request to commit after a newer retry and roll
+      // the server back despite client-side revision checks.
+      const canonical = await api.saveCrazyGamesPreferences(
+        readCrazyGamesPreferences(),
+      );
+      if (
+        statusRef.current !== 'linked' ||
+        userRef.current?.id !== requestedUserId
+      ) {
+        return;
+      }
+      preferenceRetryRef.current = 0;
+      // Never let an older response overwrite a browser edit that happened
+      // while this PUT was in flight. The dirty snapshot is sent next.
+      if (
+        requestedRevision === preferenceRevisionRef.current &&
+        !preferenceDirtyRef.current
+      ) {
+        applyingPreferencesRef.current = true;
+        try {
+          applyCrazyGamesPreferences(canonical, true);
+        } finally {
+          applyingPreferencesRef.current = false;
+        }
+      }
+    } catch (error) {
+      if (
+        statusRef.current !== 'linked' ||
+        userRef.current?.id !== requestedUserId
+      ) {
+        return;
+      }
+      console.warn('CrazyGames preference save will retry:', error);
+      preferenceDirtyRef.current = true;
+      preferenceRetryRef.current += 1;
+      retryDelay = Math.min(
+        PREFERENCE_RETRY_MAX_MS,
+        1000 * 2 ** Math.min(preferenceRetryRef.current, 5),
+      );
+    } finally {
+      preferenceSaveInFlightRef.current = false;
+      if (
+        preferenceDirtyRef.current &&
+        statusRef.current === 'linked' &&
+        userRef.current?.id === requestedUserId
+      ) {
+        if (preferenceTimerRef.current) {
+          clearTimeout(preferenceTimerRef.current);
+        }
+        preferenceTimerRef.current = setTimeout(() => {
+          void flushPreferences();
+        }, retryDelay ?? PREFERENCE_SAVE_DELAY_MS);
+      }
+    }
+  }, []);
+
+  useEffect(() => subscribeGameStorage((key) => {
+    if (
+      !IS_CRAZY_GAMES_BUILD ||
+      statusRef.current !== 'linked' ||
+      applyingPreferencesRef.current ||
+      !CRAZY_GAMES_PREFERENCE_KEYS.has(key)
+    ) {
+      return;
+    }
+    preferenceDirtyRef.current = true;
+    preferenceRevisionRef.current += 1;
+    preferenceRetryRef.current = 0;
+    if (preferenceSaveInFlightRef.current) {
+      return;
+    }
+    if (preferenceTimerRef.current) {
+      clearTimeout(preferenceTimerRef.current);
+    }
+    preferenceTimerRef.current = setTimeout(() => {
+      void flushPreferences();
+    }, PREFERENCE_SAVE_DELAY_MS);
+  }), [flushPreferences]);
+
+  useEffect(() => () => {
+    clearRenewalRetry();
+    if (preferenceTimerRef.current) {
+      clearTimeout(preferenceTimerRef.current);
+    }
+  }, [clearRenewalRetry]);
 
   const login = useCallback(async (username: string, password: string) => {
-    try {
-      // Keep an active guest session intact until authentication succeeds.
-      // The auth endpoint replaces the token atomically on success, allowing
-      // the WebSocket context to reconnect under the new identity.
-      const data = await api.login(username, password);
-      setUser(data.user);
-    } catch (err) {
-      throw err;
-    }
-  }, []);
+    const data = await api.login(username, password);
+    setUser(data.user);
+  }, [setUser]);
 
   const register = useCallback(async (username: string, password: string | null) => {
-    try {
-      // As with login, retain the guest token unless account creation succeeds.
-      const data = await api.register(username, password || '');
-      setUser(data.user);
-    } catch (err) {
-      throw err;
+    const data = await api.register(username, password || '');
+    setUser(data.user);
+  }, [setUser]);
+
+  const createGuestSession = useCallback(async (nickname: string) => {
+    const generation = generationRef.current;
+    // Do not time out a state-creating request without abort/idempotency: its
+    // late success would orphan one guest while a retry created another. This
+    // also preserves the original website/itch behavior exactly.
+    const data = await api.createGuest(nickname);
+    if (
+      IS_CRAZY_GAMES_BUILD &&
+      (generation !== generationRef.current || statusRef.current !== 'guest')
+    ) {
+      throw new Error('CrazyGames identity changed while creating a guest session');
     }
-  }, []);
+    api.setAuthToken(data.token);
+    const guestUser: User = { ...data.user, isGuest: true };
+    setUser(guestUser);
+    try {
+      gameStorage.setItem('savedUsername', guestUser.username);
+    } catch {
+      // Storage is optional for guest display-name convenience.
+    }
+    return { user: guestUser, token: data.token };
+  }, [setUser]);
+
+  const ensurePlayableSession = useCallback(async (nickname?: string) => {
+    if (IS_CRAZY_GAMES_BUILD) {
+      const resolving = resolutionFlightRef.current;
+      if (resolving) {
+        await resolving;
+      }
+      if (statusRef.current === 'resolving') {
+        throw new Error('CrazyGames account is still connecting.');
+      }
+      if (statusRef.current === 'error') {
+        throw new Error('CrazyGames account progress is unavailable. Retry account sync first.');
+      }
+    }
+
+    const currentUser = userRef.current;
+    const currentToken = api.getAuthToken();
+    if (currentUser && currentToken) {
+      return { user: currentUser, token: currentToken };
+    }
+
+    if (IS_CRAZY_GAMES_BUILD && statusRef.current !== 'guest') {
+      throw new Error('CrazyGames account is not ready for gameplay.');
+    }
+    if (guestFlightRef.current) {
+      return guestFlightRef.current;
+    }
+
+    const normalizedNickname = nickname?.trim();
+    const flight = createGuestSession(
+      normalizedNickname && normalizedNickname.length >= 3
+        ? normalizedNickname
+        : fallbackGuestNickname(),
+    );
+    guestFlightRef.current = flight;
+    const clearGuestFlight = () => {
+      if (guestFlightRef.current === flight) {
+        guestFlightRef.current = null;
+      }
+    };
+    void flight.then(clearGuestFlight, clearGuestFlight);
+    return flight;
+  }, [createGuestSession]);
 
   const createGuest = useCallback(async (nickname: string) => {
-    try {
-      const data = await api.createGuest(nickname);
-      const guestUser: User = { ...data.user, isGuest: true };
-      setUser(guestUser);
-      try {
-        localStorage.setItem('savedUsername', guestUser.username);
-      } catch {
-        // ignore storage errors
-      }
-      return { user: guestUser, token: data.token };
-    } catch (err) {
-      throw err;
+    if (IS_CRAZY_GAMES_BUILD) {
+      return ensurePlayableSession(nickname);
     }
-  }, []);
+    return createGuestSession(nickname);
+  }, [createGuestSession, ensurePlayableSession]);
 
   const updateGuestNickname = useCallback((nickname: string) => {
-    setUser(prev => {
-      if (!prev) {
-        return prev;
-      }
-      return { ...prev, username: nickname };
+    setUserState((previous) => {
+      if (!previous) return previous;
+      const next = { ...previous, username: nickname };
+      userRef.current = next;
+      return next;
     });
-
     try {
-      localStorage.setItem('savedUsername', nickname);
+      gameStorage.setItem('savedUsername', nickname);
     } catch {
       // ignore storage errors
     }
@@ -109,12 +723,33 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const logout = useCallback(() => {
     api.setAuthToken(null);
     setUser(null);
+    if (IS_CRAZY_GAMES_BUILD) {
+      setCrazyGamesSessionStatus('guest');
+    }
     navigate('/');
-  }, [navigate]);
+  }, [navigate, setCrazyGamesSessionStatus, setUser]);
 
-  const getToken = useCallback((): string | null => {
-    return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
-  }, []);
+  const getToken = useCallback((): string | null => api.getAuthToken(), []);
+
+  const retryCrazyGamesSession = useCallback(async () => {
+    if (crazyGamesSdkAccountError?.code === 'sdkUnavailable') {
+      // SDK bootstrap is deliberately single-shot so a timed-out init cannot
+      // later register duplicate listeners. A full reload is the only safe
+      // retry; the tab-scoped internal session survives it.
+      window.location.reload();
+      return;
+    }
+    await resolveCrazyGamesAccount(false);
+  }, [crazyGamesSdkAccountError?.code, resolveCrazyGamesAccount]);
+
+  const beginCrazyGamesAccountTransition = useCallback(() => {
+    if (!IS_CRAZY_GAMES_BUILD) return;
+    generationRef.current += 1;
+    clearRenewalRetry();
+    setLoading(true);
+    setCrazyGamesSessionError(null);
+    setCrazyGamesSessionStatus('resolving');
+  }, [clearRenewalRetry, setCrazyGamesSessionStatus]);
 
   const value: AuthContextType = {
     user,
@@ -122,14 +757,33 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     login,
     register,
     createGuest,
+    ensurePlayableSession,
     updateGuestNickname,
     logout,
     getToken,
+    crazyGamesSessionStatus,
+    crazyGamesSessionError,
+    retryCrazyGamesSession,
+    beginCrazyGamesAccountTransition,
+    crazyGamesAccountTransitionSequence,
   };
 
   return (
     <AuthContext.Provider value={value}>
-      {children}
+      {IS_CRAZY_GAMES_BUILD && !initialResolutionComplete && !isCrazyGamesPrivacyPage ? (
+        <main className="min-h-screen flex items-center justify-center px-6" aria-busy="true">
+          <div className="max-w-md border-2 border-black bg-white p-8 text-center shadow-[8px_8px_0_#000]">
+            <div
+              className="mx-auto mb-4 h-7 w-7 animate-spin rounded-full border-4 border-black/20 border-t-black"
+              aria-hidden="true"
+            />
+            <h1 className="text-xl font-black uppercase tracking-1">Connecting your account</h1>
+            <p className="mt-3 text-sm text-gray-600">
+              Restoring your Snaketron progress from CrazyGames…
+            </p>
+          </div>
+        </main>
+      ) : children}
     </AuthContext.Provider>
   );
 };

--- a/client/web/contexts/CrazyGamesContext.tsx
+++ b/client/web/contexts/CrazyGamesContext.tsx
@@ -8,7 +8,7 @@ import {
 
 interface CrazyGamesContextValue extends CrazyGamesSnapshot {
   showAuthPrompt: () => Promise<CrazyGamesPortalUser | null>;
-  getUserToken: () => Promise<string | null>;
+  getUserToken: () => Promise<string>;
   listFriends: (page?: number, size?: number) => Promise<CrazyGamesFriendsPage | null>;
   showAccountLinkPrompt: () => Promise<'yes' | 'no' | null>;
 }

--- a/client/web/contexts/WebSocketContext.tsx
+++ b/client/web/contexts/WebSocketContext.tsx
@@ -54,6 +54,7 @@ import {
   replacementFailureAction,
   replacementReadyForPromotion,
 } from '../services/websocketLifecycle';
+import { subscribeGameStorage } from '../services/gameStorage';
 
 interface WebSocketProviderProps {
   children: React.ReactNode;
@@ -108,6 +109,17 @@ declare global {
 const WebSocketContext = createContext<WebSocketContextType | null>(null);
 
 const LOBBY_STORAGE_KEY = 'snaketron:lastLobby';
+const NO_LOBBY_STORAGE_KEY = '__snaketron:no-lobby-storage__';
+
+export const lobbyStorageKeyForIdentity = (
+  isCrazyGamesBuild: boolean,
+  userId: number | null,
+): string | null => {
+  if (!isCrazyGamesBuild) {
+    return LOBBY_STORAGE_KEY;
+  }
+  return userId === null ? null : `${LOBBY_STORAGE_KEY}:user:${userId}`;
+};
 const MAX_CHAT_HISTORY = 200;
 const VALID_LOBBY_MODES: LobbyGameMode[] = ['duel', '2v2', 'solo', 'ffa'];
 const VALID_LOBBY_STATES: LobbyState[] = ['waiting', 'queued', 'matched'];
@@ -247,6 +259,16 @@ const normalizeLobbyPreferences = (payload: any): LobbyPreferences => {
   };
 };
 
+const sameLobbyPreferences = (
+  current: LobbyPreferences | null,
+  next: LobbyPreferences,
+): boolean => Boolean(
+  current &&
+  current.competitive === next.competitive &&
+  current.selectedModes.length === next.selectedModes.length &&
+  current.selectedModes.every((mode, index) => mode === next.selectedModes[index]),
+);
+
 interface StoredLobbyInfo {
   code: string;
   id?: number | null;
@@ -270,6 +292,7 @@ export const useWebSocket = (): WebSocketContextType => {
 
 export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }) => {
   const {
+    isCrazyGamesBuild,
     inviteParams,
     isInstantMultiplayer,
     settings: { disableChat },
@@ -316,7 +339,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const syncRequestTimes = useRef<Map<number, number>>(new Map());
   const isInitializingRef = useRef(false);
   const storedLobbyRef = useRef<StoredLobbyInfo | null>(null);
-  const hasLoadedStoredLobbyRef = useRef(false);
+  const loadedLobbyStorageKeyRef = useRef<string | null>(null);
+  const persistedLobbyStorageKeyRef = useRef<string | null>(null);
   const restoreInProgressRef = useRef(false);
   // QueueForMatch is safe to replay because Redis admission preserves the
   // first physical queue identity. Keep only the one unacknowledged intent
@@ -326,7 +350,16 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   const gameChatIdRef = useRef<number | null>(null);
   const { settings: latencySettings } = useLatency();
   const latencySettingsRef = useRef(latencySettings);
-  const { user, getToken } = useAuth();
+  const {
+    user,
+    getToken,
+    loading: authLoading,
+    crazyGamesSessionStatus,
+  } = useAuth();
+  const activeLobbyStorageKey = useMemo(
+    () => lobbyStorageKeyForIdentity(isCrazyGamesBuild, user?.id ?? null),
+    [isCrazyGamesBuild, user?.id],
+  );
   const hasEverConnectedRef = useRef(false);
   const authHandshakeRef = useRef(false);
   const lastAuthTokenRef = useRef<string | null>(null);
@@ -356,6 +389,25 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       desiredLobbyPreferencesRef.current = lobbyPreferences;
     }
   }, [lobbyPreferences]);
+
+  // Account exchange can replace the local snapshot after this provider has
+  // mounted. Adopt that canonical backend value before any lobby/gameplay UI
+  // becomes available instead of writing the stale pre-exchange value back.
+  useEffect(() => subscribeGameStorage((key) => {
+    if (key !== 'lastLobbyPreferences') {
+      return;
+    }
+    const restored = loadStoredLobbyPreferences();
+    if (!restored) {
+      desiredLobbyPreferencesRef.current = null;
+      setLobbyPreferences(null);
+      return;
+    }
+    desiredLobbyPreferencesRef.current = restored;
+    setLobbyPreferences((current) => (
+      sameLobbyPreferences(current, restored) ? current : restored
+    ));
+  }), []);
 
   useEffect(() => {
     if (lobbyPreferences) {
@@ -428,12 +480,30 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   }, []);
 
   useEffect(() => {
-    if (hasLoadedStoredLobbyRef.current) {
+    if (
+      isCrazyGamesBuild &&
+      (authLoading || crazyGamesSessionStatus === 'resolving' || crazyGamesSessionStatus === 'error')
+    ) {
       return;
     }
 
+    const storageMarker = activeLobbyStorageKey ?? NO_LOBBY_STORAGE_KEY;
+    if (loadedLobbyStorageKeyRef.current === storageMarker) {
+      return;
+    }
+
+    storedLobbyRef.current = null;
+    persistedLobbyStorageKeyRef.current = activeLobbyStorageKey;
+    setLobbyRestorationComplete(false);
+
     if (typeof window === 'undefined') {
-      hasLoadedStoredLobbyRef.current = true;
+      loadedLobbyStorageKeyRef.current = storageMarker;
+      setLobbyRestorationComplete(true);
+      return;
+    }
+
+    if (!activeLobbyStorageKey) {
+      loadedLobbyStorageKeyRef.current = storageMarker;
       setLobbyRestorationComplete(true);
       return;
     }
@@ -442,11 +512,11 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       if (isInstantMultiplayer || inviteParams?.lobbyCode || inviteParams?.roomCode) {
         // Platform-directed multiplayer launches always supersede an
         // unrelated lobby persisted from a prior visit.
-        window.localStorage.removeItem(LOBBY_STORAGE_KEY);
+        window.localStorage.removeItem(activeLobbyStorageKey);
         storedLobbyRef.current = null;
         return;
       }
-      const raw = window.localStorage.getItem(LOBBY_STORAGE_KEY);
+      const raw = window.localStorage.getItem(activeLobbyStorageKey);
       if (raw) {
         const parsed = JSON.parse(raw);
         if (parsed && typeof parsed.code === 'string' && parsed.code.trim()) {
@@ -459,17 +529,25 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     } catch (error) {
       console.warn('Failed to load stored lobby info, clearing persisted data', error);
       try {
-        window.localStorage.removeItem(LOBBY_STORAGE_KEY);
+        window.localStorage.removeItem(activeLobbyStorageKey);
       } catch {
         // Ignore removal errors
       }
     } finally {
-      hasLoadedStoredLobbyRef.current = true;
+      loadedLobbyStorageKeyRef.current = storageMarker;
       if (!storedLobbyRef.current) {
         setLobbyRestorationComplete(true);
       }
     }
-  }, [inviteParams?.lobbyCode, inviteParams?.roomCode, isInstantMultiplayer]);
+  }, [
+    activeLobbyStorageKey,
+    authLoading,
+    crazyGamesSessionStatus,
+    inviteParams?.lobbyCode,
+    inviteParams?.roomCode,
+    isCrazyGamesBuild,
+    isInstantMultiplayer,
+  ]);
 
   const persistLobby = useCallback((lobby: { id: number | null; code: string }) => {
     storedLobbyRef.current = { id: lobby.id, code: lobby.code.toUpperCase() };
@@ -478,15 +556,20 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       return;
     }
 
+    if (!activeLobbyStorageKey) {
+      return;
+    }
+
     try {
+      persistedLobbyStorageKeyRef.current = activeLobbyStorageKey;
       window.localStorage.setItem(
-        LOBBY_STORAGE_KEY,
+        activeLobbyStorageKey,
         JSON.stringify({ id: lobby.id, code: lobby.code.toUpperCase() })
       );
     } catch (error) {
       console.warn('Failed to persist lobby info', error);
     }
-  }, []);
+  }, [activeLobbyStorageKey]);
 
   const clearPersistedLobby = useCallback(() => {
     storedLobbyRef.current = null;
@@ -496,11 +579,18 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     }
 
     try {
-      window.localStorage.removeItem(LOBBY_STORAGE_KEY);
+      const keys = new Set([
+        activeLobbyStorageKey,
+        persistedLobbyStorageKeyRef.current,
+      ]);
+      for (const key of keys) {
+        if (key) window.localStorage.removeItem(key);
+      }
+      persistedLobbyStorageKeyRef.current = activeLobbyStorageKey;
     } catch (error) {
       console.warn('Failed to clear stored lobby info', error);
     }
-  }, []);
+  }, [activeLobbyStorageKey]);
 
   const resetLobbyState = useCallback(() => {
     clearPendingMatchmakingIntent();
@@ -1787,6 +1877,32 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     const previous = previousUserRef.current;
     const token = getToken();
     if (
+      isCrazyGamesBuild &&
+      (crazyGamesSessionStatus === 'resolving' || crazyGamesSessionStatus === 'error')
+    ) {
+      const active = activeSlotRef.current;
+      if (
+        currentLobbyRef.current &&
+        active?.role === 'active' &&
+        active.authenticated &&
+        active.socket.readyState === WebSocket.OPEN
+      ) {
+        try {
+          active.socket.send(JSON.stringify('LeaveLobby'));
+        } catch (error) {
+          console.warn('Failed to leave lobby while CrazyGames identity was gated', error);
+        }
+      }
+      clearPendingMatchmakingIntent();
+      resetLobbyState();
+      setAuthHandshakeState(false);
+      lastAuthTokenRef.current = null;
+      disconnect();
+      // Retain previousUserRef so a retry resolving a different portal account
+      // is compared with the identity that actually owned the retired socket.
+      return;
+    }
+    if (
       pendingMatchmakingIntentRef.current &&
       pendingMatchmakingIntentRef.current.authToken !== token
     ) {
@@ -1837,6 +1953,26 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     }
 
     const tokenChanged = lastAuthTokenRef.current && token !== lastAuthTokenRef.current;
+    const crazyGamesIdentityChanged = Boolean(
+      isCrazyGamesBuild &&
+      previous &&
+      user &&
+      previous.id !== user.id,
+    );
+
+    if (crazyGamesIdentityChanged) {
+      console.log('CrazyGames identity changed, clearing lobby state before reconnecting');
+      previousUserRef.current = user;
+      resetLobbyState();
+      setAuthHandshakeState(false);
+      const url = activeSlotRef.current?.url ?? currentRegionUrl;
+      disconnect();
+      if (url) {
+        reconnectEnabledRef.current = true;
+        connect(url, onConnectCallback.current || undefined);
+      }
+      return;
+    }
 
     // If the auth token changes (guest -> real account, logout, etc.), force a reconnect
     // because the server only accepts authentication during the initial handshake.
@@ -1889,10 +2025,19 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     clearPendingMatchmakingIntent,
     resetLobbyState,
     setAuthHandshakeState,
+    isCrazyGamesBuild,
+    crazyGamesSessionStatus,
   ]);
 
   // Auto-connect to the preferred or closest region on mount
   useEffect(() => {
+    if (
+      isCrazyGamesBuild &&
+      (authLoading || crazyGamesSessionStatus === 'resolving' || crazyGamesSessionStatus === 'error')
+    ) {
+      return;
+    }
+
     let cancelled = false;
     let detectionAttempt = 0;
     let retryTimeout: ReturnType<typeof setTimeout> | null = null;
@@ -1981,7 +2126,12 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
         clearTimeout(retryTimeout);
       }
     };
-  }, [connectToRegion]);
+  }, [
+    authLoading,
+    connectToRegion,
+    crazyGamesSessionStatus,
+    isCrazyGamesBuild,
+  ]);
 
   // Lobby methods
   const createLobby = useCallback(async () => {
@@ -2314,6 +2464,13 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
       }, 5000);
     });
   }, [beginResponseTrackedRequest, onMessage, sendMessage, resetLobbyState]);
+
+  const clearSessionForAccountChange = useCallback(() => {
+    resetLobbyState();
+    setLobbyRestorationComplete(true);
+    setAuthHandshakeState(false);
+    disconnect();
+  }, [disconnect, resetLobbyState, setAuthHandshakeState]);
 
   const updateLobbyPreferences = useCallback(
     (preferences: LobbyPreferences) => {
@@ -2790,7 +2947,8 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
   }, [disconnect]);
 
   useEffect(() => {
-    if (!hasLoadedStoredLobbyRef.current) {
+    const expectedStorageMarker = activeLobbyStorageKey ?? NO_LOBBY_STORAGE_KEY;
+    if (loadedLobbyStorageKeyRef.current !== expectedStorageMarker) {
       return;
     }
 
@@ -2853,7 +3011,14 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     return () => {
       cancelled = true;
     };
-  }, [isConnected, isSessionAuthenticated, currentLobby, joinLobby, resetLobbyState]);
+  }, [
+    activeLobbyStorageKey,
+    currentLobby,
+    isConnected,
+    isSessionAuthenticated,
+    joinLobby,
+    resetLobbyState,
+  ]);
 
   const value: WebSocketContextType = {
     isConnected,
@@ -2878,6 +3043,7 @@ export const WebSocketProvider: React.FC<WebSocketProviderProps> = ({ children }
     createLobby,
     joinLobby,
     leaveLobby,
+    clearSessionForAccountChange,
     sendChatMessage,
     updateLobbyPreferences,
   };

--- a/client/web/package-lock.json
+++ b/client/web/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
-        "react-router-dom": "^7.6.2",
+        "react-router-dom": "^7.18.2",
         "wasm-snaketron": "file:../pkg"
       },
       "bin": {
@@ -6166,9 +6166,10 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
-      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -6187,11 +6188,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.6.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.6.2.tgz",
-      "integrity": "sha512-Q8zb6VlTbdYKK5JJBLQEN06oTUa/RAbG/oQS1auK1I0TbJOXktqm+QENEVJU6QvWynlXPRBXI3fiOQcSEA78rA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
+      "license": "MIT",
       "dependencies": {
-        "react-router": "7.6.2"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -6202,11 +6204,16 @@
       }
     },
     "node_modules/react-router/node_modules/cookie": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
-      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/readable-stream": {
@@ -6641,9 +6648,10 @@
       }
     },
     "node_modules/set-cookie-parser": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
-      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ=="
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",

--- a/client/web/package.json
+++ b/client/web/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^7.6.2",
+    "react-router-dom": "^7.18.2",
     "wasm-snaketron": "file:../pkg"
   },
   "devDependencies": {

--- a/client/web/services/api.ts
+++ b/client/web/services/api.ts
@@ -37,15 +37,44 @@ interface RequestOptions extends RequestInit {
   headers?: Record<string, string>;
 }
 
+export interface CrazyGamesPreferences {
+  tutorialSeen?: Record<string, boolean>;
+  lobbyPreferences?: {
+    selectedModes: string[];
+    competitive: boolean;
+  };
+  boostInputMode?: 'hold' | 'toggle';
+}
+
+export type CrazyGamesGuestPromotion = 'check' | 'allow' | 'decline';
+
+export type CrazyGamesExchangeResolution = 'created' | 'guestClaimed' | 'returning';
+
+export interface CrazyGamesExchangeUser extends UserInfo {
+  authSource: 'crazygames';
+  avatarUrl?: string | null;
+}
+
+export interface CrazyGamesExchangeResponse {
+  token: string;
+  expiresAt: number;
+  resolution: CrazyGamesExchangeResolution;
+  user: CrazyGamesExchangeUser;
+  preferences: CrazyGamesPreferences;
+}
+
 // Portal sessions are intentionally isolated from first-party username/
-// password sessions. The CrazyGames pilot uses this only for a guest token;
-// the full account exchange will mint the same internal JWT under this key.
+// password sessions. This key stores only Snaketron's internal JWT; the
+// short-lived CrazyGames token is never persisted.
 export const AUTH_TOKEN_STORAGE_KEY = process.env.CRAZYGAMES_BUILD === 'true'
   ? 'snaketron:crazygames:session-token'
   : 'token';
+const IS_CRAZY_GAMES_BUILD = process.env.CRAZYGAMES_BUILD === 'true';
 
 class API {
   private baseURL: string;
+  private crazyGamesMemoryToken: string | null = null;
+  private crazyGamesTokenLoaded = false;
 
   constructor() {
     // Base API host; endpoints below include the /api prefix explicitly
@@ -54,15 +83,71 @@ class API {
   }
 
   private getToken(): string | null {
-    return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    if (!IS_CRAZY_GAMES_BUILD) {
+      return localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    }
+    if (this.crazyGamesTokenLoaded) {
+      return this.crazyGamesMemoryToken;
+    }
+    this.crazyGamesTokenLoaded = true;
+    try {
+      this.crazyGamesMemoryToken = sessionStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+    } catch {
+      // In-memory auth still works when an embed blocks Web Storage.
+    }
+    if (this.crazyGamesMemoryToken) {
+      return this.crazyGamesMemoryToken;
+    }
+    // One-time migration from the earlier shared-tab pilot. All new reads and
+    // writes are tab-scoped so another portal account cannot replace this
+    // tab's bearer token.
+    try {
+      const legacyToken = localStorage.getItem(AUTH_TOKEN_STORAGE_KEY);
+      if (legacyToken) {
+        this.crazyGamesMemoryToken = legacyToken;
+        try {
+          sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, legacyToken);
+        } catch {
+          // Memory remains authoritative for this page lifetime.
+        }
+      }
+      localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    } catch {
+      // Shared storage is optional and is never used as the live CG source.
+    }
+    return this.crazyGamesMemoryToken;
   }
 
   setAuthToken(token: string | null): void {
-    if (token) {
-      localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
-    } else {
-      localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    if (!IS_CRAZY_GAMES_BUILD) {
+      if (token) {
+        localStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+      } else {
+        localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+      }
+      return;
     }
+
+    this.crazyGamesTokenLoaded = true;
+    this.crazyGamesMemoryToken = token;
+    try {
+      if (token) {
+        sessionStorage.setItem(AUTH_TOKEN_STORAGE_KEY, token);
+      } else {
+        sessionStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+      }
+    } catch {
+      // Memory remains authoritative until the next full page load.
+    }
+    try {
+      localStorage.removeItem(AUTH_TOKEN_STORAGE_KEY);
+    } catch {
+      // Best-effort cleanup of the shared-tab legacy key.
+    }
+  }
+
+  getAuthToken(): string | null {
+    return this.getToken();
   }
 
   // T must be specified by the caller (typically a generated wire DTO). The
@@ -116,12 +201,42 @@ class API {
   }
 
   async createGuest(nickname: string): Promise<CreateGuestResponse> {
-    const data = await this.request<CreateGuestResponse>('/api/auth/guest', {
+    return this.request<CreateGuestResponse>('/api/auth/guest', {
       method: 'POST',
       body: JSON.stringify({ nickname }),
     });
-    this.setAuthToken(data.token);
-    return data;
+  }
+
+  /**
+   * Exchange a short-lived CrazyGames JWT without ever persisting it. The
+   * optional internal bearer attached by request() lets the server inspect or
+   * promote an eligible guest according to the caller's explicit consent.
+   */
+  async exchangeCrazyGamesToken(
+    token: string,
+    guestPromotion: CrazyGamesGuestPromotion,
+    initialPreferences?: CrazyGamesPreferences,
+  ): Promise<CrazyGamesExchangeResponse> {
+    return this.request<CrazyGamesExchangeResponse>('/api/auth/crazygames/exchange', {
+      method: 'POST',
+      body: JSON.stringify({
+        token,
+        guestPromotion,
+        ...(initialPreferences ? { initialPreferences } : {}),
+      }),
+    });
+  }
+
+  async saveCrazyGamesPreferences(
+    preferences: CrazyGamesPreferences,
+  ): Promise<CrazyGamesPreferences> {
+    const response = await this.request<{ preferences: CrazyGamesPreferences }>(
+      '/api/auth/crazygames/preferences', {
+      method: 'PUT',
+      body: JSON.stringify(preferences),
+      },
+    );
+    return response.preferences;
   }
 
   async checkUsername(username: string): Promise<CheckUsernameResult> {

--- a/client/web/services/crazyGames.ts
+++ b/client/web/services/crazyGames.ts
@@ -1,6 +1,34 @@
 export type CrazyGamesEnvironment = 'local' | 'crazygames' | 'disabled';
 export type CrazyGamesAdState = 'idle' | 'requesting' | 'playing';
 export type CrazyGamesAdType = 'midgame' | 'rewarded';
+export type CrazyGamesAccountStatus =
+  | 'disabled'
+  | 'checking'
+  | 'authenticated'
+  | 'signed-out'
+  | 'unavailable'
+  | 'error';
+export type CrazyGamesAccountErrorCode =
+  | 'userNotAuthenticated'
+  | 'userAccountUnavailable'
+  | 'sdkUnavailable'
+  | 'invalidToken'
+  | 'unknown';
+
+export interface CrazyGamesAccountError {
+  code: CrazyGamesAccountErrorCode;
+  message: string;
+}
+
+export class CrazyGamesAccountException extends Error {
+  readonly code: CrazyGamesAccountErrorCode;
+
+  constructor(error: CrazyGamesAccountError) {
+    super(error.message);
+    this.name = 'CrazyGamesAccountException';
+    this.code = error.code;
+  }
+}
 
 export interface CrazyGamesPortalUser {
   __dangerousUserId: string;
@@ -105,8 +133,8 @@ interface CrazyGamesSdk {
     listFriends(input: { page: number; size: number }): Promise<CrazyGamesFriendsPage>;
     showAuthPrompt(): Promise<CrazyGamesPortalUser>;
     showAccountLinkPrompt(): Promise<{ response: 'yes' | 'no' }>;
-    addAuthListener(listener: (user: CrazyGamesPortalUser) => void): void;
-    removeAuthListener(listener: (user: CrazyGamesPortalUser) => void): void;
+    addAuthListener(listener: (user: CrazyGamesPortalUser | null) => void): void;
+    removeAuthListener(listener: (user: CrazyGamesPortalUser | null) => void): void;
   };
   data: CrazyGamesDataModule;
 }
@@ -123,6 +151,9 @@ export interface CrazyGamesSnapshot {
   settings: CrazyGamesGameSettings;
   portalUser: CrazyGamesPortalUser | null;
   userAccountAvailable: boolean;
+  accountStatus: CrazyGamesAccountStatus;
+  accountError: CrazyGamesAccountError | null;
+  authChangeSequence: number;
   systemInfo: CrazyGamesSystemInfo | null;
   isInstantMultiplayer: boolean;
   inviteParams: CrazyGamesInviteParams | null;
@@ -147,6 +178,7 @@ const ARE_CRAZY_GAMES_ADS_ENABLED = process.env.CRAZYGAMES_ADS_ENABLED === 'true
 const IS_CRAZY_GAMES_DATA_ENABLED = process.env.CRAZYGAMES_DATA_ENABLED === 'true';
 const SDK_INIT_TIMEOUT_MS = 15_000;
 const AD_REQUEST_TIMEOUT_MS = 15_000;
+const PROFILE_LOOKUP_DELAY_MS = 300;
 
 const DEFAULT_SETTINGS: CrazyGamesGameSettings = {
   disableChat: false,
@@ -170,6 +202,33 @@ const errorMessage = (error: unknown): string => {
   return String(error ?? 'Unknown CrazyGames SDK error');
 };
 
+const errorCode = (error: unknown): string => {
+  if (error && typeof error === 'object' && 'code' in error) {
+    return String((error as { code?: unknown }).code ?? '');
+  }
+  return '';
+};
+
+/** Normalize the SDK's Error/string/object variants without exposing them to callers. */
+export const normalizeCrazyGamesAccountError = (error: unknown): CrazyGamesAccountError => {
+  const message = errorMessage(error);
+  const normalized = `${errorCode(error)} ${message}`.replace(/[\s_-]+/g, '').toLowerCase();
+
+  if (normalized.includes('usernotauthenticated') || normalized.includes('notauthenticated')) {
+    return { code: 'userNotAuthenticated', message };
+  }
+  if (normalized.includes('useraccountunavailable') || normalized.includes('accountunavailable')) {
+    return { code: 'userAccountUnavailable', message };
+  }
+  if (normalized.includes('sdknotavailable') || normalized.includes('sdkunavailable')) {
+    return { code: 'sdkUnavailable', message };
+  }
+  if (normalized.includes('invalidtoken') || normalized.includes('emptytoken')) {
+    return { code: 'invalidToken', message };
+  }
+  return { code: 'unknown', message };
+};
+
 const normalizedSettings = (
   settings: Partial<CrazyGamesGameSettings> | undefined,
 ): CrazyGamesGameSettings => ({
@@ -178,9 +237,9 @@ const normalizedSettings = (
 });
 
 /**
- * The CrazyGames SDK is deliberately isolated behind this adapter. Every
- * portal call fails open so an unavailable/disabled SDK can never make the
- * game itself unplayable.
+ * The CrazyGames SDK is deliberately isolated behind this adapter. Cosmetic,
+ * ad, and room calls fail open. Account-token failures remain typed so the
+ * authentication layer can avoid restoring the wrong player's cached session.
  */
 class CrazyGamesService {
   private sdk: CrazyGamesSdk | null = null;
@@ -188,6 +247,9 @@ class CrazyGamesService {
   private listeners = new Set<(snapshot: CrazyGamesSnapshot) => void>();
   private gameplayActive = false;
   private loadingActive = false;
+  private profileLookupScheduled = false;
+  private accountLinkPromptActive = false;
+  private userTokenFlight: Promise<string> | null = null;
 
   private snapshot: CrazyGamesSnapshot = {
     isCrazyGamesBuild: IS_CRAZY_GAMES_BUILD,
@@ -197,6 +259,9 @@ class CrazyGamesService {
     settings: DEFAULT_SETTINGS,
     portalUser: null,
     userAccountAvailable: false,
+    accountStatus: IS_CRAZY_GAMES_BUILD ? 'checking' : 'disabled',
+    accountError: null,
+    authChangeSequence: 0,
     systemInfo: null,
     isInstantMultiplayer: false,
     inviteParams: null,
@@ -215,8 +280,8 @@ class CrazyGamesService {
     this.updateSnapshot({ settings: normalizedSettings(settings) });
   };
 
-  private readonly authListener = (user: CrazyGamesPortalUser) => {
-    this.updateSnapshot({ portalUser: user });
+  private readonly authListener = (user: CrazyGamesPortalUser | null) => {
+    this.publishAuthChange(user);
   };
 
   private readonly roomJoinListener = (params: CrazyGamesInviteParams) => {
@@ -248,6 +313,53 @@ class CrazyGamesService {
     });
   }
 
+  private publishAuthChange(user: CrazyGamesPortalUser | null): void {
+    this.updateSnapshot({
+      portalUser: user,
+      accountStatus: user ? 'authenticated' : 'signed-out',
+      accountError: user ? null : {
+        code: 'userNotAuthenticated',
+        message: 'CrazyGames user signed out',
+      },
+      authChangeSequence: this.snapshot.authChangeSequence + 1,
+    });
+  }
+
+  private schedulePortalProfileLookup(): void {
+    const sdk = this.sdk;
+    if (
+      this.profileLookupScheduled ||
+      !sdk ||
+      !this.snapshot.userAccountAvailable ||
+      this.snapshot.portalUser
+    ) {
+      return;
+    }
+    this.profileLookupScheduled = true;
+    setTimeout(() => {
+      // Account-token retrieval is the security-critical User-module call.
+      // Only start this cosmetic lookup after it has resolved, never beside
+      // it, since the portal may rate-limit or serialize User-module calls.
+      if (this.sdk !== sdk || !this.canUseSdk(sdk) || this.snapshot.portalUser) {
+        return;
+      }
+      if (this.accountLinkPromptActive) {
+        this.profileLookupScheduled = false;
+        this.schedulePortalProfileLookup();
+        return;
+      }
+      void sdk.user.getUser()
+        .then((portalUser) => {
+          if (this.sdk === sdk && portalUser) {
+            this.updateSnapshot({ portalUser });
+          }
+        })
+        .catch((error) => {
+          console.info('CrazyGames user profile unavailable:', errorMessage(error));
+        });
+    }, PROFILE_LOOKUP_DELAY_MS);
+  }
+
   private canUseSdk(sdk: CrazyGamesSdk | null): sdk is CrazyGamesSdk {
     return Boolean(sdk && this.snapshot.available);
   }
@@ -271,6 +383,11 @@ class CrazyGamesService {
       this.updateSnapshot({
         initialized: true,
         initializationError: 'CrazyGames SDK script was not available',
+        accountStatus: 'unavailable',
+        accountError: {
+          code: 'sdkUnavailable',
+          message: 'CrazyGames SDK script was not available',
+        },
       });
       return this.snapshot;
     }
@@ -299,6 +416,20 @@ class CrazyGamesService {
         environment,
         settings: available ? normalizedSettings(sdk.game.settings) : DEFAULT_SETTINGS,
         userAccountAvailable: available && sdk.user.isUserAccountAvailable === true,
+        accountStatus: available
+          ? sdk.user.isUserAccountAvailable === true ? 'checking' : 'unavailable'
+          : 'unavailable',
+        accountError: available && sdk.user.isUserAccountAvailable === true
+          ? null
+          : {
+              // A loaded SDK can deliberately report a disabled environment
+              // on affiliate/non-CrazyGames embeds. That is a supported
+              // guest-only state, not a failed SDK bootstrap.
+              code: 'userAccountUnavailable',
+              message: available
+                ? 'CrazyGames user accounts are unavailable in this embed'
+                : 'CrazyGames account services are unavailable in this embed',
+            },
         systemInfo: available ? sdk.user.systemInfo ?? null : null,
         isInstantMultiplayer: available && sdk.game.isInstantMultiplayer === true,
         initializationError: null,
@@ -312,16 +443,6 @@ class CrazyGamesService {
       sdk.game.addJoinRoomListener(this.roomJoinListener);
       sdk.user.addAuthListener(this.authListener);
       this.publishInvite(sdk.game.inviteParams ?? null);
-
-      if (sdk.user.isUserAccountAvailable === true) {
-        // Profile lookup is not part of the render-critical SDK bootstrap. A
-        // slow account service must never hold the game on a blank page.
-        void sdk.user.getUser()
-          .then((portalUser) => this.updateSnapshot({ portalUser }))
-          .catch((error) => {
-            console.info('CrazyGames user is not authenticated:', errorMessage(error));
-          });
-      }
 
       void sdk.ad.hasAdblock()
         .then((hasAdblock) => this.updateSnapshot({ hasAdblock }))
@@ -338,6 +459,8 @@ class CrazyGamesService {
         available: false,
         environment: 'disabled',
         initializationError: errorMessage(error),
+        accountStatus: 'error',
+        accountError: normalizeCrazyGamesAccountError(error),
       });
       return this.snapshot;
     }
@@ -484,7 +607,10 @@ class CrazyGamesService {
     }
     try {
       const user = await this.sdk.user.showAuthPrompt();
-      this.updateSnapshot({ portalUser: user });
+      // Some SDK environments emit the auth listener and some only resolve
+      // the prompt. Publishing here makes both paths observable; consumers
+      // collapse duplicate events into one hard reload.
+      this.publishAuthChange(user);
       return user;
     } catch (error) {
       const message = errorMessage(error);
@@ -495,17 +621,76 @@ class CrazyGamesService {
     }
   };
 
-  getUserToken = async (): Promise<string | null> => {
-    if (!this.canUseSdk(this.sdk) || !this.snapshot.portalUser) {
-      return null;
+  getUserToken = (): Promise<string> => {
+    if (this.userTokenFlight) {
+      return this.userTokenFlight;
     }
-    try {
-      return await this.sdk.user.getUserToken();
-    } catch (error) {
-      console.info('CrazyGames user token unavailable:', errorMessage(error));
-      return null;
-    }
+    const flight = this.requestUserToken();
+    this.userTokenFlight = flight;
+    const clearFlight = () => {
+      if (this.userTokenFlight === flight) {
+        this.userTokenFlight = null;
+      }
+    };
+    // Clear only when the actual SDK promise settles. Auth-layer timeouts may
+    // stop waiting, but Retry must never start a concurrent User-module call.
+    void flight.then(clearFlight, clearFlight);
+    return flight;
   };
+
+  private async requestUserToken(): Promise<string> {
+    if (!this.canUseSdk(this.sdk)) {
+      const initializedGuestOnlyEmbed = Boolean(
+        this.sdk &&
+        this.snapshot.initialized &&
+        this.snapshot.initializationError === null &&
+        this.snapshot.environment === 'disabled',
+      );
+      const error: CrazyGamesAccountError = {
+        code: initializedGuestOnlyEmbed ? 'userAccountUnavailable' : 'sdkUnavailable',
+        message: initializedGuestOnlyEmbed
+          ? 'CrazyGames account services are unavailable in this embed'
+          : this.snapshot.initializationError ?? 'CrazyGames SDK is unavailable',
+      };
+      this.updateSnapshot({ accountStatus: 'unavailable', accountError: error });
+      throw new CrazyGamesAccountException(error);
+    }
+    if (!this.snapshot.userAccountAvailable) {
+      const error: CrazyGamesAccountError = {
+        code: 'userAccountUnavailable',
+        message: 'CrazyGames user accounts are unavailable in this embed',
+      };
+      this.updateSnapshot({ accountStatus: 'unavailable', accountError: error });
+      throw new CrazyGamesAccountException(error);
+    }
+    this.updateSnapshot({ accountStatus: 'checking', accountError: null });
+    try {
+      const token = await this.sdk.user.getUserToken();
+      if (typeof token !== 'string' || token.trim() === '') {
+        throw new CrazyGamesAccountException({
+          code: 'invalidToken',
+          message: 'CrazyGames returned an empty user token',
+        });
+      }
+      this.updateSnapshot({ accountStatus: 'authenticated', accountError: null });
+      this.schedulePortalProfileLookup();
+      return token;
+    } catch (error) {
+      const normalized = error instanceof CrazyGamesAccountException
+        ? { code: error.code, message: error.message }
+        : normalizeCrazyGamesAccountError(error);
+      const accountStatus: CrazyGamesAccountStatus = normalized.code === 'userNotAuthenticated'
+        ? 'signed-out'
+        : normalized.code === 'userAccountUnavailable' || normalized.code === 'sdkUnavailable'
+          ? 'unavailable'
+          : 'error';
+      this.updateSnapshot({ accountStatus, accountError: normalized });
+      if (normalized.code !== 'userNotAuthenticated') {
+        console.info('CrazyGames user token unavailable:', normalized.message);
+      }
+      throw new CrazyGamesAccountException(normalized);
+    }
+  }
 
   listFriends = async (page = 1, size = 50): Promise<CrazyGamesFriendsPage | null> => {
     if (!this.canUseSdk(this.sdk) || !this.snapshot.portalUser) {
@@ -523,14 +708,18 @@ class CrazyGamesService {
   };
 
   showAccountLinkPrompt = async (): Promise<'yes' | 'no' | null> => {
-    if (!this.canUseSdk(this.sdk) || !this.snapshot.portalUser) {
+    if (!this.canUseSdk(this.sdk) || !this.snapshot.userAccountAvailable) {
       return null;
     }
+    this.accountLinkPromptActive = true;
     try {
-      return (await this.sdk.user.showAccountLinkPrompt()).response;
+      const response = (await this.sdk.user.showAccountLinkPrompt()).response;
+      return response === 'yes' || response === 'no' ? response : null;
     } catch (error) {
       console.info('CrazyGames account link prompt unavailable:', errorMessage(error));
       return null;
+    } finally {
+      this.accountLinkPromptActive = false;
     }
   };
 

--- a/client/web/services/crazyGamesPreferences.ts
+++ b/client/web/services/crazyGamesPreferences.ts
@@ -1,0 +1,135 @@
+import type { CrazyGamesPreferences } from './api.ts';
+import { gameStorage } from './gameStorage.ts';
+
+export const CRAZY_GAMES_PREFERENCE_KEYS = new Set([
+  'snaketron:tutorial-seen:v1',
+  'lastLobbyPreferences',
+  'snaketron:boost-input-mode:v1',
+]);
+const CRAZY_GAMES_PREFERENCE_OWNER_KEY = 'snaketron:crazygames:preferences-owner';
+const MAX_TUTORIAL_KEYS = 128;
+const MAX_TUTORIAL_KEY_LENGTH = 64;
+
+const readJson = (key: string): unknown => {
+  const raw = gameStorage.getItem(key);
+  if (!raw) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return undefined;
+  }
+};
+
+const tutorialSeen = (raw: unknown): Record<string, boolean> | undefined => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+  const result: Record<string, boolean> = {};
+  for (const [key, value] of Object.entries(raw)) {
+    if (
+      Object.keys(result).length < MAX_TUTORIAL_KEYS &&
+      key.length > 0 &&
+      key.length <= MAX_TUTORIAL_KEY_LENGTH &&
+      !/[\u0000-\u001f\u007f]/.test(key) &&
+      value === true
+    ) {
+      result[key] = true;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+};
+
+const lobbyPreferences = (
+  raw: unknown,
+): CrazyGamesPreferences['lobbyPreferences'] | undefined => {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return undefined;
+  }
+  const record = raw as Record<string, unknown>;
+  const rawModes = record.selectedModes ?? record.selected_modes;
+  if (!Array.isArray(rawModes)) {
+    return undefined;
+  }
+  const validModes = new Set(['solo', 'duel', '2v2', 'ffa']);
+  const selectedModes = [...new Set(rawModes
+    .filter((mode): mode is string => typeof mode === 'string')
+    .map((mode) => mode.trim().toLowerCase())
+    .filter((mode) => validModes.has(mode)))]
+    .slice(0, 4);
+  if (selectedModes.length === 0) {
+    return undefined;
+  }
+  return {
+    selectedModes,
+    competitive: record.competitive === true || record.isCompetitive === true,
+  };
+};
+
+export const readCrazyGamesPreferences = (): CrazyGamesPreferences => {
+  const preferences: CrazyGamesPreferences = {};
+  const seen = tutorialSeen(readJson('snaketron:tutorial-seen:v1'));
+  const lobby = lobbyPreferences(readJson('lastLobbyPreferences'));
+  const boost = gameStorage.getItem('snaketron:boost-input-mode:v1');
+
+  if (seen) preferences.tutorialSeen = seen;
+  if (lobby) preferences.lobbyPreferences = lobby;
+  if (boost === 'hold' || boost === 'toggle') preferences.boostInputMode = boost;
+  return preferences;
+};
+
+/** Apply the server's canonical preference snapshot before gameplay mounts. */
+export const applyCrazyGamesPreferences = (
+  preferences?: CrazyGamesPreferences,
+  replaceMissing = false,
+): void => {
+  if (!preferences) {
+    return;
+  }
+  if (preferences.tutorialSeen) {
+    gameStorage.setItem(
+      'snaketron:tutorial-seen:v1',
+      JSON.stringify(preferences.tutorialSeen),
+    );
+  } else if (replaceMissing) {
+    gameStorage.removeItem('snaketron:tutorial-seen:v1');
+  }
+  if (preferences.lobbyPreferences) {
+    gameStorage.setItem(
+      'lastLobbyPreferences',
+      JSON.stringify(preferences.lobbyPreferences),
+    );
+  } else if (replaceMissing) {
+    gameStorage.removeItem('lastLobbyPreferences');
+  }
+  if (preferences.boostInputMode === 'hold' || preferences.boostInputMode === 'toggle') {
+    gameStorage.setItem('snaketron:boost-input-mode:v1', preferences.boostInputMode);
+  } else if (replaceMissing) {
+    gameStorage.removeItem('snaketron:boost-input-mode:v1');
+  }
+};
+
+export const crazyGamesPreferenceOwner = (): number | null => {
+  const raw = gameStorage.getItem(CRAZY_GAMES_PREFERENCE_OWNER_KEY);
+  if (!raw) return null;
+  const parsed = Number(raw);
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+export const markCrazyGamesPreferencesOwnedBy = (userId: number): void => {
+  gameStorage.setItem(CRAZY_GAMES_PREFERENCE_OWNER_KEY, String(userId));
+};
+
+export const clearCrazyGamesPreferenceOwner = (): void => {
+  gameStorage.removeItem(CRAZY_GAMES_PREFERENCE_OWNER_KEY);
+};
+
+/** Remove linked-account data before exposing tab-local guest settings. */
+export const clearLinkedCrazyGamesPreferences = (force = false): void => {
+  if (!force && crazyGamesPreferenceOwner() === null) {
+    return;
+  }
+  applyCrazyGamesPreferences({}, true);
+  clearCrazyGamesPreferenceOwner();
+};

--- a/client/web/services/gameStorage.ts
+++ b/client/web/services/gameStorage.ts
@@ -6,22 +6,114 @@ export interface GameStorage {
   removeItem(key: string): void;
 }
 
-const browserStorage = (): Storage | null => {
+type GameStorageListener = (key: string) => void;
+const storageListeners = new Set<GameStorageListener>();
+const crazyGamesMemoryStorage = new Map<string, string | null>();
+
+const publishStorageChange = (key: string): void => {
+  for (const listener of storageListeners) {
+    listener(key);
+  }
+};
+
+export const subscribeGameStorage = (listener: GameStorageListener): (() => void) => {
+  storageListeners.add(listener);
+  return () => storageListeners.delete(listener);
+};
+
+const browserStorage = (kind: 'local' | 'session'): Storage | null => {
   if (typeof window === 'undefined') {
     return null;
   }
   try {
-    return window.localStorage;
+    return kind === 'session' ? window.sessionStorage : window.localStorage;
   } catch {
     return null;
   }
 };
 
+const fallbackGetItem = (key: string): string | null => {
+  if (!crazyGames.getSnapshot().isCrazyGamesBuild) {
+    return browserStorage('local')?.getItem(key) ?? null;
+  }
+  if (crazyGamesMemoryStorage.has(key)) {
+    return crazyGamesMemoryStorage.get(key) ?? null;
+  }
+  const session = browserStorage('session');
+  const current = session?.getItem(key) ?? null;
+  if (current !== null) {
+    crazyGamesMemoryStorage.set(key, current);
+    return current;
+  }
+  // Migrate the earlier shared-tab preference mirror once. Canonical linked
+  // preferences are applied by the backend exchange immediately afterward;
+  // all live CG reads/writes remain tab-scoped from this point onward.
+  const local = browserStorage('local');
+  const legacy = local?.getItem(key) ?? null;
+  if (legacy !== null) {
+    crazyGamesMemoryStorage.set(key, legacy);
+    try {
+      if (session) {
+        session.setItem(key, legacy);
+      }
+      local?.removeItem(key);
+    } catch {
+      try {
+        local?.removeItem(key);
+      } catch {
+        // Memory is still authoritative for this page lifetime.
+      }
+    }
+  }
+  return legacy;
+};
+
+const fallbackSetItem = (key: string, value: string): void => {
+  const isCrazyGamesBuild = crazyGames.getSnapshot().isCrazyGamesBuild;
+  if (!isCrazyGamesBuild) {
+    browserStorage('local')?.setItem(key, value);
+    return;
+  }
+  // Memory is the live tab authority. Web Storage is only a best-effort
+  // reload mirror, so blocked/quota-limited sessionStorage cannot suppress a
+  // preference event or make a second script/account replace the live value.
+  crazyGamesMemoryStorage.set(key, value);
+  try {
+    browserStorage('session')?.setItem(key, value);
+  } catch {
+    // Memory remains authoritative for this page lifetime.
+  }
+  try {
+    browserStorage('local')?.removeItem(key);
+  } catch {
+    // Best-effort legacy cleanup.
+  }
+};
+
+const fallbackRemoveItem = (key: string): void => {
+  const isCrazyGamesBuild = crazyGames.getSnapshot().isCrazyGamesBuild;
+  if (!isCrazyGamesBuild) {
+    browserStorage('local')?.removeItem(key);
+    return;
+  }
+  crazyGamesMemoryStorage.set(key, null);
+  try {
+    browserStorage('session')?.removeItem(key);
+  } catch {
+    // Memory removal is authoritative.
+  }
+  try {
+    browserStorage('local')?.removeItem(key);
+  } catch {
+    // Best-effort legacy cleanup.
+  }
+};
+
 /**
- * Preferences saved through this facade use CrazyGames cloud data in the
- * portal build and ordinary LocalStorage elsewhere. Authentication tokens,
- * reconnect state, and server-authoritative progression intentionally do not
- * use this facade.
+ * Preferences saved through this facade use CrazyGames cloud data when it is
+ * explicitly enabled, a tab-scoped browser mirror in the portal build, and
+ * ordinary LocalStorage elsewhere. Authentication tokens, reconnect state,
+ * and server-authoritative progression intentionally do not use this facade.
  */
 export const gameStorage: GameStorage = {
   getItem(key: string): string | null {
@@ -35,7 +127,7 @@ export const gameStorage: GameStorage = {
     }
 
     try {
-      return browserStorage()?.getItem(key) ?? null;
+      return fallbackGetItem(key);
     } catch {
       return null;
     }
@@ -46,6 +138,7 @@ export const gameStorage: GameStorage = {
     if (data) {
       try {
         data.setItem(key, value);
+        publishStorageChange(key);
         return;
       } catch (error) {
         console.warn(`CrazyGames data write failed for ${key}`, error);
@@ -53,7 +146,8 @@ export const gameStorage: GameStorage = {
     }
 
     try {
-      browserStorage()?.setItem(key, value);
+      fallbackSetItem(key, value);
+      publishStorageChange(key);
     } catch {
       // Preferences are non-critical and must never stop gameplay.
     }
@@ -64,6 +158,7 @@ export const gameStorage: GameStorage = {
     if (data) {
       try {
         data.removeItem(key);
+        publishStorageChange(key);
         return;
       } catch (error) {
         console.warn(`CrazyGames data removal failed for ${key}`, error);
@@ -71,7 +166,8 @@ export const gameStorage: GameStorage = {
     }
 
     try {
-      browserStorage()?.removeItem(key);
+      fallbackRemoveItem(key);
+      publishStorageChange(key);
     } catch {
       // Preferences are non-critical and must never stop gameplay.
     }

--- a/client/web/tests/crazygames-account-flow.spec.js
+++ b/client/web/tests/crazygames-account-flow.spec.js
@@ -1,0 +1,1097 @@
+const { test, expect } = require('@playwright/test');
+
+test.use({ headless: true });
+test.skip(
+  process.env.SNAKETRON_CRAZYGAMES_E2E !== 'true',
+  'Run against a CRAZYGAMES_BUILD=true bundle with SNAKETRON_CRAZYGAMES_E2E=true',
+);
+
+const appUrl = process.env.SNAKETRON_TEST_BASE_URL || 'http://127.0.0.1:3100';
+
+const sdkScript = `
+(() => {
+  const portalUser = {
+    __dangerousUserId: 'display-only-do-not-trust',
+    username: 'Verified.Player',
+    profilePictureUrl: 'https://example.test/avatar.png'
+  };
+  const listeners = { auth: null, join: null, settings: null };
+  window.__cgTest = {
+    tokenCalls: 0,
+    linkPromptCalls: 0,
+    leftRoomCalls: 0,
+    emitAuth: user => listeners.auth?.(user ?? portalUser)
+  };
+  window.CrazyGames = { SDK: {
+    environment: 'local',
+    init: async () => {},
+    ad: { hasAdblock: async () => false, requestAd: (_type, callbacks) => callbacks.adFinished() },
+    banner: {
+      requestBanner: async () => {}, requestResponsiveBanner: async () => {},
+      clearBanner: () => {}, clearAllBanners: () => {}
+    },
+    data: { clear: () => {}, getItem: () => null, removeItem: () => {}, setItem: () => {} },
+    game: {
+      settings: { disableChat: false, muteAudio: false },
+      isInstantMultiplayer: false,
+      inviteParams: null,
+      addSettingsChangeListener: listener => { listeners.settings = listener; },
+      removeSettingsChangeListener: () => {},
+      addJoinRoomListener: listener => { listeners.join = listener; },
+      removeJoinRoomListener: () => {},
+      gameplayStart: () => {}, gameplayStop: () => {},
+      loadingStart: () => {}, loadingStop: () => {}, happytime: () => {},
+      reportGameCompletedPercentage: () => {}, setGameContext: () => {}, clearGameContext: () => {},
+      updateRoom: () => {},
+      leftRoom: () => { window.__cgTest.leftRoomCalls += 1; },
+      inviteLink: () => '', getInviteParam: () => null
+    },
+    user: {
+      isUserAccountAvailable: true,
+      systemInfo: { locale: 'en-US', device: { type: 'desktop' } },
+      getUser: async () => new Promise(resolve => setTimeout(() => resolve(portalUser), 250)),
+      getUserToken: async () => {
+        window.__cgTest.tokenCalls += 1;
+        return 'fresh-crazygames-jwt';
+      },
+      listFriends: async () => ({ friends: [], page: 1, size: 50, hasMore: false, total: 0 }),
+      showAuthPrompt: async () => portalUser,
+      showAccountLinkPrompt: async () => {
+        window.__cgTest.linkPromptCalls += 1;
+        const response = sessionStorage.getItem('__cg-link-response') || 'no';
+        if (response === 'error') throw new Error('account link prompt failed');
+        return { response };
+      },
+      addAuthListener: listener => { listeners.auth = listener; },
+      removeAuthListener: () => {}
+    }
+  }};
+})();
+`;
+
+const signedOutSdkScript = sdkScript.replace(
+  "return 'fresh-crazygames-jwt';",
+  "throw { code: 'userNotAuthenticated', message: 'The user is not authenticated' };",
+);
+
+const accountUnavailableSdkScript = sdkScript.replace(
+  'isUserAccountAvailable: true,',
+  'isUserAccountAvailable: false,',
+);
+
+const disabledEnvironmentSdkScript = sdkScript.replace(
+  "environment: 'local',",
+  "environment: 'disabled',",
+);
+
+const authRaceSdkScript = sdkScript.replace(
+  "return 'fresh-crazygames-jwt';",
+  "return sessionStorage.getItem('__cg-race-account') === 'b' ? 'crazygames-token-b' : 'crazygames-token-a';",
+);
+
+const authBoundarySdkScript = authRaceSdkScript.replace(
+  '  window.CrazyGames = { SDK: {',
+  `  const originalSetItem = Storage.prototype.setItem;
+  Storage.prototype.setItem = function(key, value) {
+    originalSetItem.call(this, key, value);
+    if (
+      key === 'snaketron:crazygames:session-token' &&
+      value === 'internal-boundary-a' &&
+      sessionStorage.getItem('__cg-boundary-fired') !== 'true'
+    ) {
+      originalSetItem.call(sessionStorage, '__cg-boundary-fired', 'true');
+      originalSetItem.call(sessionStorage, '__cg-race-account', 'b');
+      queueMicrotask(() => listeners.auth?.({
+        __dangerousUserId: 'display-only-boundary-b',
+        username: 'Boundary.B',
+        profilePictureUrl: ''
+      }));
+    }
+  };
+  window.CrazyGames = { SDK: {`,
+);
+
+const interactiveSignInSdkScript = sdkScript
+  .replace(
+    "return 'fresh-crazygames-jwt';",
+    "if (localStorage.getItem('__cg-signed-in') === 'true') return 'fresh-crazygames-jwt'; throw { code: 'userNotAuthenticated', message: 'The user is not authenticated' };",
+  )
+  .replace(
+    'showAuthPrompt: async () => portalUser,',
+    "showAuthPrompt: async () => { localStorage.setItem('__cg-signed-in', 'true'); return portalUser; },",
+  )
+  .replace(
+    'leftRoom: () => { window.__cgTest.leftRoomCalls += 1; },',
+    "leftRoom: () => { window.__cgTest.leftRoomCalls += 1; sessionStorage.setItem('__cg-left-room', String(Number(sessionStorage.getItem('__cg-left-room') || '0') + 1)); },",
+  );
+
+test('fresh CrazyGames identity wins before cached session or socket startup', async ({ page }) => {
+  const requests = [];
+  let exchangeAuthorization = null;
+  let exchangeBody = null;
+  let preferenceAuthorization = null;
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'stale-internal-session');
+    localStorage.setItem('lastLobbyPreferences', JSON.stringify({
+      selectedModes: ['duel'],
+      competitive: false,
+    }));
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    requests.push(pathname);
+    const headers = { 'access-control-allow-origin': '*' };
+
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchangeAuthorization = request.headers().authorization ?? null;
+      exchangeBody = request.postDataJSON();
+      await new Promise(resolve => setTimeout(resolve, 150));
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'verified-internal-session',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'returning',
+          user: {
+            id: 912,
+            username: 'Verified.Player',
+            mmr: 1120,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: 'https://example.test/avatar.png',
+          },
+          preferences: {
+            tutorialSeen: { movement: true },
+            lobbyPreferences: { selectedModes: ['solo'], competitive: true },
+            boostInputMode: 'toggle',
+          },
+        }),
+      });
+    }
+    if (pathname === '/api/auth/crazygames/preferences') {
+      preferenceAuthorization = request.headers().authorization ?? null;
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({ preferences: request.postDataJSON() }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Connecting your account')).toBeVisible();
+  await expect(page.getByText('Verified.Player', { exact: true })).toBeVisible();
+  await expect(page.getByText(/progress saves automatically/i)).toBeVisible();
+
+  expect(exchangeAuthorization).toBe('Bearer stale-internal-session');
+  expect(exchangeBody).toEqual({
+    token: 'fresh-crazygames-jwt',
+    guestPromotion: 'check',
+  });
+  expect(requests.indexOf('/api/auth/crazygames/exchange')).toBeLessThan(
+    requests.indexOf('/api/regions'),
+  );
+  expect(await page.evaluate(() => window.__cgTest.tokenCalls)).toBe(1);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(0);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('verified-internal-session');
+  expect(await page.evaluate(() => (
+    Object.values(localStorage).includes('fresh-crazygames-jwt') ||
+    Object.values(sessionStorage).includes('fresh-crazygames-jwt')
+  )))
+    .toBe(false);
+  // The provider's live preference state and storage must both reflect the
+  // canonical backend response, not the pre-exchange browser snapshot.
+  expect(await page.evaluate(() => window.__wsContext?.lobbyPreferences)).toEqual({
+    selectedModes: ['solo'],
+    competitive: true,
+  });
+  expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lastLobbyPreferences'))))
+    .toEqual({ selectedModes: ['solo'], competitive: true });
+
+  // Simulate another tab replacing the old shared localStorage key. This
+  // tab's API and socket identity remain bound to its in-memory/session token.
+  await page.evaluate(() => {
+    localStorage.setItem('snaketron:crazygames:session-token', 'other-tab-session');
+    window.__wsContext.updateLobbyPreferences({
+      selectedModes: ['ffa'],
+      competitive: false,
+    });
+  });
+  await expect.poll(() => preferenceAuthorization).toBe('Bearer verified-internal-session');
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('verified-internal-session');
+});
+
+test('an eligible guest is promoted only after explicit CrazyGames link consent', async ({ page }) => {
+  const exchanges = [];
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'saved-guest-session');
+    localStorage.setItem('lastLobbyPreferences', JSON.stringify({
+      selectedModes: ['ffa'],
+      competitive: true,
+    }));
+    localStorage.setItem('snaketron:boost-input-mode:v1', 'toggle');
+    sessionStorage.setItem('__cg-link-response', 'yes');
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchanges.push({
+        authorization: request.headers().authorization ?? null,
+        body: request.postDataJSON(),
+      });
+      if (exchanges.length === 1) {
+        return route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify({
+            code: 'guestLinkConsentRequired',
+            error: 'Confirm whether to keep guest progress',
+          }),
+        });
+      }
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'claimed-guest-session',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'guestClaimed',
+          user: {
+            id: 920,
+            username: 'Claimed.Guest',
+            mmr: 1042,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: null,
+          },
+          preferences: {
+            lobbyPreferences: { selectedModes: ['ffa'], competitive: true },
+            boostInputMode: 'toggle',
+          },
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Claimed.Guest', { exact: true })).toBeVisible();
+
+  expect(exchanges).toEqual([
+    {
+      authorization: 'Bearer saved-guest-session',
+      body: {
+        token: 'fresh-crazygames-jwt',
+        guestPromotion: 'check',
+      },
+    },
+    {
+      authorization: 'Bearer saved-guest-session',
+      body: {
+        token: 'fresh-crazygames-jwt',
+        guestPromotion: 'allow',
+        initialPreferences: {
+          lobbyPreferences: { selectedModes: ['ffa'], competitive: true },
+          boostInputMode: 'toggle',
+        },
+      },
+    },
+  ]);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('claimed-guest-session');
+});
+
+test('declining guest promotion creates the CrazyGames identity without sharing preferences', async ({ page }) => {
+  const exchanges = [];
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'declined-guest-session');
+    localStorage.setItem('lastLobbyPreferences', JSON.stringify({
+      selectedModes: ['duel'],
+      competitive: false,
+    }));
+    sessionStorage.setItem('__cg-link-response', 'no');
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchanges.push({
+        authorization: request.headers().authorization ?? null,
+        body: request.postDataJSON(),
+      });
+      if (exchanges.length === 1) {
+        return route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify({ code: 'guestLinkConsentRequired' }),
+        });
+      }
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'new-crazygames-session',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'created',
+          user: {
+            id: 921,
+            username: 'Separate.Player',
+            mmr: 1000,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: null,
+          },
+          preferences: {},
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Separate.Player', { exact: true })).toBeVisible();
+
+  expect(exchanges).toEqual([
+    {
+      authorization: 'Bearer declined-guest-session',
+      body: {
+        token: 'fresh-crazygames-jwt',
+        guestPromotion: 'check',
+      },
+    },
+    {
+      authorization: 'Bearer declined-guest-session',
+      body: {
+        token: 'fresh-crazygames-jwt',
+        guestPromotion: 'decline',
+      },
+    },
+  ]);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('new-crazygames-session');
+});
+
+test('an unavailable account-link prompt fails closed and preserves the guest session', async ({ page }) => {
+  const exchanges = [];
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'retryable-guest-session');
+    sessionStorage.setItem('__cg-link-response', 'error');
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchanges.push({
+        authorization: request.headers().authorization ?? null,
+        body: request.postDataJSON(),
+      });
+      return route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({ code: 'guestLinkConsentRequired' }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Progress connection failed')).toBeVisible();
+
+  expect(exchanges).toEqual([{
+    authorization: 'Bearer retryable-guest-session',
+    body: {
+      token: 'fresh-crazygames-jwt',
+      guestPromotion: 'check',
+    },
+  }]);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('retryable-guest-session');
+});
+
+test('a direct privacy visit stays passive and resolves the account only after leaving', async ({ page }) => {
+  const exchanges = [];
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'privacy-guest-session');
+    sessionStorage.setItem('__cg-link-response', 'no');
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchanges.push(request.postDataJSON());
+      if (exchanges.length === 1) {
+        return route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify({ code: 'guestLinkConsentRequired' }),
+        });
+      }
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'privacy-return-session',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'created',
+          user: {
+            id: 922,
+            username: 'Privacy.Return',
+            mmr: 1000,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: null,
+          },
+          preferences: {},
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(`${appUrl}/#/privacy`);
+  await expect(page.getByRole('heading', { name: 'Privacy on CrazyGames' })).toBeVisible();
+  await page.waitForTimeout(500);
+  expect(exchanges).toEqual([]);
+  expect(await page.evaluate(() => window.__cgTest.tokenCalls)).toBe(0);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(0);
+
+  await page.getByRole('link', { name: /Back to Snaketron/ }).click();
+  await expect(page.getByText('Privacy.Return', { exact: true })).toBeVisible();
+  expect(exchanges).toEqual([
+    { token: 'fresh-crazygames-jwt', guestPromotion: 'check' },
+    { token: 'fresh-crazygames-jwt', guestPromotion: 'decline' },
+  ]);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(1);
+});
+
+test('preference writes stay serialized and a delayed response cannot overwrite a newer edit', async ({ page }) => {
+  const putBodies = [];
+  let concurrentPuts = 0;
+  let maxConcurrentPuts = 0;
+  let targetWriteStarted = false;
+  let releaseFirstPut;
+  let notifyFirstPut;
+  const firstPutReleased = new Promise(resolve => { releaseFirstPut = resolve; });
+  const firstPutStarted = new Promise(resolve => { notifyFirstPut = resolve; });
+
+  await page.addInitScript(() => localStorage.clear());
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: sdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'preference-session',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'returning',
+          user: {
+            id: 919,
+            username: 'Preference.Player',
+            mmr: 1000,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: null,
+          },
+          preferences: {},
+        }),
+      });
+    }
+    if (pathname === '/api/auth/crazygames/preferences') {
+      concurrentPuts += 1;
+      maxConcurrentPuts = Math.max(maxConcurrentPuts, concurrentPuts);
+      const body = request.postDataJSON();
+      const isTargetWrite = body.lobbyPreferences?.selectedModes?.includes('2v2');
+      if (isTargetWrite && !targetWriteStarted) {
+        targetWriteStarted = true;
+        putBodies.push(body);
+        notifyFirstPut();
+        await firstPutReleased;
+      } else if (targetWriteStarted) {
+        putBodies.push(body);
+      }
+      concurrentPuts -= 1;
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({ preferences: body }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Preference.Player', { exact: true })).toBeVisible();
+  await page.getByRole('button', { name: '2V2', exact: true }).click();
+  await firstPutStarted;
+  await page.getByRole('button', { name: '2V2', exact: true }).click();
+  await page.getByRole('button', { name: 'FFA', exact: true }).click();
+  await page.getByText('Competitive', { exact: true }).click();
+
+  // Hold the real first fetch beyond the second edit's debounce window. No
+  // second request may begin until this one actually settles.
+  await page.waitForTimeout(900);
+  expect(putBodies).toHaveLength(1);
+  releaseFirstPut();
+  await expect.poll(() => putBodies.length).toBe(2);
+  expect(maxConcurrentPuts).toBe(1);
+  expect(putBodies[0].lobbyPreferences).toEqual({
+    selectedModes: ['duel', '2v2'],
+    competitive: false,
+  });
+  expect(putBodies[1].lobbyPreferences).toEqual({
+    selectedModes: ['duel', 'ffa'],
+    competitive: true,
+  });
+  await expect.poll(() => page.evaluate(() => (
+    JSON.parse(sessionStorage.getItem('lastLobbyPreferences'))
+  ))).toEqual({ selectedModes: ['duel', 'ffa'], competitive: true });
+});
+
+test('signed-out CrazyGames users stay guest-capable without restoring a linked account', async ({ page }) => {
+  let guestCalls = 0;
+  const requests = [];
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'previous-linked-session');
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: signedOutSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    requests.push(pathname);
+    const headers = { 'access-control-allow-origin': '*' };
+
+    if (pathname === '/api/auth/me') {
+      expect(request.headers().authorization).toBe('Bearer previous-linked-session');
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({ id: 111, username: 'Previous.Player', mmr: 1000, isGuest: false }),
+      });
+    }
+    if (pathname === '/api/auth/guest') {
+      guestCalls += 1;
+      expect(request.headers().authorization).toBeUndefined();
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'new-guest-session',
+          user: { id: 222, username: 'GuestPlayer', mmr: 1000, isGuest: true },
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Sign in with CrazyGames').first()).toBeVisible();
+  expect(requests).not.toContain('/api/auth/crazygames/exchange');
+  expect(guestCalls).toBe(0);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBeNull();
+
+  await page.getByPlaceholder('Nickname').fill('GuestPlayer');
+  await page.getByRole('button', { name: 'Start Game' }).click();
+  await expect.poll(() => guestCalls).toBe(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('new-guest-session');
+});
+
+test('a transient guest verification failure preserves the saved guest for retry', async ({ page }) => {
+  let meCalls = 0;
+  let guestCreationCalls = 0;
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    localStorage.setItem('snaketron:crazygames:session-token', 'saved-guest-session');
+    localStorage.setItem('lastLobbyPreferences', JSON.stringify({
+      selectedModes: ['ffa'],
+      competitive: false,
+    }));
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: signedOutSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/me') {
+      meCalls += 1;
+      expect(request.headers().authorization).toBe('Bearer saved-guest-session');
+      if (meCalls === 1) {
+        return route.fulfill({
+          status: 503,
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify({ error: 'temporary outage' }),
+        });
+      }
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          id: 515,
+          username: 'SavedGuest',
+          mmr: 1000,
+          isGuest: true,
+        }),
+      });
+    }
+    if (pathname === '/api/auth/guest') {
+      guestCreationCalls += 1;
+      return route.abort();
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Progress connection failed')).toBeVisible();
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('saved-guest-session');
+  expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lastLobbyPreferences'))))
+    .toEqual({ selectedModes: ['ffa'], competitive: false });
+
+  await page.getByRole('button', { name: 'Retry account sync' }).click();
+  await expect(page.getByText('Sign in with CrazyGames').first()).toBeVisible();
+  expect(meCalls).toBe(2);
+  expect(guestCreationCalls).toBe(0);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('saved-guest-session');
+  expect(await page.evaluate(() => JSON.parse(sessionStorage.getItem('lastLobbyPreferences'))))
+    .toEqual({ selectedModes: ['ffa'], competitive: false });
+});
+
+test('embeds without CrazyGames account support remain fully guest-capable', async ({ page }) => {
+  let exchangeCalls = 0;
+
+  await page.addInitScript(() => localStorage.clear());
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: accountUnavailableSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const pathname = new URL(route.request().url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchangeCalls += 1;
+      return route.abort();
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Playing as guest').first()).toBeVisible();
+  await expect(page.getByText('Playing as CrazyGames guest')).toBeVisible();
+  expect(exchangeCalls).toBe(0);
+  expect(await page.evaluate(() => window.__cgTest.tokenCalls)).toBe(0);
+});
+
+test('a successfully initialized disabled SDK environment remains fully guest-capable', async ({ page }) => {
+  let exchangeCalls = 0;
+  let guestCalls = 0;
+
+  await page.addInitScript(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: disabledEnvironmentSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchangeCalls += 1;
+      return route.abort();
+    }
+    if (pathname === '/api/auth/guest') {
+      guestCalls += 1;
+      expect(request.headers().authorization).toBeUndefined();
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'disabled-environment-guest-session',
+          user: {
+            id: 923,
+            username: 'AffiliateGuest',
+            mmr: 1000,
+            isGuest: true,
+          },
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Playing as guest').first()).toBeVisible();
+  await expect(page.getByText('Playing as CrazyGames guest')).toBeVisible();
+  expect(exchangeCalls).toBe(0);
+  expect(await page.evaluate(() => window.__cgTest.tokenCalls)).toBe(0);
+  expect(await page.evaluate(() => window.__cgTest.linkPromptCalls)).toBe(0);
+
+  await page.getByPlaceholder('Nickname').fill('AffiliateGuest');
+  await page.getByRole('button', { name: 'Start Game' }).click();
+  await expect.poll(() => guestCalls).toBe(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('disabled-environment-guest-session');
+});
+
+test('retry hard-reloads after SDK bootstrap is unavailable', async ({ page }) => {
+  const missingSdkScript = `
+    sessionStorage.setItem(
+      '__cg-missing-sdk-loads',
+      String(Number(sessionStorage.getItem('__cg-missing-sdk-loads') || '0') + 1)
+    );
+  `;
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: missingSdkScript,
+  }));
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Progress connection failed')).toBeVisible();
+  expect(await page.evaluate(() => Number(sessionStorage.getItem('__cg-missing-sdk-loads'))))
+    .toBe(1);
+
+  await page.getByRole('button', { name: 'Retry account sync' }).click();
+  await expect.poll(() => page.evaluate(() => (
+    Number(sessionStorage.getItem('__cg-missing-sdk-loads'))
+  ))).toBeGreaterThanOrEqual(2);
+  await expect(page.getByText('Progress connection failed')).toBeVisible();
+});
+
+test('an auth event during the initial exchange invalidates the old account before render', async ({ page }) => {
+  const exchangedTokens = [];
+  let resolveFirstExchange;
+  const firstExchangeStarted = new Promise(resolve => { resolveFirstExchange = resolve; });
+
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('__cg-race-initialized') !== 'true') {
+      localStorage.clear();
+      sessionStorage.setItem('__cg-race-initialized', 'true');
+      sessionStorage.setItem('__cg-race-account', 'a');
+    }
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: authRaceSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      const { token } = request.postDataJSON();
+      exchangedTokens.push(token);
+      if (token === 'crazygames-token-a') {
+        resolveFirstExchange();
+        await new Promise(resolve => setTimeout(resolve, 500));
+      }
+      const accountB = token === 'crazygames-token-b';
+      try {
+        return await route.fulfill({
+          contentType: 'application/json',
+          headers,
+          body: JSON.stringify({
+            token: accountB ? 'internal-account-b' : 'internal-account-a',
+            expiresAt: Math.floor(Date.now() / 1000) + 3600,
+            resolution: 'returning',
+            user: {
+              id: accountB ? 702 : 701,
+              username: accountB ? 'Account.B' : 'Account.A',
+              mmr: 1000,
+              isGuest: false,
+              authSource: 'crazygames',
+              avatarUrl: null,
+            },
+            preferences: {},
+          }),
+        });
+      } catch {
+        // Reloading intentionally aborts the superseded account-A request.
+        return undefined;
+      }
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await firstExchangeStarted;
+  await expect(page.getByText('Connecting your account')).toBeVisible();
+  await page.evaluate(() => {
+    sessionStorage.setItem('__cg-race-account', 'b');
+    window.__cgTest.emitAuth({
+      __dangerousUserId: 'display-only-account-b',
+      username: 'Account.B',
+      profilePictureUrl: '',
+    });
+  });
+
+  await expect(page.getByText('Account.B', { exact: true })).toBeVisible();
+  await expect(page.getByText('Account.A', { exact: true })).toHaveCount(0);
+  expect(exchangedTokens).toContain('crazygames-token-a');
+  expect(exchangedTokens).toContain('crazygames-token-b');
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('internal-account-b');
+});
+
+test('an auth event on the exchange-completion render boundary cannot be missed', async ({ page }) => {
+  const exchangedTokens = [];
+
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('__cg-boundary-initialized') !== 'true') {
+      localStorage.clear();
+      sessionStorage.setItem('__cg-boundary-initialized', 'true');
+      sessionStorage.setItem('__cg-race-account', 'a');
+    }
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: authBoundarySdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/crazygames/exchange') {
+      const { token } = request.postDataJSON();
+      exchangedTokens.push(token);
+      const accountB = token === 'crazygames-token-b';
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: accountB ? 'internal-boundary-b' : 'internal-boundary-a',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'returning',
+          user: {
+            id: accountB ? 802 : 801,
+            username: accountB ? 'Boundary.B' : 'Boundary.A',
+            mmr: 1000,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: null,
+          },
+          preferences: {},
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Boundary.B', { exact: true })).toBeVisible();
+  await expect(page.getByText('Boundary.A', { exact: true })).toHaveCount(0);
+  expect(exchangedTokens).toEqual([
+    'crazygames-token-a',
+    'crazygames-token-b',
+  ]);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('internal-boundary-b');
+});
+
+test('an in-page CrazyGames sign-in clears portal room state and reloads into the linked account', async ({ page }) => {
+  let guestCalls = 0;
+  let exchangeCalls = 0;
+
+  await page.addInitScript(() => {
+    if (sessionStorage.getItem('__cg-test-initialized') !== 'true') {
+      localStorage.clear();
+      sessionStorage.setItem('__cg-test-initialized', 'true');
+    }
+  });
+  await page.route('https://sdk.crazygames.com/crazygames-sdk-v3.js', route => route.fulfill({
+    contentType: 'application/javascript',
+    body: interactiveSignInSdkScript,
+  }));
+  await page.route('http://localhost:8080/api/**', async route => {
+    const request = route.request();
+    const pathname = new URL(request.url()).pathname;
+    const headers = { 'access-control-allow-origin': '*' };
+    if (pathname === '/api/auth/guest') {
+      guestCalls += 1;
+      return route.abort();
+    }
+    if (pathname === '/api/auth/crazygames/exchange') {
+      exchangeCalls += 1;
+      return route.fulfill({
+        contentType: 'application/json',
+        headers,
+        body: JSON.stringify({
+          token: 'linked-after-prompt',
+          expiresAt: Math.floor(Date.now() / 1000) + 3600,
+          resolution: 'created',
+          user: {
+            id: 333,
+            username: 'Verified.Player',
+            mmr: 1000,
+            isGuest: false,
+            authSource: 'crazygames',
+            avatarUrl: 'https://example.test/avatar.png',
+          },
+          preferences: {},
+        }),
+      });
+    }
+    if (pathname === '/api/regions') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '[]' });
+    }
+    if (pathname === '/api/regions/user-counts') {
+      return route.fulfill({ contentType: 'application/json', headers, body: '{}' });
+    }
+    return route.abort();
+  });
+
+  await page.goto(appUrl);
+  await expect(page.getByText('Sign in with CrazyGames').first()).toBeVisible();
+  await page.getByText('Sign in with CrazyGames').first().click();
+
+  await expect(page.getByText('Verified.Player', { exact: true })).toBeVisible();
+  expect(exchangeCalls).toBe(1);
+  expect(guestCalls).toBe(0);
+  expect(await page.evaluate(() => Number(sessionStorage.getItem('__cg-left-room') || '0')))
+    .toBeGreaterThanOrEqual(1);
+  expect(await page.evaluate(() => sessionStorage.getItem('snaketron:crazygames:session-token')))
+    .toBe('linked-after-prompt');
+});

--- a/client/web/tests/unit/crazyGames.test.ts
+++ b/client/web/tests/unit/crazyGames.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 import {
   crazyGames,
   crazyGamesGuestNickname,
+  normalizeCrazyGamesAccountError,
 } from '../../services/crazyGames.ts';
 
 type InviteParams = Record<string, string>;
@@ -12,7 +13,9 @@ const withInviteSdk = async (
   assertion: (input: {
     service: typeof crazyGames;
     emitJoinRoom: (params: InviteParams) => void;
+    getUserTokenCalls: () => number;
   }) => Promise<void>,
+  environment: 'local' | 'crazygames' | 'disabled' = 'local',
 ) => {
   const previousBuild = process.env.CRAZYGAMES_BUILD;
   const previousAds = process.env.CRAZYGAMES_ADS_ENABLED;
@@ -20,13 +23,14 @@ const withInviteSdk = async (
   const hadWindow = 'window' in globalThis;
   const previousWindow = (globalThis as any).window;
   let joinRoomListener: ((params: InviteParams) => void) | null = null;
+  let userTokenCalls = 0;
 
   process.env.CRAZYGAMES_BUILD = 'true';
   process.env.CRAZYGAMES_ADS_ENABLED = 'false';
   process.env.CRAZYGAMES_DATA_ENABLED = 'false';
 
   const sdk = {
-    environment: 'local',
+    environment,
     init: async () => {},
     ad: {
       hasAdblock: async () => false,
@@ -70,7 +74,7 @@ const withInviteSdk = async (
     user: {
       isUserAccountAvailable: false,
       getUser: async () => null,
-      getUserToken: async () => '',
+      getUserToken: async () => { userTokenCalls += 1; return ''; },
       listFriends: async () => ({ friends: [], page: 1, size: 50, hasMore: false, total: 0 }),
       showAuthPrompt: async () => { throw new Error('not authenticated'); },
       showAccountLinkPrompt: async () => ({ response: 'no' as const }),
@@ -91,6 +95,7 @@ const withInviteSdk = async (
         assert.ok(joinRoomListener, 'CrazyGames join-room listener was registered');
         joinRoomListener(params);
       },
+      getUserTokenCalls: () => userTokenCalls,
     });
   } finally {
     if (hadWindow) {
@@ -111,12 +116,56 @@ test('CrazyGames display names become valid, recognizable guest nicknames', () =
   assert.match(crazyGamesGuestNickname('x'), /^CGPlayer\d{4}$/);
 });
 
+test('CrazyGames account errors are normalized from SDK codes and messages', () => {
+  assert.deepEqual(
+    normalizeCrazyGamesAccountError({ code: 'userNotAuthenticated', message: 'sign in first' }),
+    { code: 'userNotAuthenticated', message: 'sign in first' },
+  );
+  assert.equal(
+    normalizeCrazyGamesAccountError(new Error('The user is not authenticated')).code,
+    'userNotAuthenticated',
+  );
+  assert.equal(
+    normalizeCrazyGamesAccountError({ code: 'unexpected', message: 'network failed' }).code,
+    'unknown',
+  );
+});
+
 test('the adapter fails open outside a CrazyGames build', async () => {
   const snapshot = await crazyGames.init();
   assert.equal(snapshot.isCrazyGamesBuild, false);
   assert.equal(snapshot.available, false);
   assert.equal(crazyGames.getDataModule(), null);
   assert.deepEqual(await crazyGames.requestAd('midgame'), { status: 'disabled' });
+});
+
+test('an embed without CrazyGames account support never calls account functionality', async () => {
+  await withInviteSdk(null, async ({ service, getUserTokenCalls }) => {
+    await service.init();
+    await assert.rejects(
+      service.getUserToken(),
+      (error: any) => error?.code === 'userAccountUnavailable',
+    );
+    assert.equal(getUserTokenCalls(), 0);
+    assert.equal(service.getSnapshot().accountStatus, 'unavailable');
+  });
+});
+
+test('a successfully initialized disabled SDK environment is guest-only, not a bootstrap failure', async () => {
+  await withInviteSdk(null, async ({ service, getUserTokenCalls }) => {
+    const snapshot = await service.init();
+    assert.equal(snapshot.initialized, true);
+    assert.equal(snapshot.available, false);
+    assert.equal(snapshot.environment, 'disabled');
+    assert.equal(snapshot.initializationError, null);
+    assert.equal(snapshot.accountError?.code, 'userAccountUnavailable');
+    await assert.rejects(
+      service.getUserToken(),
+      (error: any) => error?.code === 'userAccountUnavailable',
+    );
+    assert.equal(getUserTokenCalls(), 0);
+    assert.equal(service.getSnapshot().accountStatus, 'unavailable');
+  }, 'disabled');
 });
 
 test('cold-start inviteParams are published for the invitation bridge', async () => {
@@ -271,7 +320,9 @@ test('an enabled v3 adapter bridges settings, data, rooms, identity, and ads', a
     assert.equal(initialized.available, true);
     assert.equal(initialized.environment, 'local');
     assert.equal(initialized.isInstantMultiplayer, true);
-    assert.equal(service.getSnapshot().portalUser?.username, 'Portal.Player');
+    // Cosmetic profile lookup is deliberately deferred until after the
+    // security-critical token call, so SDK User-module calls never overlap.
+    assert.equal(service.getSnapshot().portalUser, null);
     assert.equal(service.getSnapshot().inviteSequence, 1);
 
     settingsListener({ disableChat: true, muteAudio: true });
@@ -298,8 +349,15 @@ test('an enabled v3 adapter bridges settings, data, rooms, identity, and ads', a
 
     authListener({ ...portalUser, username: 'Renamed.Player' });
     assert.equal(service.getSnapshot().portalUser?.username, 'Renamed.Player');
+    assert.equal(service.getSnapshot().authChangeSequence, 1);
     assert.equal(await service.getUserToken(), 'signed.jwt');
+    assert.equal(service.getSnapshot().accountStatus, 'authenticated');
     assert.equal(await service.requestBanner({ id: 'banner', width: 728, height: 90 }), true);
+
+    authListener(null);
+    assert.equal(service.getSnapshot().portalUser, null);
+    assert.equal(service.getSnapshot().accountStatus, 'signed-out');
+    assert.equal(service.getSnapshot().authChangeSequence, 2);
   } finally {
     if (hadWindow) {
       (globalThis as any).window = previousWindow;
@@ -309,5 +367,106 @@ test('an enabled v3 adapter bridges settings, data, rooms, identity, and ads', a
     process.env.CRAZYGAMES_BUILD = previousBuild;
     process.env.CRAZYGAMES_ADS_ENABLED = previousAds;
     process.env.CRAZYGAMES_DATA_ENABLED = previousData;
+  }
+});
+
+test('getUserToken is single-flight and runs before the display-only portal profile', async () => {
+  const previousBuild = process.env.CRAZYGAMES_BUILD;
+  const hadWindow = 'window' in globalThis;
+  const previousWindow = (globalThis as any).window;
+  process.env.CRAZYGAMES_BUILD = 'true';
+  let tokenCalls = 0;
+  let profileCalls = 0;
+  let linkPromptCalls = 0;
+  let linkPromptResponse = 'no';
+  let resolveToken: ((token: string) => void) | null = null;
+
+  const noOpGame = {
+    settings: {},
+    addSettingsChangeListener: () => {},
+    removeSettingsChangeListener: () => {},
+    addJoinRoomListener: () => {},
+    removeJoinRoomListener: () => {},
+    gameplayStart: () => {},
+    gameplayStop: () => {},
+    loadingStart: () => {},
+    loadingStop: () => {},
+    happytime: () => {},
+    reportGameCompletedPercentage: () => {},
+    setGameContext: () => {},
+    clearGameContext: () => {},
+    updateRoom: () => {},
+    leftRoom: () => {},
+    inviteLink: () => '',
+    getInviteParam: () => null,
+  };
+  (globalThis as any).window = {
+    CrazyGames: {
+      SDK: {
+        environment: 'local',
+        init: async () => {},
+        ad: { hasAdblock: async () => false, requestAd: () => {} },
+        banner: {
+          requestBanner: async () => {}, requestResponsiveBanner: async () => {},
+          clearBanner: () => {}, clearAllBanners: () => {},
+        },
+        data: { clear: () => {}, getItem: () => null, removeItem: () => {}, setItem: () => {} },
+        game: noOpGame,
+        user: {
+          isUserAccountAvailable: true,
+          getUser: () => {
+            profileCalls += 1;
+            return new Promise(() => {});
+          },
+          getUserToken: () => new Promise<string>((resolve) => {
+            tokenCalls += 1;
+            resolveToken = resolve;
+          }),
+          listFriends: async () => ({ friends: [], page: 1, size: 50, hasMore: false, total: 0 }),
+          showAuthPrompt: async () => { throw new Error('cancelled'); },
+          showAccountLinkPrompt: async () => {
+            linkPromptCalls += 1;
+            return { response: linkPromptResponse };
+          },
+          addAuthListener: () => {},
+          removeAuthListener: () => {},
+        },
+      },
+    },
+  };
+
+  try {
+    const module = await import(`../../services/crazyGames.ts?token-first=${Date.now()}`);
+    const service = module.crazyGames as typeof crazyGames;
+    await service.init();
+    assert.equal(service.getSnapshot().portalUser, null);
+    assert.equal(profileCalls, 0);
+    const firstToken = service.getUserToken();
+    const concurrentToken = service.getUserToken();
+    assert.equal(tokenCalls, 1);
+    assert.equal(profileCalls, 0);
+    assert.ok(resolveToken);
+    resolveToken('fresh.jwt');
+    assert.deepEqual(await Promise.all([firstToken, concurrentToken]), [
+      'fresh.jwt',
+      'fresh.jwt',
+    ]);
+    assert.equal(service.getSnapshot().accountStatus, 'authenticated');
+    assert.equal(service.getSnapshot().portalUser, null);
+    assert.equal(await service.showAccountLinkPrompt(), 'no');
+    assert.equal(linkPromptCalls, 1);
+    assert.equal(profileCalls, 0);
+    linkPromptResponse = 'unexpected';
+    assert.equal(await service.showAccountLinkPrompt(), null);
+    assert.equal(linkPromptCalls, 2);
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    assert.equal(profileCalls, 1);
+  } finally {
+    if (hadWindow) {
+      (globalThis as any).window = previousWindow;
+    } else {
+      delete (globalThis as any).window;
+    }
+    process.env.CRAZYGAMES_BUILD = previousBuild;
   }
 });

--- a/client/web/tests/unit/crazyGamesPreferences.test.ts
+++ b/client/web/tests/unit/crazyGamesPreferences.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+const makeStorage = () => {
+  const values = new Map<string, string>();
+  return {
+    values,
+    storage: {
+      get length() { return values.size; },
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      key: (index: number) => [...values.keys()][index] ?? null,
+      removeItem: (key: string) => { values.delete(key); },
+      setItem: (key: string, value: string) => { values.set(key, String(value)); },
+    },
+  };
+};
+
+test('CrazyGames preferences sanitize local values and apply the server snapshot', async () => {
+  const hadWindow = 'window' in globalThis;
+  const previousWindow = (globalThis as any).window;
+  const { values, storage } = makeStorage();
+  (globalThis as any).window = { localStorage: storage };
+
+  const manyTutorials = Object.fromEntries(
+    Array.from({ length: 140 }, (_unused, index) => [`tutorial-${index}`, true]),
+  );
+  values.set('snaketron:tutorial-seen:v1', JSON.stringify({
+    movement: true,
+    boost: false,
+    ...manyTutorials,
+    ['x'.repeat(65)]: true,
+    ['bad\u0000key']: true,
+  }));
+  values.set('lastLobbyPreferences', JSON.stringify({
+    selectedModes: ['duel', 'bad-mode', 'duel', 'solo'],
+    competitive: true,
+  }));
+  values.set('snaketron:boost-input-mode:v1', 'toggle');
+
+  try {
+    const {
+      applyCrazyGamesPreferences,
+      clearLinkedCrazyGamesPreferences,
+      crazyGamesPreferenceOwner,
+      markCrazyGamesPreferencesOwnedBy,
+      readCrazyGamesPreferences,
+    } = await import(`../../services/crazyGamesPreferences.ts?prefs=${Date.now()}`);
+
+    const sanitized = readCrazyGamesPreferences();
+    assert.equal(Object.keys(sanitized.tutorialSeen!).length, 128);
+    assert.equal(sanitized.tutorialSeen?.movement, true);
+    assert.equal(sanitized.tutorialSeen?.boost, undefined);
+    assert.equal(sanitized.tutorialSeen?.['x'.repeat(65)], undefined);
+    assert.equal(sanitized.tutorialSeen?.['bad\u0000key'], undefined);
+    assert.deepEqual(sanitized.lobbyPreferences, {
+      selectedModes: ['duel', 'solo'],
+      competitive: true,
+    });
+    assert.equal(sanitized.boostInputMode, 'toggle');
+
+    applyCrazyGamesPreferences({
+      tutorialSeen: { movement: true, boost: true },
+      lobbyPreferences: { selectedModes: ['ffa'], competitive: false },
+      boostInputMode: 'hold',
+    });
+    assert.deepEqual(JSON.parse(values.get('snaketron:tutorial-seen:v1')!), {
+      movement: true,
+      boost: true,
+    });
+    assert.deepEqual(JSON.parse(values.get('lastLobbyPreferences')!), {
+      selectedModes: ['ffa'],
+      competitive: false,
+    });
+    assert.equal(values.get('snaketron:boost-input-mode:v1'), 'hold');
+
+    markCrazyGamesPreferencesOwnedBy(912);
+    assert.equal(crazyGamesPreferenceOwner(), 912);
+    clearLinkedCrazyGamesPreferences();
+    assert.equal(crazyGamesPreferenceOwner(), null);
+    assert.equal(values.has('snaketron:tutorial-seen:v1'), false);
+    assert.equal(values.has('lastLobbyPreferences'), false);
+    assert.equal(values.has('snaketron:boost-input-mode:v1'), false);
+
+    // Missing fields in a canonical server snapshot are deletions, not an
+    // instruction to leak a prior account's browser-local values.
+    values.set('lastLobbyPreferences', JSON.stringify({
+      selectedModes: ['duel'],
+      competitive: false,
+    }));
+    applyCrazyGamesPreferences({}, true);
+    assert.equal(values.has('lastLobbyPreferences'), false);
+  } finally {
+    if (hadWindow) {
+      (globalThis as any).window = previousWindow;
+    } else {
+      delete (globalThis as any).window;
+    }
+  }
+});

--- a/client/web/tests/unit/gameStorageCrazyGames.test.ts
+++ b/client/web/tests/unit/gameStorageCrazyGames.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+test('CrazyGames preference memory stays authoritative when sessionStorage is blocked', async () => {
+  const previousBuild = process.env.CRAZYGAMES_BUILD;
+  const hadWindow = 'window' in globalThis;
+  const previousWindow = (globalThis as any).window;
+  const localValues = new Map<string, string>();
+  let published = 0;
+
+  process.env.CRAZYGAMES_BUILD = 'true';
+  (globalThis as any).window = {
+    localStorage: {
+      getItem: (key: string) => localValues.get(key) ?? null,
+      setItem: (key: string, value: string) => localValues.set(key, String(value)),
+      removeItem: (key: string) => { localValues.delete(key); },
+    },
+    sessionStorage: {
+      getItem: () => null,
+      setItem: () => { throw new Error('blocked'); },
+      removeItem: () => { throw new Error('blocked'); },
+    },
+  };
+
+  try {
+    const { gameStorage, subscribeGameStorage } = await import(
+      `../../services/gameStorage.ts?cg-memory=${Date.now()}`
+    );
+    const unsubscribe = subscribeGameStorage(() => { published += 1; });
+
+    gameStorage.setItem('lastLobbyPreferences', 'account-a');
+    localValues.set('lastLobbyPreferences', 'account-b');
+    assert.equal(gameStorage.getItem('lastLobbyPreferences'), 'account-a');
+    assert.equal(published, 1);
+
+    gameStorage.removeItem('lastLobbyPreferences');
+    localValues.set('lastLobbyPreferences', 'stale-account-b');
+    assert.equal(gameStorage.getItem('lastLobbyPreferences'), null);
+    assert.equal(published, 2);
+    unsubscribe();
+  } finally {
+    process.env.CRAZYGAMES_BUILD = previousBuild;
+    if (hadWindow) {
+      (globalThis as any).window = previousWindow;
+    } else {
+      delete (globalThis as any).window;
+    }
+  }
+});

--- a/client/web/types/index.ts
+++ b/client/web/types/index.ts
@@ -63,7 +63,16 @@ export interface User {
   mmr?: number;
   token?: string;
   isGuest?: boolean;
+  authSource?: 'crazygames' | string;
+  avatarUrl?: string | null;
 }
+
+export type CrazyGamesSessionStatus =
+  | 'not-applicable'
+  | 'resolving'
+  | 'linked'
+  | 'guest'
+  | 'error';
 
 export interface AuthContextType {
   user: User | null;
@@ -71,9 +80,15 @@ export interface AuthContextType {
   login: (username: string, password: string) => Promise<void>;
   register: (username: string, password: string | null) => Promise<void>;
   createGuest: (nickname: string) => Promise<{ user: User; token: string }>;
+  ensurePlayableSession: (nickname?: string) => Promise<{ user: User; token: string }>;
   updateGuestNickname: (nickname: string) => void;
   logout: () => void;
   getToken: () => string | null;
+  crazyGamesSessionStatus: CrazyGamesSessionStatus;
+  crazyGamesSessionError: string | null;
+  retryCrazyGamesSession: () => Promise<void>;
+  beginCrazyGamesAccountTransition: () => void;
+  crazyGamesAccountTransitionSequence: number;
 }
 
 // Lobby Types
@@ -145,6 +160,7 @@ export interface WebSocketContextType {
   createLobby: () => Promise<void>;
   joinLobby: (lobbyCode: string) => Promise<void>;
   leaveLobby: () => Promise<void>;
+  clearSessionForAccountChange: () => void;
   sendChatMessage: (scope: ChatScope, message: string) => void;
   updateLobbyPreferences: (preferences: LobbyPreferences) => void;
 }

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -11,6 +11,11 @@ const isProduction = process.env.NODE_ENV === 'production';
 // href "./" in index.html) and routing must not rely on the History API.
 const isItchBuild = process.env.ITCH_BUILD === 'true';
 const isCrazyGamesBuild = process.env.CRAZYGAMES_BUILD === 'true';
+
+if (isItchBuild && isCrazyGamesBuild) {
+  throw new Error('ITCH_BUILD and CRAZYGAMES_BUILD are mutually exclusive release targets');
+}
+
 const isEmbeddedBuild = isItchBuild || isCrazyGamesBuild;
 
 module.exports = {

--- a/server/src/api/auth.rs
+++ b/server/src/api/auth.rs
@@ -21,6 +21,7 @@ pub struct AuthState {
     pub db: Arc<dyn Database>,
     pub jwt_manager: Arc<JwtManager>,
     pub user_cache: Option<UserCache>,
+    pub crazygames_verifier: Option<Arc<super::crazygames::CrazyGamesJwtVerifier>>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/server/src/api/crazygames.rs
+++ b/server/src/api/crazygames.rs
@@ -1,0 +1,937 @@
+use anyhow::{Context, Result};
+use axum::{
+    Json,
+    extract::{Extension, State},
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use chrono::Utc;
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashSet, sync::Arc, time::Duration};
+use tokio::sync::{Mutex, RwLock};
+use tracing::{info, warn};
+use url::Url;
+
+use crate::{
+    db::models::{
+        CrazyGamesAccountOutcome, CrazyGamesAccountResolution, CrazyGamesGuestPromotion,
+        CrazyGamesPreferences, CrazyGamesProfile,
+    },
+    matchmaking_pool::MatchmakingPool,
+};
+
+use super::{auth::AuthState, middleware::AuthUser};
+
+pub const CRAZYGAMES_AUTH_ENABLED_ENV: &str = "SNAKETRON_CRAZYGAMES_AUTH_ENABLED";
+pub const CRAZYGAMES_GAME_ID_ENV: &str = "SNAKETRON_CRAZYGAMES_GAME_ID";
+const CRAZYGAMES_PUBLIC_KEY_URL: &str = "https://sdk.crazygames.com/publicKey.json";
+const PUBLIC_KEY_CACHE_TTL: Duration = Duration::from_secs(15 * 60);
+// Invalid signatures are attacker-controlled. Limit forced rotation checks so
+// sequential forged tokens cannot turn the official key endpoint into an
+// outbound request oracle; a real rotation can be delayed only briefly.
+const SIGNATURE_REFRESH_COOLDOWN: Duration = Duration::from_secs(30);
+const PUBLIC_KEY_FETCH_FAILURE_BACKOFF: Duration = Duration::from_secs(5);
+const MAX_PUBLIC_KEY_RESPONSE_BYTES: usize = 32 * 1024;
+const MAX_TOKEN_BYTES: usize = 16 * 1024;
+const MAX_TOKEN_LIFETIME_SECONDS: i64 = 2 * 60 * 60;
+const CLOCK_SKEW_SECONDS: i64 = 60;
+const MAX_PREFERENCES_BYTES: usize = 32 * 1024;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CrazyGamesTokenClaims {
+    pub user_id: String,
+    pub game_id: String,
+    pub username: String,
+    pub profile_picture_url: String,
+    pub iat: i64,
+    pub exp: i64,
+}
+
+impl CrazyGamesTokenClaims {
+    fn validate(&self, expected_game_id: &str) -> std::result::Result<(), VerifyError> {
+        let now = Utc::now().timestamp();
+        if self.game_id != expected_game_id
+            || self.user_id.is_empty()
+            || self.user_id.len() > 256
+            || self.user_id.chars().any(char::is_control)
+            || self.username.is_empty()
+            || self.username.len() > 128
+            || self.username.chars().any(char::is_control)
+            || self.profile_picture_url.len() > 2048
+            || Url::parse(&self.profile_picture_url)
+                .ok()
+                .is_none_or(|url| url.scheme() != "https" || url.host_str().is_none())
+            || self.iat > now + CLOCK_SKEW_SECONDS
+            || self.exp <= self.iat
+            || self
+                .exp
+                .checked_sub(self.iat)
+                .is_none_or(|lifetime| lifetime > MAX_TOKEN_LIFETIME_SECONDS)
+            || self.exp <= now - CLOCK_SKEW_SECONDS
+        {
+            return Err(VerifyError::InvalidToken);
+        }
+        Ok(())
+    }
+
+    fn profile(&self) -> CrazyGamesProfile {
+        CrazyGamesProfile {
+            provider_user_id: self.user_id.clone(),
+            username: self.username.clone(),
+            avatar_url: self.profile_picture_url.clone(),
+            profile_iat: self.iat,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum VerifyError {
+    #[error("invalid CrazyGames token")]
+    InvalidToken,
+    #[error("CrazyGames public key is unavailable")]
+    PublicKeyUnavailable,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PublicKeyDocument {
+    public_key: String,
+}
+
+#[derive(Clone)]
+struct CachedPublicKey {
+    pem: String,
+    fetched_at: std::time::Instant,
+    generation: u64,
+}
+
+/// Verifies CrazyGames JWTs without introducing a dependency into ordinary
+/// Snaketron auth. The key is fetched lazily, cached briefly, and forcibly
+/// refreshed once after an RS256 signature failure to handle key rotation.
+pub struct CrazyGamesJwtVerifier {
+    expected_game_id: String,
+    client: reqwest::Client,
+    #[cfg(test)]
+    public_key_url: String,
+    cache: RwLock<Option<CachedPublicKey>>,
+    refresh_lock: Mutex<()>,
+    last_network_fetch_attempt: RwLock<Option<std::time::Instant>>,
+    fetch_public_key: bool,
+}
+
+impl CrazyGamesJwtVerifier {
+    pub fn new(expected_game_id: String) -> Result<Self> {
+        if expected_game_id.trim().is_empty() {
+            anyhow::bail!("{CRAZYGAMES_GAME_ID_ENV} must not be empty");
+        }
+        let client = reqwest::Client::builder()
+            .connect_timeout(Duration::from_secs(2))
+            .timeout(Duration::from_secs(5))
+            .build()
+            .context("Failed to construct CrazyGames public-key client")?;
+        Ok(Self {
+            expected_game_id,
+            client,
+            #[cfg(test)]
+            public_key_url: CRAZYGAMES_PUBLIC_KEY_URL.to_string(),
+            cache: RwLock::new(None),
+            refresh_lock: Mutex::new(()),
+            last_network_fetch_attempt: RwLock::new(None),
+            fetch_public_key: true,
+        })
+    }
+
+    #[cfg(test)]
+    fn with_static_key(expected_game_id: &str, public_key: &str) -> Self {
+        Self {
+            expected_game_id: expected_game_id.to_string(),
+            client: reqwest::Client::new(),
+            public_key_url: CRAZYGAMES_PUBLIC_KEY_URL.to_string(),
+            cache: RwLock::new(Some(CachedPublicKey {
+                pem: public_key.to_string(),
+                fetched_at: std::time::Instant::now(),
+                generation: 1,
+            })),
+            refresh_lock: Mutex::new(()),
+            last_network_fetch_attempt: RwLock::new(Some(std::time::Instant::now())),
+            fetch_public_key: false,
+        }
+    }
+
+    #[cfg(test)]
+    fn with_fetching_key_url(expected_game_id: &str, public_key_url: String) -> Self {
+        Self {
+            expected_game_id: expected_game_id.to_string(),
+            client: reqwest::Client::builder()
+                .connect_timeout(Duration::from_secs(1))
+                .timeout(Duration::from_secs(1))
+                .build()
+                .expect("test public-key client"),
+            public_key_url,
+            cache: RwLock::new(None),
+            refresh_lock: Mutex::new(()),
+            last_network_fetch_attempt: RwLock::new(None),
+            fetch_public_key: true,
+        }
+    }
+
+    fn public_key_url(&self) -> &str {
+        #[cfg(test)]
+        {
+            &self.public_key_url
+        }
+        #[cfg(not(test))]
+        {
+            CRAZYGAMES_PUBLIC_KEY_URL
+        }
+    }
+
+    async fn public_key(
+        &self,
+        refresh_after_generation: Option<u64>,
+    ) -> std::result::Result<CachedPublicKey, VerifyError> {
+        if refresh_after_generation.is_none()
+            && let Some(cached) = self.cache.read().await.as_ref()
+            && cached.fetched_at.elapsed() < PUBLIC_KEY_CACHE_TTL
+        {
+            return Ok(cached.clone());
+        }
+
+        let _refresh_guard = self.refresh_lock.lock().await;
+        if let Some(cached) = self.cache.read().await.as_ref()
+            && (refresh_after_generation.is_some_and(|observed| cached.generation != observed)
+                || (refresh_after_generation.is_none()
+                    && cached.fetched_at.elapsed() < PUBLIC_KEY_CACHE_TTL))
+        {
+            // Another request already refreshed this generation while we
+            // waited for the single-flight lock.
+            return Ok(cached.clone());
+        }
+        if let Some(last_attempt) = *self.last_network_fetch_attempt.read().await {
+            let retry_window = if refresh_after_generation.is_some() {
+                SIGNATURE_REFRESH_COOLDOWN
+            } else {
+                PUBLIC_KEY_FETCH_FAILURE_BACKOFF
+            };
+            if last_attempt.elapsed() < retry_window {
+                // Return a cached key when possible so valid tokens signed by
+                // it remain available. With no key, preserve a short negative
+                // cache after network failure instead of retrying per request.
+                return self
+                    .cache
+                    .read()
+                    .await
+                    .as_ref()
+                    .cloned()
+                    .ok_or(VerifyError::PublicKeyUnavailable);
+            }
+        }
+        if !self.fetch_public_key {
+            return self
+                .cache
+                .read()
+                .await
+                .as_ref()
+                .cloned()
+                .ok_or(VerifyError::PublicKeyUnavailable);
+        }
+
+        *self.last_network_fetch_attempt.write().await = Some(std::time::Instant::now());
+
+        let mut response = self
+            .client
+            .get(self.public_key_url())
+            .send()
+            .await
+            .map_err(|error| {
+                warn!("Failed to fetch CrazyGames public key: {error}");
+                VerifyError::PublicKeyUnavailable
+            })?
+            .error_for_status()
+            .map_err(|error| {
+                warn!("CrazyGames public-key endpoint failed: {error}");
+                VerifyError::PublicKeyUnavailable
+            })?;
+        if response
+            .content_length()
+            .is_some_and(|size| size > MAX_PUBLIC_KEY_RESPONSE_BYTES as u64)
+        {
+            return Err(VerifyError::PublicKeyUnavailable);
+        }
+        let mut body = Vec::new();
+        while let Some(chunk) = response.chunk().await.map_err(|error| {
+            warn!("Failed to read CrazyGames public key: {error}");
+            VerifyError::PublicKeyUnavailable
+        })? {
+            let next_len = body
+                .len()
+                .checked_add(chunk.len())
+                .ok_or(VerifyError::PublicKeyUnavailable)?;
+            if next_len > MAX_PUBLIC_KEY_RESPONSE_BYTES {
+                return Err(VerifyError::PublicKeyUnavailable);
+            }
+            body.extend_from_slice(&chunk);
+        }
+        let document: PublicKeyDocument = serde_json::from_slice(&body).map_err(|error| {
+            warn!("Invalid CrazyGames public-key document: {error}");
+            VerifyError::PublicKeyUnavailable
+        })?;
+        DecodingKey::from_rsa_pem(document.public_key.as_bytes()).map_err(|error| {
+            warn!("Invalid CrazyGames RSA public key: {error}");
+            VerifyError::PublicKeyUnavailable
+        })?;
+        let generation = self
+            .cache
+            .read()
+            .await
+            .as_ref()
+            .map_or(1, |cached| cached.generation.saturating_add(1));
+        let cached = CachedPublicKey {
+            pem: document.public_key.clone(),
+            fetched_at: std::time::Instant::now(),
+            generation,
+        };
+        *self.cache.write().await = Some(cached.clone());
+        Ok(cached)
+    }
+
+    fn decode_with_key(
+        &self,
+        token: &str,
+        public_key: &str,
+    ) -> std::result::Result<CrazyGamesTokenClaims, jsonwebtoken::errors::Error> {
+        let key = DecodingKey::from_rsa_pem(public_key.as_bytes())?;
+        let mut validation = Validation::new(Algorithm::RS256);
+        validation.algorithms = vec![Algorithm::RS256];
+        validation.leeway = CLOCK_SKEW_SECONDS as u64;
+        validation.validate_exp = true;
+        validation.set_required_spec_claims(&["exp"]);
+        decode::<CrazyGamesTokenClaims>(token, &key, &validation).map(|data| data.claims)
+    }
+
+    pub async fn verify(
+        &self,
+        token: &str,
+    ) -> std::result::Result<CrazyGamesTokenClaims, VerifyError> {
+        if token.is_empty() || token.len() > MAX_TOKEN_BYTES {
+            return Err(VerifyError::InvalidToken);
+        }
+        let header = decode_header(token).map_err(|_| VerifyError::InvalidToken)?;
+        if header.alg != Algorithm::RS256 {
+            return Err(VerifyError::InvalidToken);
+        }
+
+        let key = self.public_key(None).await?;
+        let claims = match self.decode_with_key(token, &key.pem) {
+            Ok(claims) => claims,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    jsonwebtoken::errors::ErrorKind::InvalidSignature
+                ) =>
+            {
+                let refreshed = self.public_key(Some(key.generation)).await?;
+                self.decode_with_key(token, &refreshed.pem)
+                    .map_err(|_| VerifyError::InvalidToken)?
+            }
+            Err(_) => return Err(VerifyError::InvalidToken),
+        };
+        claims.validate(&self.expected_game_id)?;
+        Ok(claims)
+    }
+}
+
+pub fn configured_verifier_from_env() -> Result<Option<Arc<CrazyGamesJwtVerifier>>> {
+    let enabled = match std::env::var(CRAZYGAMES_AUTH_ENABLED_ENV) {
+        Err(std::env::VarError::NotPresent) => false,
+        Err(error) => return Err(error).context("Invalid CrazyGames auth enabled setting"),
+        Ok(value) if value.eq_ignore_ascii_case("true") => true,
+        Ok(value) if value.is_empty() || value.eq_ignore_ascii_case("false") => false,
+        Ok(value) => anyhow::bail!(
+            "{CRAZYGAMES_AUTH_ENABLED_ENV} must be either true or false, got '{value}'"
+        ),
+    };
+    if !enabled {
+        return Ok(None);
+    }
+    let game_id = std::env::var(CRAZYGAMES_GAME_ID_ENV)
+        .with_context(|| format!("{CRAZYGAMES_GAME_ID_ENV} is required when auth is enabled"))?;
+    Ok(Some(Arc::new(CrazyGamesJwtVerifier::new(game_id)?)))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ExchangeRequest {
+    pub token: String,
+    #[serde(default)]
+    pub guest_promotion: CrazyGamesGuestPromotion,
+    #[serde(default)]
+    pub initial_preferences: Option<CrazyGamesPreferences>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExchangeResponse {
+    pub token: String,
+    pub expires_at: i64,
+    pub resolution: CrazyGamesAccountResolution,
+    pub user: CrazyGamesUserInfo,
+    pub preferences: CrazyGamesPreferences,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CrazyGamesUserInfo {
+    pub id: i32,
+    pub username: String,
+    pub mmr: i32,
+    pub ranked_mmr: i32,
+    pub casual_mmr: i32,
+    pub xp: i32,
+    pub is_guest: bool,
+    pub auth_source: &'static str,
+    pub avatar_url: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PreferencesResponse {
+    pub preferences: CrazyGamesPreferences,
+}
+
+#[derive(Debug)]
+pub enum CrazyGamesApiError {
+    Disabled,
+    InvalidToken,
+    PublicKeyUnavailable,
+    InvalidPreferences,
+    GuestLinkConsentRequired,
+    NotLinked,
+    Internal(anyhow::Error),
+}
+
+impl IntoResponse for CrazyGamesApiError {
+    fn into_response(self) -> Response {
+        let (status, message, code) = match self {
+            Self::Disabled => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "CrazyGames account integration is unavailable",
+                None,
+            ),
+            Self::InvalidToken => (StatusCode::UNAUTHORIZED, "Invalid CrazyGames token", None),
+            Self::PublicKeyUnavailable => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "CrazyGames authentication is temporarily unavailable",
+                None,
+            ),
+            Self::InvalidPreferences => (
+                StatusCode::BAD_REQUEST,
+                "Invalid CrazyGames preferences",
+                None,
+            ),
+            Self::GuestLinkConsentRequired => (
+                StatusCode::CONFLICT,
+                "Guest progress can be linked to this CrazyGames account",
+                Some("guestLinkConsentRequired"),
+            ),
+            Self::NotLinked => (
+                StatusCode::FORBIDDEN,
+                "User is not linked to CrazyGames",
+                None,
+            ),
+            Self::Internal(error) => {
+                warn!("CrazyGames account integration error: {error:?}");
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Internal server error",
+                    None,
+                )
+            }
+        };
+        let body = match code {
+            Some(code) => serde_json::json!({ "error": message, "code": code }),
+            None => serde_json::json!({ "error": message }),
+        };
+        let mut response = (status, Json(body)).into_response();
+        apply_no_store_headers(&mut response);
+        response
+    }
+}
+
+fn apply_no_store_headers(response: &mut Response) {
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static("no-cache, no-store, must-revalidate, private"),
+    );
+    response
+        .headers_mut()
+        .insert(header::PRAGMA, HeaderValue::from_static("no-cache"));
+}
+
+fn guest_candidate(headers: &HeaderMap, state: &AuthState) -> Option<i32> {
+    let token = headers
+        .get(header::AUTHORIZATION)?
+        .to_str()
+        .ok()?
+        .strip_prefix("Bearer ")?;
+    let claims = state.jwt_manager.verify_token(token).ok()?;
+    if !claims.is_guest || claims.matchmaking_pool != MatchmakingPool::Public {
+        return None;
+    }
+    claims.sub.parse().ok()
+}
+
+fn validate_preferences(
+    preferences: &CrazyGamesPreferences,
+) -> std::result::Result<(), CrazyGamesApiError> {
+    if serde_json::to_vec(preferences)
+        .map_err(|_| CrazyGamesApiError::InvalidPreferences)?
+        .len()
+        > MAX_PREFERENCES_BYTES
+    {
+        return Err(CrazyGamesApiError::InvalidPreferences);
+    }
+    if let Some(tutorials) = &preferences.tutorial_seen
+        && (tutorials.len() > 128
+            || tutorials
+                .keys()
+                .any(|key| key.is_empty() || key.len() > 128 || key.chars().any(char::is_control)))
+    {
+        return Err(CrazyGamesApiError::InvalidPreferences);
+    }
+    if let Some(lobby) = &preferences.lobby_preferences {
+        if lobby.selected_modes.len() > 32 {
+            return Err(CrazyGamesApiError::InvalidPreferences);
+        }
+        let mut unique = HashSet::new();
+        if lobby.selected_modes.iter().any(|mode| {
+            mode.is_empty()
+                || mode.len() > 64
+                || mode.chars().any(char::is_control)
+                || !unique.insert(mode)
+        }) {
+            return Err(CrazyGamesApiError::InvalidPreferences);
+        }
+    }
+    Ok(())
+}
+
+pub async fn exchange(
+    State(state): State<AuthState>,
+    headers: HeaderMap,
+    Json(request): Json<ExchangeRequest>,
+) -> std::result::Result<Response, CrazyGamesApiError> {
+    if let Some(preferences) = &request.initial_preferences {
+        validate_preferences(preferences)?;
+    }
+    let verifier = state
+        .crazygames_verifier
+        .as_ref()
+        .ok_or(CrazyGamesApiError::Disabled)?;
+    let claims = verifier
+        .verify(&request.token)
+        .await
+        .map_err(|error| match error {
+            VerifyError::InvalidToken => CrazyGamesApiError::InvalidToken,
+            VerifyError::PublicKeyUnavailable => CrazyGamesApiError::PublicKeyUnavailable,
+        })?;
+    let guest_candidate_user_id = guest_candidate(&headers, &state);
+    let outcome = state
+        .db
+        .resolve_crazygames_account(
+            &claims.profile(),
+            guest_candidate_user_id,
+            request.guest_promotion,
+            request.initial_preferences.as_ref(),
+        )
+        .await
+        .map_err(CrazyGamesApiError::Internal)?;
+    let account = match outcome {
+        CrazyGamesAccountOutcome::Resolved(account) => *account,
+        CrazyGamesAccountOutcome::GuestLinkConsentRequired => {
+            return Err(CrazyGamesApiError::GuestLinkConsentRequired);
+        }
+    };
+
+    if let Some(user_cache) = &state.user_cache
+        && let Err(error) = user_cache.replace_after_guest_upgrade(&account.user).await
+    {
+        // The durable identity transaction has committed. Cache failure must
+        // not turn a successful exchange into a retry that looks like failure.
+        warn!(
+            "Failed to refresh user cache after CrazyGames exchange for {}: {}",
+            account.user.id, error
+        );
+    }
+
+    let token = state
+        .jwt_manager
+        .generate_token(account.user.id, &account.profile.username)
+        .map_err(CrazyGamesApiError::Internal)?;
+    let expires_at = state
+        .jwt_manager
+        .verify_token(&token)
+        .map_err(CrazyGamesApiError::Internal)?
+        .exp;
+    info!(
+        "Resolved verified CrazyGames account as Snaketron user {} ({:?})",
+        account.user.id, account.resolution
+    );
+    let mut response = Json(ExchangeResponse {
+        token,
+        expires_at,
+        resolution: account.resolution,
+        user: CrazyGamesUserInfo {
+            id: account.user.id,
+            username: account.profile.username,
+            mmr: account.user.mmr,
+            ranked_mmr: account.user.ranked_mmr,
+            casual_mmr: account.user.casual_mmr,
+            xp: account.user.xp,
+            is_guest: false,
+            auth_source: "crazygames",
+            avatar_url: account.profile.avatar_url,
+        },
+        preferences: account.preferences,
+    })
+    .into_response();
+    apply_no_store_headers(&mut response);
+    Ok(response)
+}
+
+pub async fn save_preferences(
+    State(state): State<AuthState>,
+    Extension(auth_user): Extension<AuthUser>,
+    Json(preferences): Json<CrazyGamesPreferences>,
+) -> std::result::Result<Response, CrazyGamesApiError> {
+    if state.crazygames_verifier.is_none() {
+        return Err(CrazyGamesApiError::Disabled);
+    }
+    if auth_user.is_guest {
+        return Err(CrazyGamesApiError::NotLinked);
+    }
+    validate_preferences(&preferences)?;
+    let saved = state
+        .db
+        .save_crazygames_preferences(auth_user.user_id, &preferences)
+        .await
+        .map_err(|error| {
+            if error.to_string().contains("not linked to CrazyGames") {
+                CrazyGamesApiError::NotLinked
+            } else {
+                CrazyGamesApiError::Internal(error)
+            }
+        })?;
+    let mut response = Json(PreferencesResponse { preferences: saved }).into_response();
+    apply_no_store_headers(&mut response);
+    Ok(response)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, body::to_bytes, http::StatusCode, response::IntoResponse, routing::get};
+    use jsonwebtoken::{EncodingKey, Header, encode};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+    const TEST_PRIVATE_KEY: &str = r#"-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA0fkUJZ4L7ESiMaM1QTb3VymgfxIIEMyCVHI5BtlNiqH7sMi0
+3PYoJif4XAV8O0iixOaQlI+dZv0qaT+hnj5wXoUfXaOOAzQUsQbwtlMeZ0psVVYy
+ap7YmfCxd9LsbUimNE0yPGwg3HH3I38njUo75SDHOmTI62b+DnXr1gDCmQ4ULLmM
+JnBweleemanxbxskDhMMtgupN7BjJViYETU0q6AeqWY0hA3LRtt4gaWGTk6USk/L
+E4qYrAxdQqJU63eb3D0Nhs/4EJ72x6BgNXb/sQ1O/0Xv67v8BcQk7aodmvj+LfvT
+sERu6+XuUdDU7Moa/+LFx6vk38IanFp5WusCUwIDAQABAoIBAEssOHlLPwuEeuj4
+fG1vp1euUIaNxxN0lEh1aFM6Yxd57KkbAh2Fh1Q5xSH02MhEtfl2blaxn/GqO4/Y
+txz3T7WXRWZ50rL051+Fk5JC6cSjEWvv4zbmzbc3Q+IZQonRk6dv58dYEt+5cXhk
+4p0j8ZOTi6AtSv10LwqwTxGbzg+LI8alyBHOalNt1BWa3S1Xph24NpHWwez4kHuW
+b0e3u5Rk0iw65u8OtzBW0829Fcvhi/AuOex07AMAEFJkZWlubbYhKgAFNYLrIvgs
+9T6xFgGwMbcitEabpXjAo5Onjg7926Xwkj/4zlKCpmQGPluYyXVETv05Sjnkas3G
+c75ZZckCgYEA6/kKmNhVXq2SyUNrtf4ELMPr/KOlobWTvqlhA8yzGvXxc0NUHzNb
+CS78Nj5egy1T7xuhbhfHRJ+yVXCx4Powf9ExVYrsTX4kjnifJOiSQH3MVPH+QwcO
+p4rAP8+/Vmt4csTQm+8+fqlSL1j5KoR39GsFLPFc4YieYo2wpbdtK9UCgYEA48sk
+F4AuVihfzgAGy/xYma6Sa/6oSEGA85BknLjIz1+BJLyzmA9KuJbfo5/jskIk55w5
+RHWdz9fN8X3aU/Q0H4oXqiLZeEWjI4BxQlSrWTVj4EFR5PBJeTlGxkpo7ou1zdlO
+vcPvjqjYJZd06GpQ5TbfJMBaY1p4oU5hMBlQ0YcCgYEAsJHucwZVgv3ge0c+vrRv
+TUvhNm8Bjio/fohhdqViU8c6v6Peu2YDNbD5umEa+Y8eYinLtoSGb/wLRlGIWK79
+QXc4Mik8vpOoKQ9rDgQVA7rd/aYCOwd52LZDOrxqEPFj9IT/D9+KZN6wB4vNDhqH
+Y9X8zm9gr8Y5tccOKkJBp20CgYEAnetk2A37Eavnzy5hh+Unn1NRGyFulLkkprZB
+qgzI2ksBgvB3KUHgsVuXKx5bgmcsoozBft5zS3X2xiZTx8QSppLbmQ2T6jeMw731
+xuBf8fZ7iSp/ldGnfizhDfLkEAw3O8AdQJ2nZCVVw6neWInsDxwdUqMvhpVf76Qg
+6HGEf90CgYB39NYGiBEuoqsc05P2xrKmmy9jbqifmFHpo5HX2dS5II2st0YVb7Ry
+TXX3uIt8x1/XA7OYMmV85ZLNM0sArOZaVVAaqSmjgda3wdHGDDA3ikB+zNhARzs2
+eVXr0jfz5DkADm1FdWRGdMNvL+1OJmGkalvIY3ts1yyzScgrGenMBg==
+-----END RSA PRIVATE KEY-----"#;
+    const TEST_PUBLIC_KEY: &str = r#"-----BEGIN RSA PUBLIC KEY-----
+MIIBCgKCAQEA0fkUJZ4L7ESiMaM1QTb3VymgfxIIEMyCVHI5BtlNiqH7sMi03PYo
+Jif4XAV8O0iixOaQlI+dZv0qaT+hnj5wXoUfXaOOAzQUsQbwtlMeZ0psVVYyap7Y
+mfCxd9LsbUimNE0yPGwg3HH3I38njUo75SDHOmTI62b+DnXr1gDCmQ4ULLmMJnBw
+eleemanxbxskDhMMtgupN7BjJViYETU0q6AeqWY0hA3LRtt4gaWGTk6USk/LE4qY
+rAxdQqJU63eb3D0Nhs/4EJ72x6BgNXb/sQ1O/0Xv67v8BcQk7aodmvj+LfvTsERu
+6+XuUdDU7Moa/+LFx6vk38IanFp5WusCUwIDAQAB
+-----END RSA PUBLIC KEY-----"#;
+
+    fn claims(game_id: &str, iat: i64, exp: i64) -> CrazyGamesTokenClaims {
+        CrazyGamesTokenClaims {
+            user_id: "User_token-123".to_string(),
+            game_id: game_id.to_string(),
+            username: "Player_1".to_string(),
+            profile_picture_url: "https://images.crazygames.com/avatar.png".to_string(),
+            iat,
+            exp,
+        }
+    }
+
+    fn rs256_token(claims: &CrazyGamesTokenClaims) -> String {
+        encode(
+            &Header::new(Algorithm::RS256),
+            claims,
+            &EncodingKey::from_rsa_pem(TEST_PRIVATE_KEY.as_bytes()).expect("test private key"),
+        )
+        .expect("test token")
+    }
+
+    fn corrupt_signature(token: String) -> String {
+        let signature_start = token.rfind('.').expect("JWT signature separator") + 1;
+        let mut token = token.into_bytes();
+        token[signature_start] = if token[signature_start] == b'A' {
+            b'B'
+        } else {
+            b'A'
+        };
+        String::from_utf8(token).expect("JWT remains UTF-8")
+    }
+
+    #[tokio::test]
+    async fn verifier_accepts_valid_rs256_token() {
+        let now = Utc::now().timestamp();
+        let verifier = CrazyGamesJwtVerifier::with_static_key("60112", TEST_PUBLIC_KEY);
+        let verified = verifier
+            .verify(&rs256_token(&claims("60112", now, now + 3600)))
+            .await
+            .expect("valid token");
+        assert_eq!(verified.user_id, "User_token-123");
+    }
+
+    #[tokio::test]
+    async fn verifier_rejects_wrong_game_expiry_and_algorithm_confusion() {
+        let now = Utc::now().timestamp();
+        let verifier = CrazyGamesJwtVerifier::with_static_key("60112", TEST_PUBLIC_KEY);
+        assert!(matches!(
+            verifier
+                .verify(&rs256_token(&claims("different", now, now + 3600)))
+                .await,
+            Err(VerifyError::InvalidToken)
+        ));
+        assert!(matches!(
+            verifier
+                .verify(&rs256_token(&claims("60112", now - 3600, now - 120)))
+                .await,
+            Err(VerifyError::InvalidToken)
+        ));
+
+        let hs_token = encode(
+            &Header::new(Algorithm::HS256),
+            &claims("60112", now, now + 3600),
+            &EncodingKey::from_secret(b"not-the-rsa-public-key"),
+        )
+        .expect("HS256 token");
+        assert!(matches!(
+            verifier.verify(&hs_token).await,
+            Err(VerifyError::InvalidToken)
+        ));
+    }
+
+    #[tokio::test]
+    async fn key_fetches_are_bounded_during_invalid_signatures_and_outages() {
+        let fetch_count = Arc::new(AtomicUsize::new(0));
+        let unavailable = Arc::new(AtomicBool::new(false));
+        let app = Router::new().route(
+            "/public-key",
+            get({
+                let fetch_count = fetch_count.clone();
+                let unavailable = unavailable.clone();
+                move || {
+                    let fetch_count = fetch_count.clone();
+                    let unavailable = unavailable.clone();
+                    async move {
+                        fetch_count.fetch_add(1, Ordering::SeqCst);
+                        if unavailable.load(Ordering::SeqCst) {
+                            return (StatusCode::SERVICE_UNAVAILABLE, "unavailable")
+                                .into_response();
+                        }
+                        Json(serde_json::json!({ "publicKey": TEST_PUBLIC_KEY })).into_response()
+                    }
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test key server");
+        let public_key_url = format!(
+            "http://{}/public-key",
+            listener.local_addr().expect("test key server address")
+        );
+        let server = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .await
+                .expect("serve test public key")
+        });
+
+        let now = Utc::now().timestamp();
+        let verifier =
+            CrazyGamesJwtVerifier::with_fetching_key_url("60112", public_key_url.clone());
+        let valid = rs256_token(&claims("60112", now, now + 3600));
+        verifier.verify(&valid).await.expect("valid token");
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 1);
+
+        // Simulate a cache older than the forced-refresh cooldown. The first
+        // invalid signature may check for rotation; the next one must reuse
+        // that generation instead of causing another outbound request.
+        *verifier.last_network_fetch_attempt.write().await =
+            Some(std::time::Instant::now() - SIGNATURE_REFRESH_COOLDOWN - Duration::from_millis(1));
+        let invalid = corrupt_signature(valid.clone());
+        assert!(matches!(
+            verifier.verify(&invalid).await,
+            Err(VerifyError::InvalidToken)
+        ));
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 2);
+        assert!(matches!(
+            verifier.verify(&invalid).await,
+            Err(VerifyError::InvalidToken)
+        ));
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 2);
+
+        // With no cached key, a provider failure is negatively cached for the
+        // short backoff instead of being retried once per incoming request.
+        unavailable.store(true, Ordering::SeqCst);
+        let unavailable_verifier =
+            CrazyGamesJwtVerifier::with_fetching_key_url("60112", public_key_url);
+        assert!(matches!(
+            unavailable_verifier.verify(&valid).await,
+            Err(VerifyError::PublicKeyUnavailable)
+        ));
+        assert!(matches!(
+            unavailable_verifier.verify(&valid).await,
+            Err(VerifyError::PublicKeyUnavailable)
+        ));
+        assert_eq!(fetch_count.load(Ordering::SeqCst), 3);
+
+        server.abort();
+    }
+
+    #[test]
+    fn preference_merge_keeps_completed_tutorials_monotonic() {
+        let current = CrazyGamesPreferences {
+            tutorial_seen: Some(
+                [("movement".to_string(), true), ("boost".to_string(), false)]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let incoming = CrazyGamesPreferences {
+            tutorial_seen: Some(
+                [("movement".to_string(), false), ("boost".to_string(), true)]
+                    .into_iter()
+                    .collect(),
+            ),
+            ..Default::default()
+        };
+        let merged = current.merge(&incoming);
+        let tutorials = merged.tutorial_seen.as_ref().expect("tutorial snapshot");
+        assert!(tutorials["movement"]);
+        assert!(tutorials["boost"]);
+    }
+
+    #[test]
+    fn preference_validation_rejects_duplicate_modes() {
+        let preferences = CrazyGamesPreferences {
+            lobby_preferences: Some(crate::db::models::CrazyGamesLobbyPreferences {
+                selected_modes: vec!["solo".to_string(), "solo".to_string()],
+                competitive: false,
+            }),
+            ..Default::default()
+        };
+        assert!(validate_preferences(&preferences).is_err());
+    }
+
+    #[test]
+    fn exchange_request_defaults_missing_guest_promotion_to_decline() {
+        let request: ExchangeRequest = serde_json::from_value(serde_json::json!({
+            "token": "provider-token"
+        }))
+        .expect("request without guestPromotion");
+        assert_eq!(request.guest_promotion, CrazyGamesGuestPromotion::Decline);
+
+        for (value, expected) in [
+            ("check", CrazyGamesGuestPromotion::Check),
+            ("allow", CrazyGamesGuestPromotion::Allow),
+            ("decline", CrazyGamesGuestPromotion::Decline),
+        ] {
+            let request: ExchangeRequest = serde_json::from_value(serde_json::json!({
+                "token": "provider-token",
+                "guestPromotion": value
+            }))
+            .expect("valid guestPromotion decision");
+            assert_eq!(request.guest_promotion, expected);
+        }
+    }
+
+    #[tokio::test]
+    async fn guest_link_consent_response_is_stable_conflict_and_no_store() {
+        let response = CrazyGamesApiError::GuestLinkConsentRequired.into_response();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response
+                .headers()
+                .get(header::CACHE_CONTROL)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache, no-store, must-revalidate, private")
+        );
+        assert_eq!(
+            response
+                .headers()
+                .get(header::PRAGMA)
+                .and_then(|value| value.to_str().ok()),
+            Some("no-cache")
+        );
+        let body = to_bytes(response.into_body(), 1024)
+            .await
+            .expect("read consent response");
+        let body: serde_json::Value = serde_json::from_slice(&body).expect("consent response JSON");
+        assert_eq!(body["code"], "guestLinkConsentRequired");
+    }
+
+    #[test]
+    fn exchange_response_contract_is_camel_case() {
+        let value = serde_json::to_value(ExchangeResponse {
+            token: "internal-token".to_string(),
+            expires_at: 42,
+            resolution: CrazyGamesAccountResolution::GuestClaimed,
+            user: CrazyGamesUserInfo {
+                id: 7,
+                username: "Exact.Name".to_string(),
+                mmr: 1_000,
+                ranked_mmr: 1_010,
+                casual_mmr: 990,
+                xp: 12,
+                is_guest: false,
+                auth_source: "crazygames",
+                avatar_url: "https://images.crazygames.com/avatar.png".to_string(),
+            },
+            preferences: CrazyGamesPreferences::default(),
+        })
+        .expect("serialize response");
+        assert_eq!(value["expiresAt"], 42);
+        assert_eq!(value["resolution"], "guestClaimed");
+        assert_eq!(value["user"]["isGuest"], false);
+        assert_eq!(value["user"]["authSource"], "crazygames");
+        assert_eq!(
+            value["user"]["avatarUrl"],
+            "https://images.crazygames.com/avatar.png"
+        );
+        assert!(value["user"].get("ranked_mmr").is_none());
+        assert_eq!(value["user"]["rankedMmr"], 1_010);
+    }
+}

--- a/server/src/api/leaderboard.rs
+++ b/server/src/api/leaderboard.rs
@@ -186,7 +186,9 @@ pub async fn get_leaderboard(
         // Check if there are more results
         let has_more = high_scores.len() > limit;
 
-        // Transform high scores to response format
+        // Preserve the established constant-read path. Names in score rows are
+        // historical snapshots; current verified profile data is used for
+        // active account/lobby identity without amplifying public reads.
         let response_entries: Vec<LeaderboardEntry> = high_scores
             .into_iter()
             .take(limit)

--- a/server/src/api/mod.rs
+++ b/server/src/api/mod.rs
@@ -1,4 +1,5 @@
 pub mod auth;
+pub mod crazygames;
 pub mod jwt;
 pub mod leaderboard;
 pub mod middleware;

--- a/server/src/api/server.rs
+++ b/server/src/api/server.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use axum::{
     Router, middleware,
-    routing::{get, post},
+    routing::{get, post, put},
 };
 use std::sync::Arc;
 use tokio::net::TcpListener;
@@ -11,6 +11,7 @@ use tracing::info;
 use crate::db::Database;
 
 use super::auth::{self, AuthState};
+use super::crazygames;
 use super::jwt::JwtManager;
 use super::middleware::{AuthMiddlewareState, auth_middleware};
 use super::rate_limit::{rate_limit_layer, rate_limit_middleware};
@@ -22,6 +23,7 @@ pub async fn run_api_server(addr: &str, db: Arc<dyn Database>, jwt_secret: &str)
         db: db.clone(),
         jwt_manager: jwt_manager.clone(),
         user_cache: None,
+        crazygames_verifier: crazygames::configured_verifier_from_env()?,
     };
     let auth_middleware_state = AuthMiddlewareState {
         jwt_manager: jwt_manager.clone(),
@@ -36,10 +38,16 @@ pub async fn run_api_server(addr: &str, db: Arc<dyn Database>, jwt_secret: &str)
 
     // Create rate limiter for username check endpoint (10 requests per minute)
     let username_check_limiter = rate_limit_layer(10, 60);
+    let crazygames_exchange_limiter = rate_limit_layer(60, 60);
 
     // Build router with protected routes
     let protected_routes = Router::new()
         .route("/api/auth/me", get(auth::get_current_user))
+        .route(
+            "/api/auth/crazygames/preferences",
+            put(crazygames::save_preferences)
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024)),
+        )
         .layer(middleware::from_fn_with_state(
             auth_middleware_state,
             auth_middleware,
@@ -49,6 +57,15 @@ pub async fn run_api_server(addr: &str, db: Arc<dyn Database>, jwt_secret: &str)
         .route("/api/health", get(health_check))
         .route("/api/auth/register", post(auth::register))
         .route("/api/auth/login", post(auth::login))
+        .route(
+            "/api/auth/crazygames/exchange",
+            post(crazygames::exchange)
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024))
+                .layer(middleware::from_fn_with_state(
+                    crazygames_exchange_limiter,
+                    rate_limit_middleware,
+                )),
+        )
         .route(
             "/api/auth/check-username",
             post(auth::check_username).layer(middleware::from_fn_with_state(

--- a/server/src/db/dynamodb.rs
+++ b/server/src/db/dynamodb.rs
@@ -11,6 +11,7 @@ use aws_sdk_dynamodb::types::{
 };
 use chrono::{DateTime, Utc};
 use serde_json::{Value as JsonValue, json};
+use sha2::{Digest, Sha256};
 use std::{collections::HashMap, time::Duration};
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
@@ -34,7 +35,17 @@ const DYNAMODB_CONTROL_PLANE_MAX_ATTEMPTS: usize = 30;
 const DYNAMODB_CONTROL_PLANE_RETRY_DELAY: Duration = Duration::from_secs(1);
 const COMPLETION_RANKING_MAX_ATTEMPTS: usize = 16;
 const GUEST_UPGRADE_MAX_ATTEMPTS: usize = 8;
+const CRAZYGAMES_IDENTITY_MAX_ATTEMPTS: usize = 8;
 const DYNAMODB_RUNTIME_MAX_ATTEMPTS: u32 = 5;
+
+#[derive(Debug, Clone)]
+struct CrazyGamesIdentityRecord {
+    user_id: i32,
+    provider_user_id: String,
+    username: String,
+    avatar_url: String,
+    profile_iat: i64,
+}
 
 #[derive(Clone, Copy)]
 enum UserProgressMutation {
@@ -946,7 +957,7 @@ impl DynamoDatabase {
         }))
     }
 
-    async fn completion_user_target(&self, user_id: u32) -> Result<(String, bool)> {
+    async fn completion_user_target(&self, user_id: u32) -> Result<(String, bool, bool)> {
         let response = self
             .client
             .get_item()
@@ -954,7 +965,7 @@ impl DynamoDatabase {
             .key("pk", Self::av_s(format!("USER#{user_id}")))
             .key("sk", Self::av_s("META"))
             .consistent_read(true)
-            .projection_expression("username, isGuest")
+            .projection_expression("username, isGuest, authProvider")
             .send()
             .await
             .context("Failed to read completion effect user")?;
@@ -963,10 +974,10 @@ impl DynamoDatabase {
             .ok_or_else(|| anyhow!("user {user_id} disappeared before completion effect"))?;
         let username = Self::extract_string(&item, "username")
             .ok_or_else(|| anyhow!("user {user_id} has no username"))?;
-        Ok((
-            username,
-            Self::extract_bool(&item, "isGuest").unwrap_or(false),
-        ))
+        let is_guest = Self::extract_bool(&item, "isGuest").unwrap_or(false);
+        let uses_username_mirror = !is_guest
+            && Self::extract_string(&item, "authProvider").as_deref() != Some("crazygames");
+        Ok((username, is_guest, uses_username_mirror))
     }
 
     fn user_progress_value(user: &User, field: &str) -> Result<i32> {
@@ -1015,7 +1026,7 @@ impl DynamoDatabase {
                 .with_context(|| format!("Failed to build canonical {field} mutation"))?;
             let mut mutations = vec![TransactWriteItem::builder().update(main_update).build()];
 
-            if !user.is_guest {
+            if !user.is_guest && user.auth_provider.as_deref() != Some("crazygames") {
                 let mirror_update = Update::builder()
                     .table_name(self.usernames_table())
                     .key("username", Self::av_s(&user.username))
@@ -1060,6 +1071,320 @@ impl DynamoDatabase {
         }
 
         unreachable!("user progress mutation attempt loop always returns")
+    }
+
+    fn crazygames_identity_pk(provider_user_id: &str) -> String {
+        let digest = Sha256::digest(provider_user_id.as_bytes());
+        format!("IDENTITY#CRAZYGAMES#{}", hex::encode(digest))
+    }
+
+    async fn get_crazygames_identity(
+        &self,
+        provider_user_id: &str,
+    ) -> Result<Option<CrazyGamesIdentityRecord>> {
+        let response = self
+            .client
+            .get_item()
+            .table_name(self.main_table())
+            .key(
+                "pk",
+                Self::av_s(Self::crazygames_identity_pk(provider_user_id)),
+            )
+            .key("sk", Self::av_s("META"))
+            .consistent_read(true)
+            .send()
+            .await
+            .context("Failed to read CrazyGames identity mapping")?;
+
+        let Some(item) = response.item else {
+            return Ok(None);
+        };
+        let stored_provider_user_id = Self::extract_string(&item, "providerUserId")
+            .ok_or_else(|| anyhow!("CrazyGames identity mapping is corrupt"))?;
+        if stored_provider_user_id != provider_user_id {
+            return Err(anyhow!(
+                "CrazyGames identity hash collision or corrupt mapping"
+            ));
+        }
+        Ok(Some(CrazyGamesIdentityRecord {
+            user_id: Self::extract_number(&item, "userId")
+                .ok_or_else(|| anyhow!("CrazyGames identity mapping is corrupt"))?,
+            provider_user_id: stored_provider_user_id,
+            username: Self::extract_string(&item, "username")
+                .ok_or_else(|| anyhow!("CrazyGames identity mapping is corrupt"))?,
+            avatar_url: Self::extract_string(&item, "profilePictureUrl")
+                .ok_or_else(|| anyhow!("CrazyGames identity mapping is corrupt"))?,
+            profile_iat: Self::extract_i64(&item, "profileIat")
+                .ok_or_else(|| anyhow!("CrazyGames identity mapping is corrupt"))?,
+        }))
+    }
+
+    async fn get_crazygames_preferences_with_version(
+        &self,
+        user_id: i32,
+    ) -> Result<(CrazyGamesPreferences, i64)> {
+        let response = self
+            .client
+            .get_item()
+            .table_name(self.main_table())
+            .key("pk", Self::av_s(format!("USER#{user_id}")))
+            .key("sk", Self::av_s("PREFERENCES#CRAZYGAMES"))
+            .consistent_read(true)
+            .send()
+            .await
+            .context("Failed to read CrazyGames preferences")?;
+
+        let Some(item) = response.item else {
+            return Ok((CrazyGamesPreferences::default(), 0));
+        };
+        let preferences = Self::extract_string(&item, "preferences")
+            .ok_or_else(|| anyhow!("CrazyGames preferences are corrupt"))
+            .and_then(|value| {
+                serde_json::from_str(&value).context("CrazyGames preferences are corrupt")
+            })?;
+        let version = Self::extract_i64(&item, "version")
+            .ok_or_else(|| anyhow!("CrazyGames preferences are corrupt"))?;
+        Ok((preferences, version))
+    }
+
+    fn crazygames_preferences_put(
+        &self,
+        user_id: i32,
+        preferences: &CrazyGamesPreferences,
+        version: i64,
+        expected_version: Option<i64>,
+    ) -> Result<Put> {
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), Self::av_s(format!("USER#{user_id}")));
+        item.insert("sk".to_string(), Self::av_s("PREFERENCES#CRAZYGAMES"));
+        item.insert("schemaVersion".to_string(), Self::av_n(1));
+        item.insert("version".to_string(), Self::av_n(version));
+        item.insert(
+            "preferences".to_string(),
+            Self::av_s(
+                serde_json::to_string(preferences)
+                    .context("Failed to serialize CrazyGames preferences")?,
+            ),
+        );
+        item.insert("updatedAt".to_string(), Self::av_s(Utc::now().to_rfc3339()));
+
+        let mut put = Put::builder()
+            .table_name(self.main_table())
+            .set_item(Some(item));
+        if let Some(expected_version) = expected_version {
+            put = put
+                .condition_expression("attribute_not_exists(pk) OR #version=:expected_version")
+                .expression_attribute_names("#version", "version")
+                .expression_attribute_values(":expected_version", Self::av_n(expected_version));
+        }
+        put.build()
+            .context("Failed to build CrazyGames preferences write")
+    }
+
+    fn crazygames_identity_put(
+        &self,
+        profile: &CrazyGamesProfile,
+        user_id: i32,
+        now: DateTime<Utc>,
+    ) -> Result<Put> {
+        let mut item = HashMap::new();
+        item.insert(
+            "pk".to_string(),
+            Self::av_s(Self::crazygames_identity_pk(&profile.provider_user_id)),
+        );
+        item.insert("sk".to_string(), Self::av_s("META"));
+        item.insert("provider".to_string(), Self::av_s("crazygames"));
+        item.insert(
+            "providerUserId".to_string(),
+            Self::av_s(&profile.provider_user_id),
+        );
+        item.insert("userId".to_string(), Self::av_n(user_id));
+        item.insert("username".to_string(), Self::av_s(&profile.username));
+        item.insert(
+            "profilePictureUrl".to_string(),
+            Self::av_s(&profile.avatar_url),
+        );
+        item.insert("profileIat".to_string(), Self::av_n(profile.profile_iat));
+        item.insert("createdAt".to_string(), Self::av_s(now.to_rfc3339()));
+        item.insert(
+            "lastAuthenticatedAt".to_string(),
+            Self::av_s(now.to_rfc3339()),
+        );
+
+        Put::builder()
+            .table_name(self.main_table())
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
+            .build()
+            .context("Failed to build CrazyGames identity mapping")
+    }
+
+    fn new_crazygames_user_put(
+        &self,
+        profile: &CrazyGamesProfile,
+        user_id: i32,
+        now: DateTime<Utc>,
+    ) -> Result<Put> {
+        let mut item = HashMap::new();
+        item.insert("pk".to_string(), Self::av_s(format!("USER#{user_id}")));
+        item.insert("sk".to_string(), Self::av_s("META"));
+        item.insert("gsi1pk".to_string(), Self::av_s("USER"));
+        item.insert("gsi1sk".to_string(), Self::av_s(now.to_rfc3339()));
+        item.insert("id".to_string(), Self::av_n(user_id));
+        item.insert("username".to_string(), Self::av_s(&profile.username));
+        item.insert("passwordHash".to_string(), Self::av_s(""));
+        item.insert("mmr".to_string(), Self::av_n(1000));
+        item.insert("rankedMmr".to_string(), Self::av_n(1000));
+        item.insert("casualMmr".to_string(), Self::av_n(1000));
+        item.insert("xp".to_string(), Self::av_n(0));
+        item.insert("createdAt".to_string(), Self::av_s(now.to_rfc3339()));
+        item.insert("isGuest".to_string(), Self::av_bool(false));
+        item.insert("isStressTest".to_string(), Self::av_bool(false));
+        item.insert("authProvider".to_string(), Self::av_s("crazygames"));
+        item.insert(
+            "crazyGamesUserId".to_string(),
+            Self::av_s(&profile.provider_user_id),
+        );
+        item.insert(
+            "profilePictureUrl".to_string(),
+            Self::av_s(&profile.avatar_url),
+        );
+        item.insert("profileIat".to_string(), Self::av_n(profile.profile_iat));
+
+        Put::builder()
+            .table_name(self.main_table())
+            .set_item(Some(item))
+            .condition_expression("attribute_not_exists(pk) AND attribute_not_exists(sk)")
+            .build()
+            .context("Failed to build CrazyGames user")
+    }
+
+    async fn update_crazygames_profile_if_newer(
+        &self,
+        current: &CrazyGamesIdentityRecord,
+        profile: &CrazyGamesProfile,
+    ) -> Result<CrazyGamesIdentityRecord> {
+        let mut observed = current.clone();
+        let mut last_error = None;
+        for attempt in 0..CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+            if profile.profile_iat <= observed.profile_iat {
+                return Ok(observed);
+            }
+
+            let identity_update = Update::builder()
+                .table_name(self.main_table())
+                .key(
+                    "pk",
+                    Self::av_s(Self::crazygames_identity_pk(&profile.provider_user_id)),
+                )
+                .key("sk", Self::av_s("META"))
+                .update_expression(concat!(
+                    "SET username=:username, profilePictureUrl=:avatar, ",
+                    "profileIat=:profile_iat, lastAuthenticatedAt=:now"
+                ))
+                .condition_expression(concat!(
+                    "attribute_exists(pk) AND providerUserId=:provider_user_id AND ",
+                    "(attribute_not_exists(profileIat) OR profileIat<:profile_iat)"
+                ))
+                .expression_attribute_values(":username", Self::av_s(&profile.username))
+                .expression_attribute_values(":avatar", Self::av_s(&profile.avatar_url))
+                .expression_attribute_values(":profile_iat", Self::av_n(profile.profile_iat))
+                .expression_attribute_values(
+                    ":provider_user_id",
+                    Self::av_s(&profile.provider_user_id),
+                )
+                .expression_attribute_values(":now", Self::av_s(Utc::now().to_rfc3339()))
+                .build()
+                .context("Failed to build CrazyGames identity profile update")?;
+            let user_update = Update::builder()
+                .table_name(self.main_table())
+                .key("pk", Self::av_s(format!("USER#{}", observed.user_id)))
+                .key("sk", Self::av_s("META"))
+                .update_expression(
+                    "SET username=:username, profilePictureUrl=:avatar, profileIat=:profile_iat",
+                )
+                .condition_expression(concat!(
+                    "attribute_exists(pk) AND authProvider=:provider AND ",
+                    "crazyGamesUserId=:provider_user_id AND ",
+                    "(attribute_not_exists(profileIat) OR profileIat<:profile_iat)"
+                ))
+                .expression_attribute_values(":username", Self::av_s(&profile.username))
+                .expression_attribute_values(":avatar", Self::av_s(&profile.avatar_url))
+                .expression_attribute_values(":profile_iat", Self::av_n(profile.profile_iat))
+                .expression_attribute_values(":provider", Self::av_s("crazygames"))
+                .expression_attribute_values(
+                    ":provider_user_id",
+                    Self::av_s(&profile.provider_user_id),
+                )
+                .build()
+                .context("Failed to build CrazyGames user profile update")?;
+
+            match self
+                .client
+                .transact_write_items()
+                .transact_items(TransactWriteItem::builder().update(identity_update).build())
+                .transact_items(TransactWriteItem::builder().update(user_update).build())
+                .send()
+                .await
+            {
+                Ok(_) => {
+                    return Ok(CrazyGamesIdentityRecord {
+                        user_id: observed.user_id,
+                        provider_user_id: profile.provider_user_id.clone(),
+                        username: profile.username.clone(),
+                        avatar_url: profile.avatar_url.clone(),
+                        profile_iat: profile.profile_iat,
+                    });
+                }
+                Err(error) => {
+                    observed = self
+                        .get_crazygames_identity(&profile.provider_user_id)
+                        .await?
+                        .ok_or_else(|| anyhow!("CrazyGames identity mapping disappeared"))?;
+                    if observed.profile_iat >= profile.profile_iat {
+                        return Ok(observed);
+                    }
+                    last_error =
+                        Some(anyhow!(error).context("Failed to update CrazyGames profile"));
+                    if attempt + 1 < CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+                        let exponent = attempt.min(6) as u32;
+                        sleep(Duration::from_millis(1_u64 << exponent)).await;
+                    }
+                }
+            }
+        }
+        Err(last_error.unwrap_or_else(|| anyhow!("Failed to update CrazyGames profile")))
+    }
+
+    async fn load_crazygames_account(
+        &self,
+        identity: CrazyGamesIdentityRecord,
+        resolution: CrazyGamesAccountResolution,
+    ) -> Result<CrazyGamesAccount> {
+        let user = self
+            .get_user_by_id(identity.user_id)
+            .await?
+            .ok_or_else(|| anyhow!("CrazyGames identity mapping points to a missing user"))?;
+        if user.is_guest
+            || user.auth_provider.as_deref() != Some("crazygames")
+            || user.crazygames_user_id.as_deref() != Some(&identity.provider_user_id)
+        {
+            return Err(anyhow!("CrazyGames identity mapping is corrupt"));
+        }
+        let (preferences, _) = self
+            .get_crazygames_preferences_with_version(identity.user_id)
+            .await?;
+        Ok(CrazyGamesAccount {
+            user,
+            profile: CrazyGamesProfile {
+                provider_user_id: identity.provider_user_id,
+                username: identity.username,
+                avatar_url: identity.avatar_url,
+                profile_iat: identity.profile_iat,
+            },
+            resolution,
+            preferences,
+        })
     }
 
     async fn transact_completion_effect(
@@ -1417,6 +1742,10 @@ impl Database for DynamoDatabase {
             is_guest: false,
             guest_token: None,
             is_stress_test: false,
+            auth_provider: None,
+            crazygames_user_id: None,
+            profile_picture_url: None,
+            profile_iat: None,
         })
     }
 
@@ -1475,6 +1804,10 @@ impl Database for DynamoDatabase {
             is_guest: true,
             guest_token: Some(guest_token.to_string()),
             is_stress_test,
+            auth_provider: None,
+            crazygames_user_id: None,
+            profile_picture_url: None,
+            profile_iat: None,
         })
     }
 
@@ -1646,6 +1979,10 @@ impl Database for DynamoDatabase {
                     is_guest: Self::extract_bool(&item, "isGuest").unwrap_or(false),
                     guest_token: Self::extract_string(&item, "guestToken"),
                     is_stress_test: Self::extract_bool(&item, "isStressTest").unwrap_or(false),
+                    auth_provider: Self::extract_string(&item, "authProvider"),
+                    crazygames_user_id: Self::extract_string(&item, "crazyGamesUserId"),
+                    profile_picture_url: Self::extract_string(&item, "profilePictureUrl"),
+                    profile_iat: Self::extract_i64(&item, "profileIat"),
                 };
                 Ok(Some(user))
             }
@@ -1717,6 +2054,311 @@ impl Database for DynamoDatabase {
             xp_to_add, user_id, new_xp
         );
         Ok(new_xp)
+    }
+
+    async fn resolve_crazygames_account(
+        &self,
+        profile: &CrazyGamesProfile,
+        guest_candidate_user_id: Option<i32>,
+        guest_promotion: CrazyGamesGuestPromotion,
+        initial_preferences: Option<&CrazyGamesPreferences>,
+    ) -> Result<CrazyGamesAccountOutcome> {
+        // Browser preferences are safe to import only when the caller proves
+        // ownership of an eligible guest through its internal bearer token.
+        // A newly created provider identity may be opening a browser last used
+        // by another linked account, so it must start from its own empty
+        // canonical snapshot instead of inheriting unscoped local state.
+        let guest_preferences = initial_preferences.cloned().unwrap_or_default();
+        let mut guest_candidate_user_id = match guest_promotion {
+            CrazyGamesGuestPromotion::Check | CrazyGamesGuestPromotion::Allow => {
+                guest_candidate_user_id
+            }
+            CrazyGamesGuestPromotion::Decline => None,
+        };
+        let mut last_error = None;
+
+        for attempt in 0..CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+            if let Some(current) = self
+                .get_crazygames_identity(&profile.provider_user_id)
+                .await?
+            {
+                let current = self
+                    .update_crazygames_profile_if_newer(&current, profile)
+                    .await?;
+                return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                    self.load_crazygames_account(current, CrazyGamesAccountResolution::Returning)
+                        .await?,
+                )));
+            }
+
+            if let Some(candidate_id) = guest_candidate_user_id {
+                let eligible = self
+                    .get_user_by_id(candidate_id)
+                    .await?
+                    .is_some_and(|user| user.is_guest && !user.is_stress_test);
+                if eligible {
+                    if guest_promotion == CrazyGamesGuestPromotion::Check {
+                        // Close the most useful race window before reporting
+                        // consent: a concurrent first launch may have created
+                        // the identity while we inspected the guest. Both
+                        // reads are strongly consistent, and this branch does
+                        // not write the guest, identity, or preferences.
+                        if let Some(current) = self
+                            .get_crazygames_identity(&profile.provider_user_id)
+                            .await?
+                        {
+                            let current = self
+                                .update_crazygames_profile_if_newer(&current, profile)
+                                .await?;
+                            return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                                self.load_crazygames_account(
+                                    current,
+                                    CrazyGamesAccountResolution::Returning,
+                                )
+                                .await?,
+                            )));
+                        }
+                        return Ok(CrazyGamesAccountOutcome::GuestLinkConsentRequired);
+                    }
+
+                    let now = Utc::now();
+                    let identity_put = self.crazygames_identity_put(profile, candidate_id, now)?;
+                    let user_update = Update::builder()
+                        .table_name(self.main_table())
+                        .key("pk", Self::av_s(format!("USER#{candidate_id}")))
+                        .key("sk", Self::av_s("META"))
+                        .update_expression(concat!(
+                            "SET username=:username, isGuest=:not_guest, ",
+                            "isStressTest=:not_stress, authProvider=:provider, ",
+                            "crazyGamesUserId=:provider_user_id, ",
+                            "profilePictureUrl=:avatar, profileIat=:profile_iat ",
+                            "REMOVE guestToken"
+                        ))
+                        .condition_expression(concat!(
+                            "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                            "isGuest=:guest AND ",
+                            "(attribute_not_exists(isStressTest) OR isStressTest=:not_stress)"
+                        ))
+                        .expression_attribute_values(":username", Self::av_s(&profile.username))
+                        .expression_attribute_values(":not_guest", Self::av_bool(false))
+                        .expression_attribute_values(":not_stress", Self::av_bool(false))
+                        .expression_attribute_values(":guest", Self::av_bool(true))
+                        .expression_attribute_values(":provider", Self::av_s("crazygames"))
+                        .expression_attribute_values(
+                            ":provider_user_id",
+                            Self::av_s(&profile.provider_user_id),
+                        )
+                        .expression_attribute_values(":avatar", Self::av_s(&profile.avatar_url))
+                        .expression_attribute_values(
+                            ":profile_iat",
+                            Self::av_n(profile.profile_iat),
+                        )
+                        .build()
+                        .context("Failed to build CrazyGames guest claim")?;
+                    let preferences_put =
+                        self.crazygames_preferences_put(candidate_id, &guest_preferences, 1, None)?;
+                    let result = self
+                        .client
+                        .transact_write_items()
+                        .client_request_token(uuid::Uuid::new_v4().to_string())
+                        .transact_items(TransactWriteItem::builder().put(identity_put).build())
+                        .transact_items(TransactWriteItem::builder().update(user_update).build())
+                        .transact_items(TransactWriteItem::builder().put(preferences_put).build())
+                        .send()
+                        .await;
+                    match result {
+                        Ok(_) => {
+                            let identity = self
+                                .get_crazygames_identity(&profile.provider_user_id)
+                                .await?
+                                .ok_or_else(|| {
+                                    anyhow!("CrazyGames identity claim committed without mapping")
+                                })?;
+                            info!(
+                                "Claimed public guest {} for a verified CrazyGames identity",
+                                candidate_id
+                            );
+                            return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                                self.load_crazygames_account(
+                                    identity,
+                                    CrazyGamesAccountResolution::GuestClaimed,
+                                )
+                                .await?,
+                            )));
+                        }
+                        Err(error) => {
+                            if let Some(winner) = self
+                                .get_crazygames_identity(&profile.provider_user_id)
+                                .await?
+                            {
+                                let winner = self
+                                    .update_crazygames_profile_if_newer(&winner, profile)
+                                    .await?;
+                                return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                                    self.load_crazygames_account(
+                                        winner,
+                                        CrazyGamesAccountResolution::Returning,
+                                    )
+                                    .await?,
+                                )));
+                            }
+                            if !self
+                                .get_user_by_id(candidate_id)
+                                .await?
+                                .is_some_and(|user| user.is_guest && !user.is_stress_test)
+                            {
+                                // A concurrent password registration won. Never
+                                // attach CrazyGames to that unrelated account.
+                                guest_candidate_user_id = None;
+                            }
+                            last_error = Some(anyhow!(error).context(
+                                "Failed to atomically claim guest for CrazyGames identity",
+                            ));
+                        }
+                    }
+                } else {
+                    guest_candidate_user_id = None;
+                }
+            }
+
+            if guest_candidate_user_id.is_none() {
+                let user_id = self.generate_id_for_entity("USER").await?;
+                let now = Utc::now();
+                let identity_put = self.crazygames_identity_put(profile, user_id, now)?;
+                let user_put = self.new_crazygames_user_put(profile, user_id, now)?;
+                let preferences_put = self.crazygames_preferences_put(
+                    user_id,
+                    &CrazyGamesPreferences::default(),
+                    1,
+                    None,
+                )?;
+                let result = self
+                    .client
+                    .transact_write_items()
+                    .client_request_token(uuid::Uuid::new_v4().to_string())
+                    .transact_items(TransactWriteItem::builder().put(identity_put).build())
+                    .transact_items(TransactWriteItem::builder().put(user_put).build())
+                    .transact_items(TransactWriteItem::builder().put(preferences_put).build())
+                    .send()
+                    .await;
+                match result {
+                    Ok(_) => {
+                        let identity = self
+                            .get_crazygames_identity(&profile.provider_user_id)
+                            .await?
+                            .ok_or_else(|| {
+                                anyhow!("CrazyGames account creation committed without mapping")
+                            })?;
+                        info!(
+                            "Created user {} for a verified CrazyGames identity",
+                            user_id
+                        );
+                        return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                            self.load_crazygames_account(
+                                identity,
+                                CrazyGamesAccountResolution::Created,
+                            )
+                            .await?,
+                        )));
+                    }
+                    Err(error) => {
+                        if let Some(winner) = self
+                            .get_crazygames_identity(&profile.provider_user_id)
+                            .await?
+                        {
+                            let winner = self
+                                .update_crazygames_profile_if_newer(&winner, profile)
+                                .await?;
+                            return Ok(CrazyGamesAccountOutcome::Resolved(Box::new(
+                                self.load_crazygames_account(
+                                    winner,
+                                    CrazyGamesAccountResolution::Returning,
+                                )
+                                .await?,
+                            )));
+                        }
+                        last_error = Some(
+                            anyhow!(error)
+                                .context("Failed to atomically create CrazyGames account"),
+                        );
+                    }
+                }
+            }
+
+            if attempt + 1 < CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+                let exponent = attempt.min(6) as u32;
+                sleep(Duration::from_millis(1_u64 << exponent)).await;
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow!("Failed to resolve CrazyGames identity")))
+    }
+
+    async fn save_crazygames_preferences(
+        &self,
+        user_id: i32,
+        preferences: &CrazyGamesPreferences,
+    ) -> Result<CrazyGamesPreferences> {
+        let user = self
+            .get_user_by_id(user_id)
+            .await?
+            .ok_or_else(|| anyhow!("User not found"))?;
+        if user.is_guest || user.auth_provider.as_deref() != Some("crazygames") {
+            return Err(anyhow!("User is not linked to CrazyGames"));
+        }
+
+        let mut last_error = None;
+        for attempt in 0..CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+            let (current, version) = self
+                .get_crazygames_preferences_with_version(user_id)
+                .await?;
+            let merged = current.merge(preferences);
+            let preference_put =
+                self.crazygames_preferences_put(user_id, &merged, version + 1, Some(version))?;
+            let user_check = ConditionCheck::builder()
+                .table_name(self.main_table())
+                .key("pk", Self::av_s(format!("USER#{user_id}")))
+                .key("sk", Self::av_s("META"))
+                .condition_expression(concat!(
+                    "attribute_exists(pk) AND attribute_exists(sk) AND ",
+                    "authProvider=:provider AND isGuest=:not_guest"
+                ))
+                .expression_attribute_values(":provider", Self::av_s("crazygames"))
+                .expression_attribute_values(":not_guest", Self::av_bool(false))
+                .build()
+                .context("Failed to build CrazyGames preference owner check")?;
+            match self
+                .client
+                .transact_write_items()
+                .transact_items(
+                    TransactWriteItem::builder()
+                        .condition_check(user_check)
+                        .build(),
+                )
+                .transact_items(TransactWriteItem::builder().put(preference_put).build())
+                .send()
+                .await
+            {
+                Ok(_) => return Ok(merged),
+                Err(error) => {
+                    let current_user = self.get_user_by_id(user_id).await?;
+                    if !current_user.is_some_and(|user| {
+                        !user.is_guest && user.auth_provider.as_deref() == Some("crazygames")
+                    }) {
+                        return Err(anyhow!("User is not linked to CrazyGames"));
+                    }
+                    last_error = Some(
+                        anyhow!(error).context("Failed to atomically save CrazyGames preferences"),
+                    );
+                    if attempt + 1 < CRAZYGAMES_IDENTITY_MAX_ATTEMPTS {
+                        let exponent = attempt.min(6) as u32;
+                        sleep(Duration::from_millis(1_u64 << exponent)).await;
+                    }
+                }
+            }
+        }
+
+        Err(last_error.unwrap_or_else(|| anyhow!("Failed to save CrazyGames preferences")))
     }
 
     async fn update_user_mmr_by_mode(
@@ -2144,7 +2786,7 @@ impl Database for DynamoDatabase {
                 CompletionEffect::AddXp {
                     user_id, amount, ..
                 } => {
-                    let (current_username, is_guest) =
+                    let (current_username, is_guest, uses_username_mirror) =
                         self.completion_user_target(*user_id).await?;
                     let main_update = Update::builder()
                         .table_name(self.main_table())
@@ -2162,7 +2804,7 @@ impl Database for DynamoDatabase {
                         .context("Failed to build idempotent XP update")?;
                     let mut mutations =
                         vec![TransactWriteItem::builder().update(main_update).build()];
-                    if !is_guest {
+                    if uses_username_mirror {
                         let mirror_update = Update::builder()
                             .table_name(self.usernames_table())
                             .key("username", Self::av_s(current_username))
@@ -2182,7 +2824,7 @@ impl Database for DynamoDatabase {
                     queue_mode,
                     ..
                 } => {
-                    let (current_username, is_guest) =
+                    let (current_username, is_guest, uses_username_mirror) =
                         self.completion_user_target(*user_id).await?;
                     let field = match queue_mode {
                         common::QueueMode::Competitive => "rankedMmr",
@@ -2204,7 +2846,7 @@ impl Database for DynamoDatabase {
                         .context("Failed to build idempotent MMR update")?;
                     let mut mutations =
                         vec![TransactWriteItem::builder().update(main_update).build()];
-                    if !is_guest {
+                    if uses_username_mirror {
                         let mirror_update = Update::builder()
                             .table_name(self.usernames_table())
                             .key("username", Self::av_s(current_username))

--- a/server/src/db/mod.rs
+++ b/server/src/db/mod.rs
@@ -74,6 +74,29 @@ pub trait Database: Send + Sync {
     async fn update_guest_username(&self, user_id: i32, username: &str) -> Result<()>;
     async fn add_user_xp(&self, user_id: i32, xp_to_add: i32) -> Result<i32>; // Returns new total XP
 
+    /// Resolve one verified CrazyGames identity into a durable Snaketron
+    /// account. Implementations own the uniqueness/claim transaction; callers
+    /// must never construct an account from unverified portal profile data.
+    /// Initial browser preferences may be imported only when an eligible
+    /// authenticated guest is actually claimed with explicit permission; a
+    /// newly created provider identity must not inherit unscoped state from a
+    /// shared browser. A consent check is read-only and returns a typed outcome
+    /// when an eligible guest could be claimed.
+    async fn resolve_crazygames_account(
+        &self,
+        profile: &CrazyGamesProfile,
+        guest_candidate_user_id: Option<i32>,
+        guest_promotion: CrazyGamesGuestPromotion,
+        initial_preferences: Option<&CrazyGamesPreferences>,
+    ) -> Result<CrazyGamesAccountOutcome>;
+    /// Save the CrazyGames-linked user's preference snapshot. Implementations
+    /// must reject users which are not linked to CrazyGames.
+    async fn save_crazygames_preferences(
+        &self,
+        user_id: i32,
+        preferences: &CrazyGamesPreferences,
+    ) -> Result<CrazyGamesPreferences>;
+
     // MMR operations for ranked/casual queues
     async fn update_user_mmr_by_mode(
         &self,

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::Value as JsonValue;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Server {
@@ -30,6 +31,111 @@ pub struct User {
     pub guest_token: Option<String>,
     #[serde(default)]
     pub is_stress_test: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub crazygames_user_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_picture_url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile_iat: Option<i64>,
+}
+
+/// The verified, server-side view of a CrazyGames identity.  None of these
+/// fields may be populated from `getUser()` or other client-controlled data;
+/// they come exclusively from a successfully verified CrazyGames JWT.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CrazyGamesProfile {
+    pub provider_user_id: String,
+    pub username: String,
+    pub avatar_url: String,
+    pub profile_iat: i64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CrazyGamesAccountResolution {
+    Created,
+    GuestClaimed,
+    Returning,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CrazyGamesGuestPromotion {
+    Check,
+    Allow,
+    #[default]
+    Decline,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CrazyGamesPreferences {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tutorial_seen: Option<HashMap<String, bool>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lobby_preferences: Option<CrazyGamesLobbyPreferences>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub boost_input_mode: Option<CrazyGamesBoostInputMode>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct CrazyGamesLobbyPreferences {
+    pub selected_modes: Vec<String>,
+    pub competitive: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CrazyGamesBoostInputMode {
+    Hold,
+    Toggle,
+}
+
+impl CrazyGamesPreferences {
+    /// Merge an incoming full/partial preference snapshot. Tutorial completion
+    /// is monotonic; device races can never make a completed tutorial unseen.
+    /// Other present fields use last-write-wins, while omitted fields retain
+    /// their current value.
+    pub fn merge(&self, incoming: &Self) -> Self {
+        let tutorial_seen = match (&self.tutorial_seen, &incoming.tutorial_seen) {
+            (None, None) => None,
+            (current, next) => {
+                let mut merged = current.clone().unwrap_or_default();
+                for (tutorial, seen) in next.iter().flat_map(|items| items.iter()) {
+                    if *seen || !merged.contains_key(tutorial) {
+                        merged.insert(tutorial.clone(), *seen);
+                    }
+                }
+                Some(merged)
+            }
+        };
+
+        Self {
+            tutorial_seen,
+            lobby_preferences: incoming
+                .lobby_preferences
+                .clone()
+                .or_else(|| self.lobby_preferences.clone()),
+            boost_input_mode: incoming.boost_input_mode.or(self.boost_input_mode),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CrazyGamesAccount {
+    pub user: User,
+    pub profile: CrazyGamesProfile,
+    pub resolution: CrazyGamesAccountResolution,
+    pub preferences: CrazyGamesPreferences,
+}
+
+#[derive(Debug, Clone)]
+pub enum CrazyGamesAccountOutcome {
+    Resolved(Box<CrazyGamesAccount>),
+    GuestLinkConsentRequired,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/server/src/game_executor_v2.rs
+++ b/server/src/game_executor_v2.rs
@@ -3150,7 +3150,10 @@ mod tests {
     use super::*;
     use crate::cluster_membership::{BootIdentity, ClusterNamespace};
     use crate::db::ServerRegistration;
-    use crate::db::models::{CustomLobby, Game, GamePlayer, HighScoreEntry, RankingEntry, User};
+    use crate::db::models::{
+        CrazyGamesAccountOutcome, CrazyGamesGuestPromotion, CrazyGamesPreferences,
+        CrazyGamesProfile, CustomLobby, Game, GamePlayer, HighScoreEntry, RankingEntry, User,
+    };
     use crate::redis_keys::RedisKeys;
     use crate::redis_utils::RedisConnection;
     use crate::replication::{GameStateReader, ReplicationManager};
@@ -4721,6 +4724,16 @@ mod tests {
         unused_database_method!(update_user_mmr(user_id: i32, mmr: i32) -> ());
         unused_database_method!(update_guest_username(user_id: i32, username: &str) -> ());
         unused_database_method!(add_user_xp(user_id: i32, xp_to_add: i32) -> i32);
+        unused_database_method!(resolve_crazygames_account(
+            profile: &CrazyGamesProfile,
+            guest_candidate_user_id: Option<i32>,
+            guest_promotion: CrazyGamesGuestPromotion,
+            initial_preferences: Option<&CrazyGamesPreferences>
+        ) -> CrazyGamesAccountOutcome);
+        unused_database_method!(save_crazygames_preferences(
+            user_id: i32,
+            preferences: &CrazyGamesPreferences
+        ) -> CrazyGamesPreferences);
         unused_database_method!(update_user_mmr_by_mode(
             user_id: i32,
             mmr_delta: i32,

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -6,7 +6,7 @@ use axum::{
     http::{Request, StatusCode},
     middleware,
     response::{IntoResponse, Response},
-    routing::{get, options, post},
+    routing::{get, options, post, put},
 };
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
@@ -18,6 +18,7 @@ use tower_http::cors::{Any, CorsLayer};
 use tracing::info;
 
 use crate::api::auth::{self, AuthState};
+use crate::api::crazygames;
 use crate::api::jwt::JwtManager;
 use crate::api::leaderboard::{self, LeaderboardState};
 use crate::api::middleware::{AuthMiddlewareState, auth_middleware};
@@ -232,6 +233,7 @@ pub async fn install_http_application(
         db: db.clone(),
         jwt_manager: jwt_manager.clone(),
         user_cache: Some(state.user_cache.clone()),
+        crazygames_verifier: crazygames::configured_verifier_from_env()?,
     };
     let auth_middleware_state = AuthMiddlewareState {
         jwt_manager: jwt_manager.clone(),
@@ -246,10 +248,16 @@ pub async fn install_http_application(
 
     // Create rate limiter for username check endpoint
     let username_check_limiter = rate_limit_layer(1000, 60);
+    let crazygames_exchange_limiter = rate_limit_layer(60, 60);
 
     // Build protected API routes
     let protected_routes = Router::new()
         .route("/api/auth/me", get(auth::get_current_user))
+        .route(
+            "/api/auth/crazygames/preferences",
+            put(crazygames::save_preferences)
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024)),
+        )
         .layer(middleware::from_fn_with_state(
             auth_middleware_state.clone(),
             auth_middleware,
@@ -296,6 +304,15 @@ pub async fn install_http_application(
         .route("/api/auth/register", post(auth::register))
         .route("/api/auth/login", post(auth::login))
         .route("/api/auth/guest", post(auth::create_guest))
+        .route(
+            "/api/auth/crazygames/exchange",
+            post(crazygames::exchange)
+                .layer(axum::extract::DefaultBodyLimit::max(64 * 1024))
+                .layer(middleware::from_fn_with_state(
+                    crazygames_exchange_limiter,
+                    rate_limit_middleware,
+                )),
+        )
         .route(
             "/api/auth/check-username",
             post(auth::check_username).layer(middleware::from_fn_with_state(

--- a/server/src/user_cache.rs
+++ b/server/src/user_cache.rs
@@ -15,9 +15,10 @@ const EXPIRATION_SECONDS: u64 = 3600; // 1 hour
 // write atomic so that late guest fill can never restore the stale identity.
 const PUT_USER_SCRIPT: &str = r#"
 local cached = redis.call('GET', KEYS[1])
-if cached and ARGV[2] == '1' then
-    local decoded_ok, cached_user = pcall(cjson.decode, cached)
-    if decoded_ok then
+if cached then
+    local cached_ok, cached_user = pcall(cjson.decode, cached)
+    local incoming_ok, incoming_user = pcall(cjson.decode, ARGV[1])
+    if cached_ok and ARGV[2] == '1' then
         local cached_is_guest = cached_user['is_guest']
         if cached_is_guest == nil then
             cached_is_guest = cached_user['isGuest']
@@ -25,6 +26,23 @@ if cached and ARGV[2] == '1' then
         if cached_is_guest == false then
             redis.call('EXPIRE', KEYS[1], ARGV[3])
             return 0
+        end
+    end
+
+    -- Profile metadata from a verified CrazyGames JWT is ordered by its iat.
+    -- A cache miss can read the old profile just before a newer exchange
+    -- commits, then reach Redis after the newer account has been written
+    -- through. Never let that stale non-guest fill restore the old identity.
+    if cached_ok and incoming_ok then
+        local cached_provider = cached_user['auth_provider'] or cached_user['authProvider']
+        local incoming_provider = incoming_user['auth_provider'] or incoming_user['authProvider']
+        if cached_provider == 'crazygames' and incoming_provider == 'crazygames' then
+            local cached_iat = cached_user['profile_iat'] or cached_user['profileIat'] or -1
+            local incoming_iat = incoming_user['profile_iat'] or incoming_user['profileIat'] or -1
+            if tonumber(cached_iat) > tonumber(incoming_iat) then
+                redis.call('EXPIRE', KEYS[1], ARGV[3])
+                return 0
+            end
         end
     end
 end
@@ -243,6 +261,63 @@ mod tests {
         let cached: serde_json::Value = serde_json::from_str(&cached)?;
         assert_eq!(cached["username"], "Player42");
         assert_eq!(cached["is_guest"], false);
+
+        redis.del::<_, ()>(&key).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn stale_crazygames_profile_fill_cannot_replace_newer_profile() -> Result<()> {
+        let client = RedisClient::open("redis://127.0.0.1:6379/15?protocol=resp3", None)?;
+        let mut redis = client.get_managed_connection().await?;
+        let key = format!(
+            "test:user-cache-crazygames-profile:{}",
+            uuid::Uuid::new_v4()
+        );
+
+        assert_eq!(
+            script_put(
+                &mut redis,
+                &key,
+                json!({
+                    "id": 42,
+                    "username": "New.Name",
+                    "is_guest": false,
+                    "auth_provider": "crazygames",
+                    "profile_iat": 200,
+                    "profile_picture_url": "https://images.crazygames.com/new.png"
+                }),
+                false,
+            )
+            .await?,
+            1
+        );
+        assert_eq!(
+            script_put(
+                &mut redis,
+                &key,
+                json!({
+                    "id": 42,
+                    "username": "Old.Name",
+                    "is_guest": false,
+                    "auth_provider": "crazygames",
+                    "profile_iat": 100,
+                    "profile_picture_url": "https://images.crazygames.com/old.png"
+                }),
+                false,
+            )
+            .await?,
+            0
+        );
+
+        let cached: String = redis.get(&key).await?;
+        let cached: serde_json::Value = serde_json::from_str(&cached)?;
+        assert_eq!(cached["username"], "New.Name");
+        assert_eq!(cached["profile_iat"], 200);
+        assert_eq!(
+            cached["profile_picture_url"],
+            "https://images.crazygames.com/new.png"
+        );
 
         redis.del::<_, ()>(&key).await?;
         Ok(())

--- a/server/tests/auth_upgrade_tests.rs
+++ b/server/tests/auth_upgrade_tests.rs
@@ -43,6 +43,7 @@ async fn isolated_state() -> Result<(AuthState, Arc<dyn Database>, Arc<JwtManage
         db: db.clone(),
         jwt_manager: jwt_manager.clone(),
         user_cache: None,
+        crazygames_verifier: None,
     };
     Ok((state, db, jwt_manager))
 }

--- a/server/tests/crazygames_account_tests.rs
+++ b/server/tests/crazygames_account_tests.rs
@@ -1,0 +1,403 @@
+use anyhow::Result;
+use common::QueueMode;
+use server::db::{
+    Database,
+    dynamodb::DynamoDatabase,
+    models::{
+        CrazyGamesAccount, CrazyGamesAccountOutcome, CrazyGamesAccountResolution,
+        CrazyGamesBoostInputMode, CrazyGamesGuestPromotion, CrazyGamesLobbyPreferences,
+        CrazyGamesPreferences, CrazyGamesProfile,
+    },
+};
+use std::{collections::HashMap, sync::Arc};
+use uuid::Uuid;
+
+// DynamoDatabase reads a process-wide table prefix during construction.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+async fn isolated_database() -> Result<Arc<dyn Database>> {
+    let prefix = format!("test_crazygames_{}", Uuid::new_v4().simple());
+    // SAFETY: every test in this integration binary holds TEST_LOCK while the
+    // database is being constructed and for the rest of its lifetime.
+    unsafe { std::env::set_var("DYNAMODB_TABLE_PREFIX", prefix) };
+    Ok(Arc::new(DynamoDatabase::new().await?))
+}
+
+fn profile(provider_user_id: &str, username: &str, iat: i64) -> CrazyGamesProfile {
+    CrazyGamesProfile {
+        provider_user_id: provider_user_id.to_string(),
+        username: username.to_string(),
+        avatar_url: format!("https://images.crazygames.com/{username}.png"),
+        profile_iat: iat,
+    }
+}
+
+fn preferences(tutorial: &str, competitive: bool) -> CrazyGamesPreferences {
+    CrazyGamesPreferences {
+        tutorial_seen: Some(HashMap::from([(tutorial.to_string(), true)])),
+        lobby_preferences: Some(CrazyGamesLobbyPreferences {
+            selected_modes: vec!["solo".to_string()],
+            competitive,
+        }),
+        boost_input_mode: Some(CrazyGamesBoostInputMode::Hold),
+    }
+}
+
+fn resolved(outcome: CrazyGamesAccountOutcome) -> CrazyGamesAccount {
+    match outcome {
+        CrazyGamesAccountOutcome::Resolved(account) => *account,
+        CrazyGamesAccountOutcome::GuestLinkConsentRequired => {
+            panic!("expected a resolved CrazyGames account")
+        }
+    }
+}
+
+#[tokio::test]
+async fn guest_claim_preserves_identity_and_progress_without_username_index() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let guest = db
+        .create_guest_user("GuestSnake", "guest-token", 1_000, false)
+        .await?;
+    let created_at = guest.created_at;
+    db.update_user_mmr(guest.id, 1_234).await?;
+    db.update_user_mmr_by_mode(guest.id, 125, &QueueMode::Competitive)
+        .await?;
+    db.update_user_mmr_by_mode(guest.id, -50, &QueueMode::Quickmatch)
+        .await?;
+    db.add_user_xp(guest.id, 77).await?;
+
+    let initial = preferences("movement", false);
+    let account = resolved(
+        db.resolve_crazygames_account(
+            &profile("cg-guest-claim", "Crazy.Player", 1_000),
+            Some(guest.id),
+            CrazyGamesGuestPromotion::Allow,
+            Some(&initial),
+        )
+        .await?,
+    );
+    assert_eq!(
+        account.resolution,
+        CrazyGamesAccountResolution::GuestClaimed
+    );
+    assert_eq!(account.user.id, guest.id);
+    assert_eq!(account.user.created_at, created_at);
+    assert_eq!(account.user.mmr, 1_234);
+    assert_eq!(account.user.ranked_mmr, 1_125);
+    assert_eq!(account.user.casual_mmr, 950);
+    assert_eq!(account.user.xp, 77);
+    assert!(!account.user.is_guest);
+    assert_eq!(account.user.auth_provider.as_deref(), Some("crazygames"));
+    assert_eq!(
+        account.user.crazygames_user_id.as_deref(),
+        Some("cg-guest-claim")
+    );
+    assert_eq!(account.preferences, initial);
+    assert!(db.get_user_by_username("Crazy.Player").await?.is_none());
+
+    // CrazyGames accounts intentionally have no password username mirror;
+    // every progression writer must continue to work without one.
+    assert_eq!(
+        db.update_user_mmr_by_mode(guest.id, 25, &QueueMode::Competitive)
+            .await?,
+        1_150
+    );
+    assert_eq!(db.add_user_xp(guest.id, 3).await?, 80);
+
+    let saved = db
+        .save_crazygames_preferences(
+            guest.id,
+            &CrazyGamesPreferences {
+                tutorial_seen: Some(HashMap::from([
+                    ("movement".to_string(), false),
+                    ("boost".to_string(), true),
+                ])),
+                boost_input_mode: Some(CrazyGamesBoostInputMode::Toggle),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let tutorials = saved.tutorial_seen.expect("tutorials");
+    assert_eq!(tutorials.get("movement"), Some(&true));
+    assert_eq!(tutorials.get("boost"), Some(&true));
+    assert_eq!(
+        saved.boost_input_mode,
+        Some(CrazyGamesBoostInputMode::Toggle)
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_promotion_check_is_read_only_and_repeatable() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let guest = db
+        .create_guest_user("ConsentGuest", "consent-token", 1_000, false)
+        .await?;
+    db.add_user_xp(guest.id, 29).await?;
+    let initial = preferences("movement", true);
+    let identity = profile("cg-consent-check", "Consent.Player", 1_500);
+
+    for _ in 0..2 {
+        let outcome = db
+            .resolve_crazygames_account(
+                &identity,
+                Some(guest.id),
+                CrazyGamesGuestPromotion::Check,
+                Some(&initial),
+            )
+            .await?;
+        assert!(matches!(
+            outcome,
+            CrazyGamesAccountOutcome::GuestLinkConsentRequired
+        ));
+
+        let persisted = db
+            .get_user_by_id(guest.id)
+            .await?
+            .expect("guest remains after consent check");
+        assert!(persisted.is_guest);
+        assert_eq!(persisted.username, "ConsentGuest");
+        assert_eq!(persisted.xp, 29);
+        assert!(persisted.auth_provider.is_none());
+        assert!(persisted.crazygames_user_id.is_none());
+    }
+    Ok(())
+}
+
+#[tokio::test]
+async fn guest_promotion_decline_creates_separate_account_without_importing_preferences()
+-> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let guest = db
+        .create_guest_user("DeclineGuest", "decline-token", 1_000, false)
+        .await?;
+    db.add_user_xp(guest.id, 37).await?;
+    let identity = profile("cg-consent-decline", "Separate.Player", 1_750);
+    let initial = preferences("must-not-import", true);
+
+    let created = resolved(
+        db.resolve_crazygames_account(
+            &identity,
+            Some(guest.id),
+            CrazyGamesGuestPromotion::Decline,
+            Some(&initial),
+        )
+        .await?,
+    );
+    assert_eq!(created.resolution, CrazyGamesAccountResolution::Created);
+    assert_ne!(created.user.id, guest.id);
+    assert_eq!(created.preferences, CrazyGamesPreferences::default());
+
+    let persisted_guest = db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("declined guest remains");
+    assert!(persisted_guest.is_guest);
+    assert_eq!(persisted_guest.xp, 37);
+    assert!(persisted_guest.auth_provider.is_none());
+
+    // Once the identity exists, even a later check with an eligible guest is
+    // a normal returning login and must never prompt or claim that guest.
+    let returning = resolved(
+        db.resolve_crazygames_account(
+            &identity,
+            Some(guest.id),
+            CrazyGamesGuestPromotion::Check,
+            Some(&initial),
+        )
+        .await?,
+    );
+    assert_eq!(returning.resolution, CrazyGamesAccountResolution::Returning);
+    assert_eq!(returning.user.id, created.user.id);
+    assert!(
+        db.get_user_by_id(guest.id)
+            .await?
+            .expect("guest remains after returning login")
+            .is_guest
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn returning_identity_wins_and_only_newer_verified_profile_is_applied() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let original_preferences = preferences("movement", false);
+    let created = resolved(
+        db.resolve_crazygames_account(
+            &profile("cg-returning", "First.Name", 1_000),
+            None,
+            CrazyGamesGuestPromotion::Decline,
+            // Unscoped browser preferences must not seed a newly created
+            // provider account on a shared device.
+            Some(&original_preferences),
+        )
+        .await?,
+    );
+    assert_eq!(created.resolution, CrazyGamesAccountResolution::Created);
+    assert_eq!(created.preferences, CrazyGamesPreferences::default());
+    let original_preferences = db
+        .save_crazygames_preferences(created.user.id, &original_preferences)
+        .await?;
+
+    let unrelated_guest = db
+        .create_guest_user("UnrelatedGuest", "unrelated-token", 1_000, false)
+        .await?;
+    db.add_user_xp(unrelated_guest.id, 41).await?;
+    let replacement_initial = preferences("should-not-overwrite", true);
+    let returning = resolved(
+        db.resolve_crazygames_account(
+            &profile("cg-returning", "Newer.Name", 2_000),
+            Some(unrelated_guest.id),
+            CrazyGamesGuestPromotion::Check,
+            Some(&replacement_initial),
+        )
+        .await?,
+    );
+    assert_eq!(returning.resolution, CrazyGamesAccountResolution::Returning);
+    assert_eq!(returning.user.id, created.user.id);
+    assert_eq!(returning.profile.username, "Newer.Name");
+    assert_eq!(returning.preferences, original_preferences);
+    let untouched_guest = db
+        .get_user_by_id(unrelated_guest.id)
+        .await?
+        .expect("unrelated guest remains");
+    assert!(untouched_guest.is_guest);
+    assert_eq!(untouched_guest.xp, 41);
+
+    let stale = resolved(
+        db.resolve_crazygames_account(
+            &profile("cg-returning", "Stale.Name", 1_500),
+            None,
+            CrazyGamesGuestPromotion::Decline,
+            None,
+        )
+        .await?,
+    );
+    assert_eq!(stale.user.id, created.user.id);
+    assert_eq!(stale.profile.username, "Newer.Name");
+    assert_eq!(stale.user.username, "Newer.Name");
+    Ok(())
+}
+
+#[tokio::test]
+async fn concurrent_first_launches_converge_on_exactly_one_account() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let identity = profile("cg-concurrent", "Race.Player", 3_000);
+    let mut tasks = Vec::new();
+    for _ in 0..8 {
+        let db = db.clone();
+        let identity = identity.clone();
+        tasks.push(tokio::spawn(async move {
+            db.resolve_crazygames_account(&identity, None, CrazyGamesGuestPromotion::Decline, None)
+                .await
+        }));
+    }
+
+    let mut ids = Vec::new();
+    let mut created = 0;
+    for task in tasks {
+        let account = resolved(task.await??);
+        ids.push(account.user.id);
+        created += usize::from(account.resolution == CrazyGamesAccountResolution::Created);
+    }
+    assert!(ids.iter().all(|id| *id == ids[0]));
+    assert_eq!(created, 1);
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_progress_writes_survive_crazygames_guest_claim() -> Result<()> {
+    const STEPS: i32 = 6;
+
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let guest = db
+        .create_guest_user("ProgressGuest", "progress-token", 1_000, false)
+        .await?;
+    let guest_id = guest.id;
+    let barrier = Arc::new(tokio::sync::Barrier::new(3));
+
+    let claim_db = db.clone();
+    let claim_barrier = barrier.clone();
+    let claim_task = tokio::spawn(async move {
+        claim_barrier.wait().await;
+        claim_db
+            .resolve_crazygames_account(
+                &profile("cg-progress-race", "Progress.Player", 3_500),
+                Some(guest_id),
+                CrazyGamesGuestPromotion::Allow,
+                None,
+            )
+            .await
+    });
+
+    let progress_db = db.clone();
+    let progress_barrier = barrier.clone();
+    let progress_task = tokio::spawn(async move {
+        progress_barrier.wait().await;
+        for _ in 0..STEPS {
+            progress_db.add_user_xp(guest_id, 1).await?;
+            progress_db
+                .update_user_mmr_by_mode(guest_id, 3, &QueueMode::Competitive)
+                .await?;
+            progress_db
+                .update_user_mmr_by_mode(guest_id, -2, &QueueMode::Quickmatch)
+                .await?;
+            tokio::task::yield_now().await;
+        }
+        Ok::<(), anyhow::Error>(())
+    });
+
+    barrier.wait().await;
+    let (claim_result, progress_result) = tokio::join!(claim_task, progress_task);
+    let claimed = resolved(claim_result??);
+    progress_result??;
+    assert_eq!(claimed.user.id, guest_id);
+    assert_eq!(
+        claimed.resolution,
+        CrazyGamesAccountResolution::GuestClaimed
+    );
+
+    let persisted = db
+        .get_user_by_id(guest_id)
+        .await?
+        .expect("claimed user remains");
+    assert!(!persisted.is_guest);
+    assert_eq!(persisted.auth_provider.as_deref(), Some("crazygames"));
+    assert_eq!(persisted.xp, STEPS);
+    assert_eq!(persisted.ranked_mmr, 1_000 + (STEPS * 3));
+    assert_eq!(persisted.casual_mmr, 1_000 - (STEPS * 2));
+    Ok(())
+}
+
+#[tokio::test]
+async fn stress_guest_is_never_claimed() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let db = isolated_database().await?;
+    let stress_guest = db
+        .create_guest_user("StressSnake", "stress-token", 1_000, true)
+        .await?;
+    let account = resolved(
+        db.resolve_crazygames_account(
+            &profile("cg-no-stress", "Public.Player", 4_000),
+            Some(stress_guest.id),
+            CrazyGamesGuestPromotion::Allow,
+            None,
+        )
+        .await?,
+    );
+    assert_eq!(account.resolution, CrazyGamesAccountResolution::Created);
+    assert_ne!(account.user.id, stress_guest.id);
+    assert!(
+        db.get_user_by_id(stress_guest.id)
+            .await?
+            .expect("stress guest remains")
+            .is_guest
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Companion PR

- https://github.com/lopatin/snaketron-io/pull/27 — merge this game-code PR first, then the infrastructure/release PR

## Summary

- authenticate CrazyGames players with User API v3 tokens, verifying RS256 signatures and the configured CrazyGames game ID
- map CrazyGames identities to backend users using hashed provider identifiers, with atomic account creation, restore, guest promotion, and explicit linking for an existing standard account
- persist player progress and preferences in the SnakeTron backend so returning CrazyGames users restore automatically
- preserve the existing guest, standard-web, and itch.io paths when CrazyGames mode is disabled
- add account/privacy UI, data-deletion documentation, backend concurrency coverage, frontend unit coverage, and end-to-end CrazyGames account-flow coverage
- update React Router to the patched 7.18.2 baseline

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test -p server -- --test-threads=1`
- `cargo test --workspace --exclude server -- --test-threads=1`
- frontend type-check
- 187 frontend unit tests
- 14 CrazyGames Chromium end-to-end tests
- production and CrazyGames release builds
- `npm audit --omit=dev` reports zero production dependency vulnerabilities

## Deployment notes

- No database migration is required.
- Deploy the backend with CrazyGames auth enabled before uploading the CrazyGames package.
- A final account-flow check in the real CrazyGames Preview environment remains a manual release gate.
