### PR TITLE
Prevent auto-ready briefing flash

### DIFF
--- a/client/web/components/GameArena.tsx
+++ b/client/web/components/GameArena.tsx
@@ -1021,9 +1021,22 @@ export default function GameArena() {
   // Local intent, distinct from the server's record of it. A dropped
   // confirmation or a mid-gate resync would otherwise leave a player who
   // already pressed Ready staring at the briefing again.
-  const [readyPressedForGameId, setReadyPressedForGameId] = useState<string | null>(null);
+  const [readyIntent, setReadyIntent] = useState<{
+    gameId: string;
+    source: 'manual' | 'automatic';
+  } | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
-  const hasPressedReady = readyPressedForGameId === gameId;
+  const currentReadyIntent = readyIntent?.gameId === gameId ? readyIntent.source : null;
+  const hasPressedReady = currentReadyIntent !== null;
+  // Read this before the auto-ready effect runs so a returning player never
+  // mounts the briefing for a frame. A manual press records its provenance
+  // before marking the tutorial seen, preserving the intentional waiting view.
+  const shouldAutoReady = currentReadyIntent === 'automatic' || Boolean(
+    currentReadyIntent === null &&
+    isAwaitingReadiness &&
+    tutorial &&
+    hasSeenTutorial(tutorial.key),
+  );
   // Treat the local click as ready immediately instead of briefly counting the
   // player among the people they are now waiting for while the server echoes it.
   const pendingReadyCount = Math.max(
@@ -1034,12 +1047,12 @@ export default function GameArena() {
   );
 
   useEffect(() => {
-    setReadyPressedForGameId((pressed) => (pressed === gameId ? pressed : null));
+    setReadyIntent((intent) => (intent?.gameId === gameId ? intent : null));
     setHelpOpen(false);
   }, [gameId]);
 
-  const confirmReady = useCallback(() => {
-    setReadyPressedForGameId(gameId);
+  const confirmReady = useCallback((source: 'manual' | 'automatic') => {
+    setReadyIntent({ gameId, source });
     if (tutorial) {
       markTutorialSeen(tutorial.key);
     }
@@ -1057,11 +1070,11 @@ export default function GameArena() {
       !tutorial ||
       hasPressedReady ||
       localUserIsReady ||
-      !hasSeenTutorial(tutorial.key)
+      !shouldAutoReady
     ) {
       return;
     }
-    confirmReady();
+    confirmReady('automatic');
   }, [
     confirmReady,
     hasPressedReady,
@@ -1069,6 +1082,7 @@ export default function GameArena() {
     isGameInteractionActive,
     isLocalUserPlaying,
     localUserIsReady,
+    shouldAutoReady,
     tutorial,
   ]);
 
@@ -1102,6 +1116,7 @@ export default function GameArena() {
     isAwaitingReadiness &&
     isLocalUserPlaying &&
     isGameInteractionActive &&
+    !shouldAutoReady &&
     !gameOver,
   );
   // `!localWasIdleKicked` is what the effect below cannot do on its own: state
@@ -1788,7 +1803,7 @@ export default function GameArena() {
           }
           pendingCount={pendingReadyCount}
           isReady={localUserIsReady || hasPressedReady}
-          onReady={confirmReady}
+          onReady={() => confirmReady('manual')}
           onClose={() => setHelpOpen(false)}
         />
       )}

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -891,6 +891,37 @@ test('an identity acquired on an open anonymous socket still gets a handshake de
   ).toEqual([{ code: 4013, reason: 'authentication timed out' }]);
 });
 
+test('a returning player is auto-readied without mounting the briefing', async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'snaketron:tutorial-seen:v1',
+      JSON.stringify({ 'duel:casual': true }),
+    );
+
+    window.__briefingMountCount = 0;
+    const briefingSelector = '[data-testid="tutorial-modal"][data-variant="briefing"]';
+    new MutationObserver((records) => {
+      for (const record of records) {
+        for (const node of record.addedNodes) {
+          if (!(node instanceof Element)) continue;
+          if (node.matches(briefingSelector)) {
+            window.__briefingMountCount += 1;
+          }
+          window.__briefingMountCount += node.querySelectorAll(briefingSelector).length;
+        }
+      }
+    }).observe(document, { childList: true, subtree: true });
+  });
+
+  const initialTutorialFrame = tutorialSnapshot();
+  initialTutorialFrame.GameEvent.event.Snapshot.game_state.readiness.ready_user_ids = [8];
+  const socketIndex = await establishActiveGame(page, initialTutorialFrame);
+
+  await expect.poll(() => socketMessages(page, socketIndex, 'PlayerReady')).toHaveLength(1);
+  await expect(page.getByTestId('tutorial-modal')).toHaveCount(0);
+  expect(await page.evaluate(() => window.__briefingMountCount)).toBe(0);
+});
+
 test('the pre-match guide reveals one animated real-arena step at a time', async ({ page }) => {
   await page.addInitScript(() => {
     window.__tutorialScoreReadouts = [];


### PR DESCRIPTION
## Summary

- avoid mounting the pre-match tutorial when a returning player will be auto-readied
- distinguish automatic readiness from a manual Ready click so first-time players keep the waiting-on-others view
- add a browser regression that detects even transient briefing mounts

## Testing

- `npm run test:unit` — 199 passed
- `npm run type-check`
- `npm run build`
- focused Playwright coverage for auto-ready and manual-ready flows — 2 passed