### PR TITLE
Expand executor capacity to 50 partitions

### DIFF
--- a/loadtest/src/report.rs
+++ b/loadtest/src/report.rs
@@ -8,6 +8,7 @@
 //! - one JSON file under `failures/` for every non-completed session.
 
 use serde::{Deserialize, Serialize};
+use server::game_executor::PARTITION_COUNT;
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fmt::{self, Write as _};
@@ -868,7 +869,7 @@ pub struct AggregateMetrics {
     pub command_counts_by_unix_second: BTreeMap<u64, u64>,
     /// First-seen authoritative command schedules grouped by executor partition
     /// and the load generator's receipt second.
-    /// Game IDs map to partitions with `game_id % 10`.
+    /// Game IDs map to partitions with `game_id % PARTITION_COUNT`.
     #[serde(default)]
     pub scheduled_command_counts_by_partition_and_unix_second: BTreeMap<u32, BTreeMap<u64, u64>>,
     /// Sum of first-seen accepted/scheduled outcomes keyed by original send
@@ -1153,7 +1154,7 @@ pub fn aggregate_report(run: &LoadTestRun) -> AggregateReport {
             for (second, count) in &session.metrics.scheduled_command_counts_by_unix_second {
                 if let Some(game_id) = session.game_id {
                     let partition_total = scheduled_command_counts_by_partition_and_unix_second
-                        .entry(game_id % 10)
+                        .entry(game_id % PARTITION_COUNT)
                         .or_default()
                         .entry(*second)
                         .or_default();
@@ -2160,7 +2161,7 @@ mod tests {
             session_id: "s1".to_owned(),
             user_id: 1,
             game_id: 21,
-            partition_id: 1,
+            partition_id: 21 % PARTITION_COUNT,
             client_game_session_id: "game-s1".to_owned(),
             command_sequence: 3,
             sent_at_unix_ms: 10_000,
@@ -2246,7 +2247,7 @@ mod tests {
             session_id: "s2".to_owned(),
             user_id: 2,
             game_id: 32,
-            partition_id: 2,
+            partition_id: 32 % PARTITION_COUNT,
             client_game_session_id: "game-s2".to_owned(),
             command_sequence: 4,
             sent_at_unix_ms: 10_001,
@@ -2403,8 +2404,8 @@ mod tests {
                 .metrics
                 .scheduled_command_counts_by_partition_and_unix_second,
             BTreeMap::from([
-                (1, BTreeMap::from([(10, 3), (11, 3)])),
-                (2, BTreeMap::from([(10, 1)])),
+                (21 % PARTITION_COUNT, BTreeMap::from([(10, 3), (11, 3)])),
+                (32 % PARTITION_COUNT, BTreeMap::from([(10, 1)])),
             ])
         );
         assert_eq!(
@@ -2480,8 +2481,10 @@ mod tests {
             Some(&serde_json::json!(6))
         );
         assert_eq!(
-            report_json
-                .pointer("/metrics/scheduled_command_counts_by_partition_and_unix_second/1/11"),
+            report_json.pointer(&format!(
+                "/metrics/scheduled_command_counts_by_partition_and_unix_second/{}/11",
+                21 % PARTITION_COUNT,
+            )),
             Some(&serde_json::json!(3))
         );
         assert_eq!(

--- a/loadtest/src/session.rs
+++ b/loadtest/src/session.rs
@@ -17,6 +17,7 @@ use common::{
 use futures_util::{SinkExt, StreamExt, future::join_all, stream::SplitSink};
 use reqwest::{Client, Url};
 use serde::Deserialize;
+use server::game_executor::PARTITION_COUNT;
 use server::lifecycle::WS_PROTOCOL_VERSION as CLIENT_PROTOCOL_VERSION;
 use server::lobby_manager::LobbyPreferences;
 use server::recovery::CommandOutcome;
@@ -5278,7 +5279,7 @@ impl LiveSession {
                 session_id: self.record.session_id.clone(),
                 user_id: self.user_id,
                 game_id,
-                partition_id: game_id % 10,
+                partition_id: game_id % PARTITION_COUNT,
                 client_game_session_id: self.client_game_session_id.clone(),
                 command_sequence: sequence,
                 sent_at_unix_ms: resolution.sent_at_unix_ms,
@@ -6756,7 +6757,7 @@ mod tests {
             session_id: "session-1".to_owned(),
             user_id: 7,
             game_id: 42,
-            partition_id: 2,
+            partition_id: 42 % PARTITION_COUNT,
             client_game_session_id: "game-session-1".to_owned(),
             command_sequence: sequence,
             sent_at_unix_ms: 1_000 + sequence,

--- a/run_autoscaling_resilience_tests.sh
+++ b/run_autoscaling_resilience_tests.sh
@@ -14,8 +14,8 @@ report_dir=""
 scaling_resource=""
 original_desired=""
 scaling_state=""
-canonical_scaling_state=$'1\t10\tFalse\tFalse\tFalse'
-suspended_scaling_state=$'1\t10\tTrue\tTrue\tTrue'
+canonical_scaling_state=$'1\t25\tFalse\tFalse\tFalse'
+suspended_scaling_state=$'1\t25\tTrue\tTrue\tTrue'
 gate_a_post_ready_required_full_seconds=60
 load_pid=""
 capacity_pid=""
@@ -457,7 +457,7 @@ select_hard_crash_authoritative_output_sample() {
                 <= .redis_observation_completed_at_ms
               and .first_scheduled_output.stream_unix_ms
                 <= .redis_observation_completed_at_ms
-              and .first_scheduled_output.game_id % 10 == $partition
+              and .first_scheduled_output.game_id % 50 == $partition
               and .first_scheduled_output.command_id.game_id
                 == .first_scheduled_output.game_id
               and .first_scheduled_output.command_id.sequence > 0
@@ -539,7 +539,7 @@ write_capacity_acceptance_report() {
               [($second | tostring)] // 0) as $command_outcomes
           | ($r.metrics.command_outcome_max_latency_ms_by_sent_unix_second
               [($second | tostring)] // null) as $max_outcome_latency_ms
-          | ([range(0; 10)
+          | ([range(0; 50)
               | . as $partition
               | select(
                   ($r.metrics
@@ -561,7 +561,7 @@ write_capacity_acceptance_report() {
                 and $command_outcomes == $commands_sent
                 and $max_outcome_latency_ms != null
                 and $max_outcome_latency_ms <= $max_latency_ms
-                and $productive_partitions == 10)
+                and $productive_partitions == 50)
             }] as $seconds
       | longest_streak($seconds) as $streak
       | {
@@ -814,7 +814,7 @@ write_gate_a_acceptance_report() {
                 == ($report.metrics.traffic.commands_sent // -1)
               and (($report.metrics
                 .scheduled_command_counts_by_partition_and_unix_second // {})
-                | length) == 10)
+                | length) == 50)
         } as $outcomes
       | (($report.missing // false) | not) as $summary_available
       | {
@@ -1336,7 +1336,7 @@ test_command_outcome_window_gate() {
       command_counts_by_unix_second: {"10": 5, "11": 6},
       scheduled_command_counts_by_sent_unix_second: {"10": 4, "11": 5},
       scheduled_command_counts_by_partition_and_unix_second:
-        (reduce range(0; 10) as $partition
+        (reduce range(0; 50) as $partition
           ({}; .[($partition | tostring)] = {"10": 1, "11": 1})),
       command_outcome_counts_by_sent_unix_second: {"10": 5, "11": 6},
       command_outcome_max_latency_ms_by_sent_unix_second: {"10": 999, "11": 1000}
@@ -1454,7 +1454,7 @@ test_command_outcome_window_gate() {
     and .duration_ms == 2000
   ' "$post_ready_window" >/dev/null || result=1
   command_outcome_window_diagnostics \
-    "$summary" "$post_ready_window" 1000 10 >"$post_ready_steady"
+    "$summary" "$post_ready_window" 1000 50 >"$post_ready_steady"
   jq -e '
     .passed
     and .required_full_seconds == 1
@@ -1463,8 +1463,17 @@ test_command_outcome_window_gate() {
     and .after_last_full_second == 12
     and .full_second_count == 1
   ' "$post_ready_steady" >/dev/null || result=1
+  jq 'del(
+    .metrics.scheduled_command_counts_by_partition_and_unix_second["49"]
+  )' "$summary" >"$invalid"
   command_outcome_window_diagnostics \
-    "$summary" "$post_ready_window" 1000 10 2 \
+    "$invalid" "$post_ready_window" 1000 50 \
+    | jq -e '
+        .passed == false
+        and .partition_coverage.uncovered_partitions == [49]
+      ' >/dev/null || result=1
+  command_outcome_window_diagnostics \
+    "$summary" "$post_ready_window" 1000 50 2 \
     >"$insufficient_post_ready_steady"
   jq -e '
     .passed == false
@@ -1585,7 +1594,7 @@ test_capacity_continuous_window_contract() {
         | {key: (. | tostring), value: $value}]
       | from_entries;
     def per_partition:
-      [range(0; 10)
+      [range(0; 50)
         | . as $partition
         | {
             key: ($partition | tostring),
@@ -2095,9 +2104,9 @@ test_hard_crash_evidence_selectors() {
         first_scheduled_output: {
           stream_id: (($stopped + 3000 | tostring) + "-0"),
           stream_unix_ms: ($stopped + 3000),
-          game_id: (10 + $partition),
+          game_id: (50 + $partition),
           command_id: {
-            game_id: (10 + $partition),
+            game_id: (50 + $partition),
             user_id: 77,
             client_game_session_id: "fixture-session",
             sequence: 1
@@ -5363,7 +5372,7 @@ assert_hard_crash_report() {
                 <= $authoritative_output[0].redis_observation_completed_at_ms
               and $authoritative_output[0].first_scheduled_output.stream_unix_ms
                 <= $authoritative_output[0].redis_observation_completed_at_ms
-              and $authoritative_output[0].first_scheduled_output.game_id % 10
+              and $authoritative_output[0].first_scheduled_output.game_id % 50
                 == $partition
               and $authoritative_output[0].first_scheduled_output
                 .command_id.game_id
@@ -5502,7 +5511,7 @@ run_staging_suite() {
       --resource-id "$scaling_resource" \
       --scalable-dimension ecs:service:DesiredCount \
       --min-capacity 1 \
-      --max-capacity 10 \
+      --max-capacity 25 \
       --suspended-state \
 "DynamicScalingInSuspended=$value,DynamicScalingOutSuspended=$value,ScheduledScalingSuspended=$value" \
       >/dev/null
@@ -5605,7 +5614,7 @@ run_staging_suite() {
     fi
     if ! staging_entry_state_is_valid \
       planned "$observed_desired" "$observed_scaling_state"; then
-      echo "Staging autoscaling must be min=1, max=10, and fully enabled; found: $observed_scaling_state" >&2
+      echo "Staging autoscaling must be min=1, max=25, and fully enabled; found: $observed_scaling_state" >&2
       exit 1
     fi
     trap restore_and_verify EXIT
@@ -5714,7 +5723,7 @@ run_staging_suite() {
             (.ecs_task_id // "") | length > 0)
           and (.assignment.eligible_members | unique | sort) == $active_boot_ids
           and ([.assignment.owners[]] | unique | sort) == $active_boot_ids
-          and (.assignment.owners | length) == 10
+          and (.assignment.owners | length) == 50
           and (
             [.assignment.eligible_members[] as $member
               | [.assignment.owners[] | select(. == $member)] | length
@@ -5730,7 +5739,7 @@ run_staging_suite() {
               or (.consumer_group_exists | not)
             )
           ] | length) == 0
-          and ([.runtime_partitions[].lease_token] | unique | length) == 10
+          and ([.runtime_partitions[].lease_token] | unique | length) == 50
         ' "$candidate" >/dev/null; then
         mv "$candidate" "$snapshot"
         return 0
@@ -5753,7 +5762,7 @@ run_staging_suite() {
         && jq -e --argjson expected "$expected_tasks" '
           ([.live_members[] | select(.lifecycle == "ACTIVE")] | length) == $expected
           and .assignment != null
-          and (.runtime_partitions | length) == 10
+          and (.runtime_partitions | length) == 50
           and all(.runtime_partitions[];
             .consumer_group_exists
             and .owner_matches
@@ -6229,7 +6238,7 @@ run_staging_suite() {
     --query 'services[0].desiredCount' \
     --output text)"
   if [[ ! "$automatic_scale_out_count" =~ ^[0-9]+$ ]] \
-    || (( automatic_scale_out_count < 2 || automatic_scale_out_count > 10 )); then
+    || (( automatic_scale_out_count < 2 || automatic_scale_out_count > 25 )); then
     echo "Target tracking did not leave a valid added-capacity count: $automatic_scale_out_count" >&2
     exit 1
   fi
@@ -6283,11 +6292,11 @@ run_staging_suite() {
     command_outcome_window_diagnostics \
       "$gate_a_summary" \
       "$report_dir/automatic-scale-out-baseline-window.json" \
-      1000 10 >"$gate_a_baseline_diagnostics"
+      1000 50 >"$gate_a_baseline_diagnostics"
     command_outcome_window_diagnostics \
       "$gate_a_summary" \
       "$report_dir/automatic-scale-out-window.json" \
-      1000 10 >"$gate_a_movement_diagnostics"
+      1000 50 >"$gate_a_movement_diagnostics"
     # Once every new task is healthy and visible through Traefik/control-plane
     # readiness, keep enforcing the same strict command budget through the
     # load stage's recorded finish. The shared window helper evaluates only
@@ -6298,7 +6307,7 @@ run_staging_suite() {
     command_outcome_window_diagnostics \
       "$gate_a_summary" \
       "$gate_a_post_ready_window" \
-      1000 10 "$gate_a_post_ready_required_full_seconds" \
+      1000 50 "$gate_a_post_ready_required_full_seconds" \
       >"$gate_a_post_ready_steady_diagnostics"
   else
     gate_a_summary="$report_dir/gate-a-missing-load-summary.json"
@@ -6328,7 +6337,7 @@ run_staging_suite() {
     exit 1
   }
 
-  # Automatic scale-out may have stopped at any count from two through ten.
+  # Automatic scale-out may have stopped at any count from two through 25.
   # Return without load to one healthy task, then start the independent
   # capacity-valid planned-transition cohort.
   local reset_to_one_started_ms
@@ -6556,7 +6565,7 @@ run_staging_suite() {
     --slurpfile ten "$report_dir/control-plane-scale-10.json" \
     --slurpfile final "$report_dir/control-plane-final-1.json" '
       def moved($left; $right):
-        [range(0; 10) as $partition
+        [range(0; 50) as $partition
           | ($partition | tostring) as $key
           | select($left.assignment.owners[$key] != $right.assignment.owners[$key])]
         | length;
@@ -6571,8 +6580,8 @@ run_staging_suite() {
   jq -e '
     .initial_version < .scale_10_version
     and .scale_10_version < .final_version
-    and .scale_out_moved_partitions == 9
-    and .scale_in_moved_partitions == 9
+    and .scale_out_moved_partitions == 45
+    and .scale_in_moved_partitions == 45
   ' "$report_dir/assignment-movement.json" >/dev/null || {
     echo "Assignment versions or minimum 1 -> 10 -> 1 movement invariants failed" >&2
     exit 1
@@ -6640,9 +6649,9 @@ run_staging_suite() {
           . >= $scale_in[0].started_at_unix_ms
           and . <= $scale_in[0].finished_at_unix_ms))
       and ($scale_in[0].duration_ms >= 1000 and $scale_in[0].duration_ms <= 45000)
-      and (.metrics.scheduled_command_counts_by_partition_and_unix_second | length) == 10
+      and (.metrics.scheduled_command_counts_by_partition_and_unix_second | length) == 50
       and ([.metrics.scheduled_command_counts_by_partition_and_unix_second[] | .[]] | add) > 0
-      and all(range(0; 10);
+      and all(range(0; 50);
         . as $partition
         | any(
           ($report.metrics.scheduled_command_counts_by_partition_and_unix_second
@@ -6650,7 +6659,7 @@ run_staging_suite() {
           | to_entries[];
           (.key | tonumber) < (($scale_out[0].started_at_unix_ms / 1000) | ceil)
           and .value > 0))
-      and all(range(0; 10);
+      and all(range(0; 50);
         . as $partition
         | any(
           ($report.metrics.scheduled_command_counts_by_partition_and_unix_second
@@ -6660,7 +6669,7 @@ run_staging_suite() {
           and ((.key | tonumber) < $scale_in_first_second)
           and .value > 0))
       and $scale_in_after_last_second > $scale_in_first_second
-      and all(range(0; 10);
+      and all(range(0; 50);
         . as $partition
         | any(
           ($report.metrics.scheduled_command_counts_by_partition_and_unix_second

--- a/run_stress_test.sh
+++ b/run_stress_test.sh
@@ -204,14 +204,16 @@ jq -e '
   (.ScalableTargets | length) == 1
   and (.ScalableTargets[0] as $target
     | $target.MinCapacity == 1
-    and $target.MaxCapacity == 10
+    and $target.MaxCapacity == 25
     and ($target.SuspendedState.DynamicScalingInSuspended // false) == false
     and ($target.SuspendedState.DynamicScalingOutSuspended // false) == false
     and ($target.SuspendedState.ScheduledScalingSuspended // false) == false)
 ' "$report_dir/scalable-targets.json" >/dev/null || {
-  echo "Stress testing requires enabled ECS autoscaling with bounds 1..10" >&2
+  echo "Stress testing requires enabled ECS autoscaling with bounds 1..25" >&2
   exit 1
 }
+max_capacity="$(jq -er '.ScalableTargets[0].MaxCapacity' \
+  "$report_dir/scalable-targets.json")"
 
 aws application-autoscaling describe-scaling-policies \
   --region "$SNAKETRON_AWS_REGION" \
@@ -244,13 +246,13 @@ aws ecs describe-services \
   --cluster "$SNAKETRON_ECS_CLUSTER" \
   --services "$SNAKETRON_ECS_SERVICE" \
   >"$report_dir/baseline-service.json"
-jq -e '
+jq -e --argjson max_capacity "$max_capacity" '
   (.failures | length) == 0
   and (.services | length) == 1
   and (.services[0] as $service
     | $service.status == "ACTIVE"
     and $service.desiredCount >= 1
-    and $service.desiredCount < 10
+    and $service.desiredCount < $max_capacity
     and $service.runningCount == $service.desiredCount
     and $service.pendingCount == 0
     and ($service.deployments | length) == 1

--- a/server/src/cluster_membership.rs
+++ b/server/src/cluster_membership.rs
@@ -15,20 +15,21 @@ use tracing::warn;
 use uuid::Uuid;
 
 pub const MEMBERSHIP_SCHEMA_VERSION: u16 = 2;
-/// Bumped for the pre-match readiness gate, Boost in Solo and free-for-all,
-/// and the idle-kick system layered on top of both.
+/// Bumped for the executor expansion from ten to fifty partitions. Partition
+/// selection and Redis key families are not encoded in serde payloads, so a
+/// mixed deployment would otherwise route the same game to different owners.
 ///
-/// Every one of those changes is invisible to serde: `readiness`,
+/// The prior version also covered serde-invisible readiness, Boost, and
+/// idle-kick changes: `readiness`,
 /// `simulation_epoch_ms`, `BoostConfig::unlimited`, `player_last_activity_ticks`,
-/// `idle_kicked_user_ids` and `completed_by_inactivity` all default. A
-/// previous-version executor would therefore deserialize a *held* checkpoint as
-/// an ungated match and simulate the whole elapsed gate window in one burst,
-/// would run a Solo or free-for-all match at half its intended simulation rate,
-/// and would resume an in-flight match with every player's idle clock reset to
-/// tick zero — silently re-arming or skipping kicks. The version gate makes it
-/// refuse the envelope instead, and keeps mixed-version executors from
-/// co-owning partitions during a rolling deploy.
-pub const EXECUTOR_PROTOCOL_VERSION: u16 = 8;
+/// `idle_kicked_user_ids` and `completed_by_inactivity` all default. Executors
+/// older than version 8 could therefore deserialize a *held* checkpoint as an
+/// ungated match and simulate the whole elapsed gate window in one burst, run a
+/// Solo or free-for-all match at half its intended simulation rate, or resume
+/// with every player's idle clock reset to tick zero. The version gate refuses
+/// incompatible envelopes and keeps mixed-version executors from co-owning
+/// partitions during a rolling deploy.
+pub const EXECUTOR_PROTOCOL_VERSION: u16 = 9;
 // Three missed one-second heartbeats prove task loss with enough margin for
 // assignment and executor bootstrap inside the five-second crash-output gate.
 pub const DEFAULT_MEMBERSHIP_TTL: Duration = Duration::from_secs(3);

--- a/server/src/game_bus.rs
+++ b/server/src/game_bus.rs
@@ -126,7 +126,7 @@ impl PartitionSubscription {
 }
 
 /// Approximate trim bounds (`MAXLEN ~`). At game rates (a handful of events
-/// per 100 ms tick, 1/10 of games per partition) the events bound keeps
+/// per 100 ms tick, 1/50 of games per partition) the events bound keeps
 /// several minutes of backlog — ample for any reconnect window — while
 /// keeping memory strictly bounded (the old implementation never trimmed).
 const EVENTS_MAXLEN: usize = 8192;

--- a/server/src/game_executor.rs
+++ b/server/src/game_executor.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use common::{ClientCommandIdentityV2, GameCommand, GameCommandMessage, GameState, GameStatus};
 use serde::{Deserialize, Serialize};
 
-pub const PARTITION_COUNT: u32 = 10;
+pub const PARTITION_COUNT: u32 = 50;
 
 // Snapshot-bearing events are message envelopes; boxing would add churn
 // without a win.

--- a/server/src/redis_keys.rs
+++ b/server/src/redis_keys.rs
@@ -16,7 +16,7 @@ impl RedisKeys {
     pub const MATCHMAKING_LOBBY_ACTIVE_GAME_PREFIX: &'static str =
         "matchmaking:{snaketron:mm}:lobby:";
     pub const MATCHMAKING_ACTIVE_GAME_SUFFIX: &'static str = ":active-game";
-    const EXECUTOR_PARTITION_COUNT: u32 = 10;
+    const EXECUTOR_PARTITION_COUNT: u32 = crate::game_executor::PARTITION_COUNT;
 
     fn executor_tag(partition_id: u32) -> String {
         format!("{{snaketron:exec:{partition_id}}}")
@@ -462,10 +462,14 @@ mod tests {
             "snaketron:readiness:use1:task:boot"
         );
         assert_eq!(hash_tag(&RedisKeys::stream_events(0)), "snaketron:exec:0");
-        assert_eq!(hash_tag(&RedisKeys::game_snapshot(123)), "snaketron:exec:3");
+        let game_partition_tag = format!(
+            "snaketron:exec:{}",
+            123 % crate::game_executor::PARTITION_COUNT,
+        );
+        assert_eq!(hash_tag(&RedisKeys::game_snapshot(123)), game_partition_tag);
         assert_eq!(
             hash_tag(&RedisKeys::cluster_planned_handoff_watermark("use1", 123)),
-            "snaketron:exec:3"
+            game_partition_tag
         );
 
         // Test game type hashing

--- a/server/src/resilience_metrics.rs
+++ b/server/src/resilience_metrics.rs
@@ -2104,9 +2104,12 @@ mod tests {
 
         assert_eq!(
             summarize_partition_leases(Some(&assignment), &leases),
-            (9, 1, 2),
+            (u64::from(PARTITION_COUNT - 1), 1, 2),
         );
-        assert_eq!(summarize_partition_leases(None, &leases), (9, 0, 0));
+        assert_eq!(
+            summarize_partition_leases(None, &leases),
+            (u64::from(PARTITION_COUNT - 1), 0, 0),
+        );
         Ok(())
     }
 

--- a/server/tests/game_bus_test.rs
+++ b/server/tests/game_bus_test.rs
@@ -741,7 +741,8 @@ async fn game_created_checkpoint_and_index_precede_ack() -> Result<()> {
 
         let token = CancellationToken::new();
         let bus = streams_bus(token.clone()).await?;
-        // These correctness paths require a real executor partition (0..10).
+        // These correctness paths require a real executor partition
+        // (0..PARTITION_COUNT).
         // Give each such test a fixed, distinct partition so parallel tests
         // cannot delete one another's shared partition stream.
         let partition = 7;

--- a/specs/autoscaling-resilience-prd.md
+++ b/specs/autoscaling-resilience-prd.md
@@ -5,7 +5,7 @@
 | Status | Direct-only implementation acceptance draft |
 | Product | Snaketron regional game service |
 | Owners | Engineering / Product |
-| Last updated | 2026-07-29 |
+| Last updated | 2026-08-09 |
 | Scope | Executor ownership, task lifecycle, WebSocket continuity, matchmaking safety, readiness, and autoscaling |
 
 ## 1. Executive summary

--- a/specs/autoscaling-resilience-prd.md
+++ b/specs/autoscaling-resilience-prd.md
@@ -98,7 +98,7 @@ For this PRD:
     inside budget;
   - the **planned-transition gate** starts from a clean one-task baseline and
     runs 128 game sessions / 64 duels with `every-tick` commands covering all
-    ten partitions through forced `1 -> 10 -> 1`, plus 10 idle, 10 lobby, and
+    fifty partitions through forced `1 -> 10 -> 1`, plus 10 idle, 10 lobby, and
     three unmatched matchmaking probes. During scale-in it also runs bounded
     open-loop idle admission at four starts per second, with a 64-session
     in-flight safety ceiling and a one-second post-ready hold. The high-load
@@ -106,7 +106,7 @@ For this PRD:
   - the **ten-task capacity gate** configures 272 game sessions / 136 duels and
     requires at least 256 authenticated game sessions / 128 concurrent duels,
     after ramping at four new sessions per second, with `every-tick` commands
-    across ten partitions for at least five continuous minutes.
+    across fifty partitions for at least five continuous minutes.
   Make-before-break candidate sockets are additional transient traffic. Every
   gate reports checkpoint write rate/size, pending backlog, per-task sockets,
   CPU/memory, and Valkey/ingress saturation. Raising a required minimum requires
@@ -116,7 +116,7 @@ For this PRD:
 ## 5. Goals
 
 1. Make crash recovery authoritative: SIGTERM accelerates recovery but is never required for it.
-2. Rebalance all ten executor partitions automatically on task arrival and departure.
+2. Rebalance all fifty executor partitions automatically on task arrival and departure.
 3. Prevent any stale executor from committing authoritative output after its lease term ends.
 4. Make executor commands durable across periods with no active executor.
 5. Resume each active game from a recent per-game checkpoint without scanning all game keys.
@@ -214,7 +214,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
    - scale-down moves only partitions assigned to departing tasks;
    - an unchanged membership set produces no movement.
    - formally, after eligibility and balance are satisfied, minimize the assignment map's Hamming distance from the preceding assignment.
-4. With ten fixed partitions, use the direct balanced/minimal-movement allocator. Do not add or persist a consistent-hash ring for this release; it would not replace the explicit assignment contract or its balance and movement tests.
+4. With fifty fixed partitions, use the direct balanced/minimal-movement allocator. Do not add or persist a consistent-hash ring for this release; it would not replace the explicit assignment contract or its balance and movement tests.
 5. The coordinator must coalesce ordinary staggered joins and planned drains behind one four-second in-memory quiet window. This wait is allowed only while every current owner is live, protocol-compatible, and `ACTIVE` or `DRAINING`; a missing, expired, `WARMING`, or incompatible owner bypasses it immediately. A coordinator-term change resets the timer, and the current assignment's partition views are repaired while a candidate is held. Do not persist this timer or add an ECS dependency or two-phase assignment protocol.
 6. The coordinator itself must use a unique tokened lease. Assignment writes must compare the exact coordinator token and expected assignment version atomically.
 7. Readers must observe either the complete old assignment or the complete new assignment, never a partial map.
@@ -222,7 +222,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 9. A task may acquire a free partition lease only if it is the desired owner in the current assignment.
 10. An incumbent stops renewing when it is no longer the desired owner. Its existing unexpired lease token remains the active authority until it is compare-deleted or expires.
 11. Assignment change alone must not invalidate a final fenced checkpoint. This desired-versus-active distinction is the cooperative handoff; no separate transfer state machine is required.
-12. Every Valkey key must be constructed through `RedisKeys`. Cluster hash tags define distinct atomicity categories: regional membership, regional canonical assignment, global matchmaking, active-server metrics, and one separate family for each of the ten executor partitions. All keys in one Lua script, transaction, multi-key command, or pipeline batch must share one tag. Executor families must remain distinct so Serverless can distribute authoritative traffic across slots.
+12. Every Valkey key must be constructed through `RedisKeys`. Cluster hash tags define distinct atomicity categories: regional membership, regional canonical assignment, global matchmaking, active-server metrics, and one separate family for each of the fifty executor partitions. All keys in one Lua script, transaction, multi-key command, or pipeline batch must share one tag. Executor families must remain distinct so Serverless can distribute authoritative traffic across slots.
 13. The canonical assignment document lives in the assignment slot. After a successful compare-and-set, the coordinator projects the complete document into each partition slot using a monotonic per-partition view. Lease acquire/renew reads that local view. A crash during projection may delay movement until reconciliation, but must never authorize two generations or roll a view backward.
 
 ### R3 — Fenced partition authority
@@ -271,7 +271,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 12. Recovery backlog processing must use batches of at most 512 while preserving per-partition stream order.
 13. Every delivered executor item must retain its Redis stream ID through dispatch and checkpointing. A malformed/poison entry needs a durable quarantine or terminal disposition before it can be ACKed.
 14. Before a task becomes ready, independently bootstrap exactly one
-    `redis-rs` cluster connection for each of the ten fixed executor partitions.
+    `redis-rs` cluster connection for each of the fifty fixed executor partitions.
     Every latency-sensitive, partition-scoped `GameBus` command, event,
     consumer-group, snapshot-anchor, and fenced mutation must use the
     deterministic lane for that partition. Do not clone one connection across
@@ -282,7 +282,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
     Partition-hot fenced scripts still validate the lease key atomically from
     their partition lane.
 16. Before a task becomes ready, independently bootstrap exactly one
-    recovery-read `redis-rs` cluster connection for each of the ten fixed
+    recovery-read `redis-rs` cluster connection for each of the fifty fixed
     partitions. Takeover journal/envelope loads, stored-snapshot and
     recovery-failure loads, reconnect outcome reads, and completion-record
     loads use the deterministic recovery lane for their partition. Regional
@@ -292,7 +292,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
     exactly one independently bootstrapped checkpoint-write dispatcher per
     task. RESP3 Pub/Sub and stream fan-out readers retain their own dedicated
     connections.
-17. The fixed topology is ten partition-hot lanes, ten partition-scoped
+17. The fixed topology is fifty partition-hot lanes, fifty partition-scoped
     recovery-read lanes, one global control dispatcher, one checkpoint-write
     dispatcher, one metrics dispatcher, and the already separate Pub/Sub and
     stream-reader connections. Do not add a dynamic or per-game pool, a
@@ -616,7 +616,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
    otherwise identical Fargate placements. This preserves headroom for command
    processing and partition recovery while the managed alarm evaluates and a
    replacement task starts.
-2. Retain `minTasks=1` and allow ten tasks in both development and production so the release-blocking `1 -> 10 -> 1` staircase can run outside production. The cap remains aligned with the ten executor partitions. The staircase uses the fixed 128-session / 64-duel one-task-capacity-valid transition cohort; the separate 128-session natural scale-out load and the complete capacity envelope must both be removed before a forced scale-in to one task. The minimum application task is two vCPU and four GiB, the smallest valid Fargate memory pairing for two vCPU; target tracking cannot protect a saturated one-task floor during the managed alarm's observation delay.
+2. Retain `minTasks=1` and allow 25 tasks in both development and production. The release-blocking `1 -> 10 -> 1` staircase still runs outside production, while fifty partitions divide evenly across both its ten-task waypoint and the 25-task autoscaling ceiling. The staircase uses the fixed 128-session / 64-duel one-task-capacity-valid transition cohort; the separate 128-session natural scale-out load and the complete capacity envelope must both be removed before a forced scale-in to one task. The minimum application task is two vCPU and four GiB, the smallest valid Fargate memory pairing for two vCPU; target tracking cannot protect a saturated one-task floor during the managed alarm's observation delay.
 3. The autoscaler must never select zero desired tasks.
 4. Validate forced `1 -> 10 -> 1` with 128 active game sessions / 64 duels
    producing `every-tick` commands on every partition, 10 idle sessions, 10
@@ -640,7 +640,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 5. No custom game-specific autoscaling metric is added in this phase.
 6. Every task currently replicates every partition, so task-local replica memory may not fall on scale-out. Scaling tests must prove memory behavior is acceptable; otherwise the replication model or memory policy needs a separate decision.
 7. Existing WebSockets do not redistribute on scale-up, so service-average CPU can hide a hot gateway task. Record per-task CPU, memory, connections, and event-forwarding load during validation.
-8. Do not increase the partition count or add adaptive splitting without load evidence.
+8. Keep the partition count fixed at fifty; do not increase it again or add adaptive splitting without load evidence.
 9. Load tests must include Serverless Valkey read/write latency, ECPU, bytes, connections, network traffic, `ThrottledCmds`, and `Evictions`, plus the shared regional NAT/Traefik host's CPU, network, connection success, and admission latency/error evidence.
    Connection-tracking occupancy is an optional capacity diagnostic when the
    host exposes it; it is not an autoscaling-correctness or release gate.
@@ -662,7 +662,7 @@ Exact suffixes are implementation details, but the brace-delimited hash-tag fami
 | Task membership | Keys tagged `{snaketron:members:<region>}` | Detect active, warming, draining, and crashed tasks atomically. |
 | Coordinator lease + canonical assignment | Keys tagged `{snaketron:assignment:<region>}` | Elect one writer and persist one explicit versioned owner map. |
 | Per-partition assignment view | Key tagged `{snaketron:exec:<p>}` containing the complete canonical document/version | Let partition lease scripts verify desired ownership without a cross-slot read. |
-| Partition lease, streams, active-game index, recovery and completion records | Keys tagged `{snaketron:exec:<p>}` | Keep every fenced executor transaction single-slot while spreading ten partitions across Serverless slots. |
+| Partition lease, streams, active-game index, recovery and completion records | Keys tagged `{snaketron:exec:<p>}` | Keep every fenced executor transaction single-slot while spreading fifty partitions across Serverless slots. |
 | Matchmaking queues, mappings, active matches, notification channels, and `GameCreated` outbox | Keys/channels tagged `{snaketron:mm}` | Keep admission/cancel/match claims and their in-script notifications in one hash slot. |
 | `GameCreated` delivery marker | Key tagged `{snaketron:exec:<p>}` beside the destination command stream | Make cross-slot outbox delivery idempotent. |
 | Active-server metrics + expiry index | Hash and sorted set tagged `{snaketron:server-metrics}` | Refresh and prune per-task region/user counts atomically without a cluster-wide key scan. |
@@ -789,7 +789,7 @@ Timing is an operational objective, never a substitute for fencing or durability
 The supported staging evidence consists of three independent gates. The
 128-session / 64-duel headroom gate proves natural CPU or memory scale-out.
 After those clients and games are gone, the planned `1 -> 10 -> 1` gate uses
-128 game sessions / 64 duels with `every-tick` commands on all ten partitions,
+128 game sessions / 64 duels with `every-tick` commands on all fifty partitions,
 23 fixed context probes, and bounded open-loop idle admission at four starts
 per second with a 64-session in-flight ceiling and one-second post-ready hold.
 The ten-task capacity gate separately holds at least
@@ -860,8 +860,8 @@ Command-outcome certification accepts report schema 11 or newer only when
 
 | Test | Pass criteria |
 | --- | --- |
-| Scale `1 -> 10` under the 128-session / 64-duel planned-transition load while games receive commands on all ten partitions | The independent 128-session natural scale-out cohort has already exited and the service has returned to a healthy one-task baseline. Exactly nine partitions move between the settled endpoint assignments, owner counts become one each, assignment versions advance monotonically, no active WebSocket hard-reconnect occurs, every full transition second resolves exactly its submitted commands with no terminal outcome taking more than one second from original send, and fingerprints match. The real-browser planned-drain suite and staging protocol evidence jointly prove that no stale overlay occurs. |
-| Scale `10 -> 1` under the same 128-session / 64-duel transition load with 10 idle, 10 lobby, three unmatched matchmaking, and open-loop admission clients | Every partition has active command work before movement. Exactly nine partitions move between the settled endpoint assignments and versions advance monotonically; every observed drain handoff has zero usable-session gap and one command owner; every full transition second resolves exactly its submitted commands with no terminal outcome taking more than one second; no active socket hard-reconnects. The admission probe starts four sessions per second throughout the scale-in window, holds each successful session for one second after it becomes ready, and never exceeds its 64-session in-flight safety ceiling; each reaches a ready backend, with p99 initial WebSocket authentication within ten seconds and no terminal error. The one-task destination remains ready and services lease renewal, membership heartbeat, checkpoint, and event traffic without starvation; no game completion is awaited. |
+| Scale `1 -> 10` under the 128-session / 64-duel planned-transition load while games receive commands on all fifty partitions | The independent 128-session natural scale-out cohort has already exited and the service has returned to a healthy one-task baseline. Exactly 45 partitions move between the settled endpoint assignments, owner counts become five each, assignment versions advance monotonically, no active WebSocket hard-reconnect occurs, every full transition second resolves exactly its submitted commands with no terminal outcome taking more than one second from original send, and fingerprints match. The real-browser planned-drain suite and staging protocol evidence jointly prove that no stale overlay occurs. |
+| Scale `10 -> 1` under the same 128-session / 64-duel transition load with 10 idle, 10 lobby, three unmatched matchmaking, and open-loop admission clients | Every partition has active command work before movement. Exactly 45 partitions move between the settled endpoint assignments and versions advance monotonically; every observed drain handoff has zero usable-session gap and one command owner; every full transition second resolves exactly its submitted commands with no terminal outcome taking more than one second; no active socket hard-reconnects. The admission probe starts four sessions per second throughout the scale-in window, holds each successful session for one second after it becomes ready, and never exceeds its 64-session in-flight safety ceiling; each reaches a ready backend, with p99 initial WebSocket authentication within ten seconds and no terminal error. The one-task destination remains ready and services lease renewal, membership heartbeat, checkpoint, and event traffic without starvation; no game completion is awaited. |
 | Kill after command `XADD`, before group delivery | Successor reads it as new work and applies one logical result. |
 | Kill after delivery into pending, before schedule | `XAUTOCLAIM` recovers it and applies one logical result. |
 | Kill after schedule, before checkpoint | Replay does not lose or double-apply the command. |
@@ -880,7 +880,7 @@ Command-outcome certification accepts report schema 11 or newer only when
 | Crash coordinator during assignment write | Readers observe a complete old or new document; recovery reconciles monotonic versions. |
 | Kill a task that owns both the coordinator lease and partitions | A survivor reacquires coordination, publishes a complete assignment, claims pending commands, and resumes authoritative output inside the crash objective. |
 | SIGKILL one ECS task during the fixed non-production certification load while another task is ready | The task receives no graceful cleanup; its membership and leases expire; a survivor recovers its naturally observed pending backlog and resumes fresh authoritative output within five seconds; affected gateway sessions automatically authenticate, rejoin, and receive a fresh snapshot within ten seconds; commands have one logical outcome; and ECS restores healthy capacity. This is the only distinct external crash action required. |
-| Change eligible membership `1 -> 4 -> 2 -> 10 -> 1` at 500 ms intervals while prior owners remain live | The safe changes coalesce into one version after the final quiet window; all ten partitions then have one matching desired/live owner, owner counts differ by at most one, and no stale assignment overwrites a newer one. Removing or warming a current owner during the pending window preempts it and reconciles immediately. |
+| Change eligible membership `1 -> 4 -> 2 -> 10 -> 1` at 500 ms intervals while prior owners remain live | The safe changes coalesce into one version after the final quiet window; all fifty partitions then have one matching desired/live owner, owner counts differ by at most one, and no stale assignment overwrites a newer one. Removing or warming a current owner during the pending window preempts it and reconciles immediately. |
 | Recover RNG-dependent games, queued commands, and custom slow ticks | Recovery envelope fields restore the same logical fingerprint and wall-clock checkpoint cadence. |
 | Recover with 10,000 unrelated snapshot keys in Valkey | Recovery reads only the indexed games for the acquired partition; unrelated key count does not change the fetched envelope count. |
 | Leave a command pending beyond 8,192 later appends | Safe trimming retains and reclaims the pending command. |
@@ -913,10 +913,10 @@ Command-outcome certification accepts report schema 11 or newer only when
 | Make Valkey unavailable through the deterministic local fault proxy | Readiness drops within seven seconds, liveness remains healthy, and restoration creates no conflicting authority. A remote ElastiCache outage is not a separate release test because availability during that accepted dependency outage is out of scope. |
 | With recovery retention set to 60 seconds, crash the sole task and delay replacement 30 seconds | The documented availability gap occurs, then games recover automatically. |
 | With recovery retention set to 60 seconds, delay sole-task replacement 61 seconds | The game returns the explicit unrecoverable outcome and no fabricated state. |
-| Run the fixed 128-session / 64-duel `every-tick` natural scale-out gate from the two-vCPU minimum task | CPU or memory target tracking produces a successful scale-out above one while the pre-movement baseline and automatic movement window both keep every command outcome within one second, without a task exit, readiness failure, or manual desired-count update. After the added tasks are ready in ECS, Traefik, and the executor control plane, at least 60 complete post-ready seconds satisfy the same command budget and produce scheduled work on all ten partitions. Failure to trigger, insufficient post-ready duration, or a budget violation is a failed certification, not permission to adjust the fixed cohort or weaken the budget. The load then finishes, all of its clients and games reach zero, and none are reused for the forced staircase. |
+| Run the fixed 128-session / 64-duel `every-tick` natural scale-out gate from the two-vCPU minimum task | CPU or memory target tracking produces a successful scale-out above one while the pre-movement baseline and automatic movement window both keep every command outcome within one second, without a task exit, readiness failure, or manual desired-count update. After the added tasks are ready in ECS, Traefik, and the executor control plane, at least 60 complete post-ready seconds satisfy the same command budget and produce scheduled work on all fifty partitions. Failure to trigger, insufficient post-ready duration, or a budget violation is a failed certification, not permission to adjust the fixed cohort or weaken the budget. The load then finishes, all of its clients and games reach zero, and none are reused for the forced staircase. |
 | Ramp at four new sessions per second, then hold 256 authenticated sessions / 128 duels with `every-tick` commands for at least five minutes | The run begins only after ten tasks are healthy in ECS and Traefik and settled in the executor control plane; every full hold second resolves exactly its submitted commands with no terminal outcome taking more than one second; Serverless Valkey reports zero `Evictions` and `ThrottledCmds`, no write failure occurs, and there is no zero-ready interval, ECS health failure, or Traefik health failure. |
 | Exhaust the CPU of a planned scale-in destination until control operations miss their deadlines | The run fails the destination-capacity gate and is not classified as a handoff-protocol defect. No stale or unproven mutation commits: fencing rejects it, the executor fails closed, cooperative drain is not advertised, and ordinary lease-expiry recovery remains authoritative. |
-| Run the complete protocol against actual ElastiCache Serverless Valkey 8 | The AWS cache identity reports major/full engine version 8; TLS certificate validation, RESP3, and cluster discovery through the advertised 6379 primary and 6380 read endpoints succeed, as do operations across every hash-slot family; all ten deterministic partition-hot lanes, all ten independently bootstrapped partition-scoped recovery-read lanes, and the independently bootstrapped control, single per-task checkpoint-write, task-wide maintenance, separate metrics, loss-tolerant Pub/Sub, and stream-reader connections operate under the fixed load without cross-role or cross-partition queue amplification, and no subscription push confirmation is consumed as an ordinary command response; no `CROSSSLOT`, `MOVED` exhaustion, unsupported `KEYS`, or nonzero database error occurs; all Lua/multi-key key-family tests pass. A standalone local Valkey run alone is insufficient evidence. |
+| Run the complete protocol against actual ElastiCache Serverless Valkey 8 | The AWS cache identity reports major/full engine version 8; TLS certificate validation, RESP3, and cluster discovery through the advertised 6379 primary and 6380 read endpoints succeed, as do operations across every hash-slot family; all fifty deterministic partition-hot lanes, all fifty independently bootstrapped partition-scoped recovery-read lanes, and the independently bootstrapped control, single per-task checkpoint-write, task-wide maintenance, separate metrics, loss-tolerant Pub/Sub, and stream-reader connections operate under the fixed load without cross-role or cross-partition queue amplification, and no subscription push confirmation is consumed as an ordinary command response; no `CROSSSLOT`, `MOVED` exhaustion, unsupported `KEYS`, or nonzero database error occurs; all Lua/multi-key key-family tests pass. A standalone local Valkey run alone is insufficient evidence. |
 | Stall one partition's recovery-read lane while reading another partition's recovery envelope | The other partition completes its recovery read within one second, and the metrics dispatcher is independently bootstrapped from every correctness-bearing recovery lane. |
 | Stall the task-wide maintenance lane during live command delivery | Pending-completion scans and trim may pause, but the partition executor continues scheduling and checkpointing commands before maintenance is released; completion retry and trim each retain at most one background worker per partition. |
 | Stall one partition's `GameCreated` destination lane while another partition has a valid durable outbox record | The unstalled partition publishes and compare-deletes its record within one second while the stalled record remains authoritative in the outbox; after release, the stalled partition publishes exactly once and is acknowledged. |
@@ -986,7 +986,7 @@ criteria pass before the production ramp.
 | --- | --- |
 | Assignment module + `redis_keys.rs` | Membership, coordinator, canonical assignment, monotonic partition views, allocator, and explicit Cluster hash-slot families. |
 | `server/src/redis_utils.rs` | One standalone/cluster-aware connection abstraction; TLS and Redis Cluster selection from the deployment URL. |
-| `server/src/game_bus.rs` | Executor consumer-group reader, safe command retention, deterministic routing through ten prewarmed partition-hot lanes and ten independently prewarmed partition-scoped recovery-read lanes, event-only gateway subscriptions, lease-aware single-slot scripts, versioned checkpoint APIs, idempotent outbox delivery, and separately retryable completion cleanup. |
+| `server/src/game_bus.rs` | Executor consumer-group reader, safe command retention, deterministic routing through fifty prewarmed partition-hot lanes and fifty independently prewarmed partition-scoped recovery-read lanes, event-only gateway subscriptions, lease-aware single-slot scripts, versioned checkpoint APIs, idempotent outbox delivery, and separately retryable completion cleanup. |
 | `server/src/game_executor_v2.rs` | Recovery envelope, dedupe, active-game index, backlog-first resume, cooperative checkpoint/release, idempotent finalization. |
 | `server/src/game_server.rs` and `main.rs` | SIGTERM, lifecycle state, readiness state, critical-worker failure policy, one bounded drain deadline. |
 | `server/src/replication.rs` | Event-only resumable partition readers and broadcast-before-eviction handling for atomically durable terminal snapshots. |
@@ -1006,7 +1006,7 @@ criteria pass before the production ramp.
 
 - Crash recovery is the correctness path; SIGTERM is an optimization.
 - Desired assignment is persisted explicitly; internal `hashring` state is not.
-- Fixed ten-partition placement uses the direct balanced/minimal-movement allocator; no hash-ring dependency is required.
+- Fixed fifty-partition placement uses the direct balanced/minimal-movement allocator; no hash-ring dependency is required.
 - Active authority is an exact, unique lease token.
 - Consumer groups are executor-only.
 - The fenced consumer-group executor is the only executor implementation.
@@ -1014,7 +1014,7 @@ criteria pass before the production ramp.
   executor commands or snapshot requests.
 - `CommandScheduledV2` is the positive semantic acknowledgement; `XACK` is still required internally.
 - Checkpoints remain full and per game.
-- Recovery reads use ten fixed partition lanes, resilience metrics use a
+- Recovery reads use fifty fixed partition lanes, resilience metrics use a
   separate dispatcher, and full-state checkpoint/completion writes retain one
   dispatcher per task. No additional pools, correctness-bearing deadline
   increases, or cache layer are part of this release.

--- a/specs/autoscaling-resilience-runbook.md
+++ b/specs/autoscaling-resilience-runbook.md
@@ -71,7 +71,7 @@ checkpoint APIs: it SIGKILLs one incumbent and SIGSTOP/SIGCONTs another after
 each has claimed a durable command, then requires a successor process to take
 the expired lease, reclaim the pending entry, checkpoint and ACK it in under
 five seconds. The successor acquires the production coordinator lease and
-reconciles the complete ten-partition assignment before acquiring the
+reconciles the complete fifty-partition assignment before acquiring the
 partition; only the initial incumbent assignment is seeded by the harness. It
 also checkpoints two live games with a test-configured
 60-second retention, SIGKILLs both incumbents, recovers one through a successor
@@ -116,18 +116,31 @@ aws application-autoscaling register-scalable-target \
   --resource-id service/SNAKETRON_CLUSTER/SNAKETRON_SERVICE \
   --scalable-dimension ecs:service:DesiredCount \
   --min-capacity 1 \
-  --max-capacity 10 \
+  --max-capacity 25 \
   --suspended-state \
 DynamicScalingInSuspended=false,DynamicScalingOutSuspended=false,ScheduledScalingSuspended=false
 ```
 
-Development and production both allow a maximum of ten so the non-production
-service can run the release-blocking `1 -> 10 -> 1` certification staircase.
+Development and production both allow a maximum of 25 while the non-production
+service retains the release-blocking `1 -> 10 -> 1` certification staircase.
 Both retain a minimum of one. The application task uses two vCPU and four GiB
 so the one-task floor has takeover and burst headroom while target tracking is
 still observing load. CPU is targeted at 15%, memory at 80%, and both scale-in
 and scale-out cooldowns are 60 seconds. Development and production use the
 same policy.
+
+### One-time partition-count cutover
+
+The change from ten to fifty partitions changes `game_id % PARTITION_COUNT`
+and therefore the Redis hash-tag family for most existing games. It must not be
+released through the routine overlapping ECS rollout: the executor protocol
+version prevents mixed owners, but it does not move streams, active-game
+indexes, or checkpoints to their new partition keys, and old gateways still
+publish with the old mapping. Before production rollout, choose and certify
+either a maintenance cutover that drains games and fully stops the old task set
+before admitting traffic on the new build, or an explicit live-data migration
+with dual-version routing. Do not treat the protocol-version bump as a data
+migration.
 
 `QueueForMatch` uses the authoritative lobby state as its semantic
 acknowledgement. The browser and certification client retain only the single
@@ -281,7 +294,7 @@ which remains ready and resolves every command inside budget.
 
 Gate B must prove no active-socket hard reconnect, zero measured usable-session
 gap, terminal command outcomes, nonterminal game handoffs with
-command-outcome barriers, and exactly nine partition moves in each direction.
+command-outcome barriers, and exactly 45 partition moves in each direction.
 No game completion is awaited before either desired-count change. Its steady
 population is 128 command-bearing game sockets plus 23 context probes. The
 open-loop admission sessions are bounded transient traffic rather than another
@@ -1103,7 +1116,7 @@ Pub/Sub. Subscription confirmations must never share the reply queue used by
 matchmaking, executor, or recovery commands; this role separation is required
 for Serverless certification.
 
-Before declaring ready, each task independently bootstraps exactly ten
+Before declaring ready, each task independently bootstraps exactly fifty
 partition-hot `redis-rs` cluster connections, one deterministic lane for each
 fixed executor partition. Partition-scoped `GameBus` command publication and
 consumption, ordinary events, snapshot anchors, acknowledgements, and fenced
@@ -1147,7 +1160,7 @@ it cannot hold the partition command reader or amplify one join across every
 game. Partition startup and detected stream-gap repair remain partition-scoped.
 
 The durable `GameCreated` scanner groups each validated scan page by partition
-and uses nonblocking sends to ten delivery workers, one per fixed partition.
+and uses nonblocking sends to fifty delivery workers, one per fixed partition.
 Each lane holds one active and at most one queued batch. Its worker preserves
 publish, compare-delete, and marker-expiry order while continuing through the
 batch after a record-specific error. A full worker leaves the batch's records
@@ -1161,7 +1174,7 @@ Fenced partition-hot scripts execute through their partition lane and validate
 the live lease key atomically there; moving lease liveness traffic onto a busy
 data lane would weaken takeover timing. Full-state periodic checkpoints and
 terminal completion commits keep one independently bootstrapped checkpoint-write
-dispatcher per task. Independently bootstrap exactly ten partition-scoped
+dispatcher per task. Independently bootstrap exactly fifty partition-scoped
 recovery-read connections and route takeover journal/envelope loads,
 stored-snapshot and recovery-failure loads, reconnect outcome reads, and
 immutable completion-record loads by partition. Regional resilience metrics


### PR DESCRIPTION
## Summary

- Increase the fixed executor partition count from 10 to 50.
- Reuse the authoritative partition constant for Redis and load-test routing.
- Bump the executor protocol from v8 to v9 so mixed partition mappings cannot co-own work.
- Align resilience metrics, certification scripts, tests, and specs with the expanded partition set and a 25-task autoscaling ceiling.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p server -p loadtest --all-targets --all-features -- -D warnings`
- `cargo test -p loadtest` (124 tests)
- `cargo test -p server --lib -- --test-threads=1` (279 tests)
- `bash -n run_autoscaling_resilience_tests.sh run_stress_test.sh`
- `./run_autoscaling_resilience_tests.sh --test-evidence-sanitizer`
- `git diff --check`

## Deployment notes

Changing `game_id % 10` to `% 50` relocates roughly 80% of existing games. Protocol v9 prevents mixed executor ownership, but it does not migrate Redis streams, indexes, checkpoints, or old gateway routing. Do not use a routine overlapping ECS rollout. Before production deployment, choose and certify either a maintenance cutover that drains games and fully stops the old task set before new admission, or an explicit live-data migration with dual-version routing.

Companion infrastructure: [snaketron-io #28](https://github.com/lopatin/snaketron-io/pull/28), stacked on snaketron-io #27. Merge this runtime PR first.