### PR TITLE
Make player idle kick timing configurable per match

### DIFF
--- a/client/web/tests/unit/idlePresentation.test.ts
+++ b/client/web/tests/unit/idlePresentation.test.ts
@@ -44,6 +44,40 @@ test('idle warning begins at the configured authoritative threshold', () => {
   });
 });
 
+test('server-provided twenty-second policy drives both warning boundaries', () => {
+  const serverConfiguredState = startedState({
+    tick: 99,
+    properties: {
+      tick_duration_ms: 100,
+      player_idle_timeout_ms: 20_000,
+      player_idle_warning_ms: 10_000,
+    },
+  });
+
+  assert.equal(buildPlayerIdlePresentation(serverConfiguredState, 7).warning, null);
+  assert.deepEqual(
+    buildPlayerIdlePresentation({ ...serverConfiguredState, tick: 100 }, 7),
+    {
+      isKicked: false,
+      warning: {
+        deadlineTick: 200,
+        remainingMs: 10_000,
+        remainingSeconds: 10,
+        progress: 1,
+        isUrgent: false,
+      },
+    },
+  );
+  assert.equal(
+    buildPlayerIdlePresentation({ ...serverConfiguredState, tick: 200 }, 7).warning,
+    null,
+  );
+  assert.equal(
+    buildPlayerIdlePresentation({ ...serverConfiguredState, tick: 201 }, 7).warning,
+    null,
+  );
+});
+
 test('idle warning uses simulation ticks, rounds seconds up, and becomes urgent', () => {
   const presentation = buildPlayerIdlePresentation(startedState({ tick: 551 }), 7);
 
@@ -51,6 +85,23 @@ test('idle warning uses simulation ticks, rounds seconds up, and becomes urgent'
   assert.equal(presentation.warning?.remainingSeconds, 5);
   assert.equal(presentation.warning?.progress, 0.49);
   assert.equal(presentation.warning?.isUrgent, true);
+});
+
+test('urgent styling begins halfway through the server-provided warning duration', () => {
+  const state = startedState({
+    tick: 499,
+    properties: {
+      tick_duration_ms: 100,
+      player_idle_timeout_ms: 60_000,
+      player_idle_warning_ms: 20_000,
+    },
+  });
+
+  assert.equal(buildPlayerIdlePresentation(state, 7).warning?.isUrgent, false);
+  assert.equal(
+    buildPlayerIdlePresentation({ ...state, tick: 500 }, 7).warning?.isUrgent,
+    true,
+  );
 });
 
 test('idle deadline rounds up to the first authoritative simulation quantum', () => {

--- a/client/web/utils/idlePresentation.ts
+++ b/client/web/utils/idlePresentation.ts
@@ -159,7 +159,7 @@ export const buildPlayerIdlePresentation = (
       remainingMs,
       remainingSeconds,
       progress,
-      isUrgent: remainingMs <= Math.min(5_000, warningMs / 2),
+      isUrgent: remainingMs <= warningMs / 2,
     },
   };
 };

--- a/common/src/constants.rs
+++ b/common/src/constants.rs
@@ -39,14 +39,14 @@ pub const EXECUTOR_POLL_INTERVAL_MS: u64 = 10;
 /// Default tick duration for custom games in milliseconds
 pub const DEFAULT_CUSTOM_GAME_TICK_MS: u32 = 100;
 
-/// A player who sends no gameplay input for this long is removed from the
-/// match. Keeping this in authoritative simulation time makes the decision
-/// deterministic across executor failover and client prediction.
+/// Compatibility fallback for snapshots that predate the inactivity fields
+/// and games constructed outside server matchmaking. The production server
+/// overwrites it with its resolved, snapshotted policy for every new match.
 pub const DEFAULT_PLAYER_IDLE_TIMEOUT_MS: u32 = 60_000;
 
-/// The local client begins warning a player this long before the authoritative
-/// inactivity deadline. The warning is derived from snapshotted match state,
-/// so it cannot drift away from the server's decision.
+/// Compatibility countdown paired with `DEFAULT_PLAYER_IDLE_TIMEOUT_MS`.
+/// Live clients derive the countdown from the authoritative match snapshot and
+/// never use this value as a UI fallback.
 pub const DEFAULT_PLAYER_IDLE_WARNING_MS: u32 = 10_000;
 
 /// Default available food target

--- a/common/src/game_state.rs
+++ b/common/src/game_state.rs
@@ -5303,7 +5303,7 @@ mod tests {
         // zeroing it would make every snapshot round trip fail admission.
         game.rng = None;
 
-        // Pin the shipped policy as well as the lower-level tick behavior.
+        // Pin the generic/legacy fallback as well as the lower-level behavior.
         assert_eq!(game.properties.player_idle_timeout_ms, 60_000);
         assert_eq!(game.properties.player_idle_warning_ms, 10_000);
         game

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,6 +60,9 @@ services:
       SNAKETRON_ENV: dev
       # New team matches snapshot this once at creation (valid range 1.000-2.000).
       SNAKETRON_BOOST_SPEED_MULTIPLIER: "1.500"
+      # New multiplayer matches warn after 10s idle, then kick after a 10s countdown.
+      SNAKETRON_PLAYER_IDLE_GRACE_MS: "${SNAKETRON_PLAYER_IDLE_GRACE_MS:-10000}"
+      SNAKETRON_PLAYER_IDLE_COUNTDOWN_MS: "${SNAKETRON_PLAYER_IDLE_COUNTDOWN_MS:-10000}"
       # Logging
       RUST_LOG: info,server=debug
       # Replay directory (using volume)

--- a/server/README.md
+++ b/server/README.md
@@ -51,6 +51,13 @@ Required environment variables:
 Optional gameplay balance:
 
 - `SNAKETRON_BOOST_SPEED_MULTIPLIER`: Boosted snake speed for newly created duel and 2v2 matches. Accepts `1.000` through `2.000` with up to three decimal places; defaults to `1.500`. The server validates it at startup and snapshots the resolved value into each match.
+- `SNAKETRON_PLAYER_IDLE_GRACE_MS`: Time without gameplay input before the kick countdown begins. Defaults to `10000`.
+- `SNAKETRON_PLAYER_IDLE_COUNTDOWN_MS`: Length of the visible kick countdown after the idle grace period. Defaults to `10000`.
+
+The server validates both inactivity phases at startup and snapshots their sum
+as the authoritative kick deadline alongside the countdown length. Existing
+matches retain the policy they started with; after a server restart, changed
+values apply to new matches without a client deployment.
 
 Completed game retention:
 

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -17,6 +17,7 @@ use crate::http_server::{DeferredHttpServer, install_http_application};
 use crate::lifecycle::TaskLifecycle;
 use crate::lobby_manager::LobbyManager;
 use crate::matchmaking_manager::MatchmakingManager;
+use crate::player_idle::PlayerIdleConfig;
 use crate::pubsub_manager::PubSubManager;
 use crate::redis_utils::{RedisClient, create_connection_manager_until_available};
 use crate::region_cache::RegionCache;
@@ -194,6 +195,8 @@ pub struct GameServerConfig {
     pub redis_url: String,
     /// Boost rules resolved and validated once at process startup.
     pub boost_config: BoostConfig,
+    /// Inactivity phases resolved once at startup and snapshotted per match.
+    pub player_idle_config: PlayerIdleConfig,
 }
 
 /// A complete game server instance with all components
@@ -259,6 +262,7 @@ impl GameServer {
             replay_dir: _,
             redis_url,
             boost_config,
+            player_idle_config,
         } = config;
 
         boost_config
@@ -447,8 +451,12 @@ impl GameServer {
         lobby_manager.start_lobby_update_forwarder();
 
         // Create the matchmaking manager
-        let matchmaking = MatchmakingManager::new_with_boost_config(redis.clone(), boost_config)
-            .context("Failed to create matchmaking manager")?;
+        let matchmaking = MatchmakingManager::new_with_gameplay_config(
+            redis.clone(),
+            boost_config,
+            player_idle_config,
+        )
+        .context("Failed to create matchmaking manager")?;
         let outbox_matchmaking = matchmaking.clone();
         let matchmaking_manager = Arc::new(tokio::sync::Mutex::new(matchmaking));
 
@@ -958,6 +966,7 @@ pub async fn start_test_server_with_grpc(
         replay_dir,
         redis_url: redis_url.clone(),
         boost_config: BoostConfig::default(),
+        player_idle_config: PlayerIdleConfig::default(),
     };
 
     let game_server = GameServer::start(config).await?;

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -19,6 +19,7 @@ pub mod mmr_persistence;
 mod otel_metrics;
 pub mod partition_assignment;
 pub mod partition_lease;
+pub mod player_idle;
 pub mod pubsub_manager;
 pub mod recovery;
 pub mod redis_keys;

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,6 +4,9 @@ use server::db::{Database, dynamodb::DynamoDatabase};
 use server::game_server::{
     BOOST_SPEED_MULTIPLIER_ENV, GameServer, GameServerConfig, resolve_boost_config,
 };
+use server::player_idle::{
+    PLAYER_IDLE_COUNTDOWN_MS_ENV, PLAYER_IDLE_GRACE_MS_ENV, resolve_player_idle_config,
+};
 use server::ws_server::TestJwtVerifier;
 use std::env;
 use std::sync::Arc;
@@ -117,6 +120,20 @@ async fn main() -> Result<()> {
         "Resolved Boost balance for new duel and 2v2 matches"
     );
 
+    let configured_idle_grace_ms = env::var(PLAYER_IDLE_GRACE_MS_ENV).ok();
+    let configured_idle_countdown_ms = env::var(PLAYER_IDLE_COUNTDOWN_MS_ENV).ok();
+    let player_idle_config = resolve_player_idle_config(
+        configured_idle_grace_ms.as_deref(),
+        configured_idle_countdown_ms.as_deref(),
+    )
+    .context("Invalid player inactivity configuration")?;
+    info!(
+        idle_grace_ms = player_idle_config.idle_grace_ms(),
+        kick_countdown_ms = player_idle_config.kick_countdown_ms(),
+        total_timeout_ms = player_idle_config.total_timeout_ms(),
+        "Resolved inactivity policy for new multiplayer matches"
+    );
+
     // Create server configuration
     let config = GameServerConfig {
         db: db.clone(),
@@ -130,6 +147,7 @@ async fn main() -> Result<()> {
         replay_dir,
         redis_url: redis_url.clone(),
         boost_config,
+        player_idle_config,
     };
 
     let mut game_server = GameServer::start(config).await?;

--- a/server/src/matchmaking.rs
+++ b/server/src/matchmaking.rs
@@ -22,6 +22,7 @@ use crate::matchmaking_manager::{
     MatchmakingManager, QueuedPlayer,
 };
 use crate::matchmaking_pool::MatchmakingPool;
+use crate::player_idle::PlayerIdleConfig;
 
 // --- Configuration Constants ---
 /// Anchors `GameState::start_ms`, which is the match's durable runtime
@@ -1304,6 +1305,7 @@ async fn prepare_game_from_lobbies(
         rng_seed,
         start_ms,
         matchmaking_manager.boost_config(),
+        matchmaking_manager.player_idle_config(),
     )?;
     game_state.is_stress_test = matchmaking_pool == MatchmakingPool::Stress;
 
@@ -1446,8 +1448,9 @@ fn build_match_game_state(
     rng_seed: Option<u64>,
     start_ms: i64,
     boost_config: &BoostConfig,
+    player_idle_config: PlayerIdleConfig,
 ) -> Result<GameState> {
-    if let Some(mut mode_config) = boost_config_for(&game_type, width, height) {
+    let mut state = if let Some(mut mode_config) = boost_config_for(&game_type, width, height) {
         // Startup configuration owns balance. The mode owns its fuel model and
         // layout: FFA uses the canonical field pads while Solo is unlimited
         // and has no pads. Copying only balance fields prevents a team-shaped
@@ -1465,12 +1468,17 @@ fn build_match_game_state(
             rng_seed,
             start_ms,
             mode_config,
-        )
+        )?
     } else {
-        Ok(GameState::new(
-            width, height, game_type, queue_mode, rng_seed, start_ms,
-        ))
-    }
+        GameState::new(width, height, game_type, queue_mode, rng_seed, start_ms)
+    };
+
+    state.properties.player_idle_timeout_ms = player_idle_config.total_timeout_ms();
+    state.properties.player_idle_warning_ms = player_idle_config.kick_countdown_ms();
+    state
+        .validate_boost_invariants()
+        .context("Configured match state failed validation")?;
+    Ok(state)
 }
 
 async fn create_game_from_lobbies(
@@ -1594,6 +1602,7 @@ mod tests {
             speed_milli: 1_750,
             ..BoostConfig::default()
         };
+        let player_idle_config = PlayerIdleConfig::default();
 
         let cases = [
             (60, 40, GameType::TeamMatch { per_team: 1 }, 2, 3, false),
@@ -1611,6 +1620,7 @@ mod tests {
                     Some(7),
                     123,
                     &boost_config,
+                    player_idle_config,
                 )?;
                 for user_id in 1..=player_count {
                     state.add_player(user_id, None)?;
@@ -1646,6 +1656,59 @@ mod tests {
                 state.validate_boost_invariants()?;
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn default_player_idle_policy_warns_at_ten_seconds_and_kicks_at_twenty() -> Result<()> {
+        let state = build_match_game_state(
+            60,
+            40,
+            GameType::TeamMatch { per_team: 1 },
+            QueueMode::Quickmatch,
+            Some(7),
+            123,
+            &BoostConfig::default(),
+            PlayerIdleConfig::default(),
+        )?;
+
+        assert_eq!(state.properties.player_idle_timeout_ms, 20_000);
+        assert_eq!(state.properties.player_idle_warning_ms, 10_000);
+        Ok(())
+    }
+
+    #[test]
+    fn configured_player_idle_policy_is_snapshotted_into_every_match_branch() -> Result<()> {
+        let player_idle_config = PlayerIdleConfig::new(12_345, 6_789)?;
+        let cases = [
+            (60, 40, GameType::TeamMatch { per_team: 1 }),
+            (40, 40, GameType::FreeForAll { max_players: 4 }),
+            (40, 40, GameType::Solo),
+            (
+                40,
+                40,
+                GameType::Custom {
+                    settings: common::CustomGameSettings::default(),
+                },
+            ),
+        ];
+
+        for (width, height, game_type) in cases {
+            let state = build_match_game_state(
+                width,
+                height,
+                game_type,
+                QueueMode::Quickmatch,
+                Some(7),
+                123,
+                &BoostConfig::default(),
+                player_idle_config,
+            )?;
+
+            assert_eq!(state.properties.player_idle_timeout_ms, 19_134);
+            assert_eq!(state.properties.player_idle_warning_ms, 6_789);
+        }
+
         Ok(())
     }
 

--- a/server/src/matchmaking_manager.rs
+++ b/server/src/matchmaking_manager.rs
@@ -1,5 +1,6 @@
 use crate::db::Database;
 use crate::matchmaking_pool::MatchmakingPool;
+use crate::player_idle::PlayerIdleConfig;
 use crate::redis_keys::RedisKeys;
 use crate::redis_utils::RedisConnection;
 use anyhow::{Context, Result, anyhow};
@@ -593,12 +594,13 @@ pub struct MatchmakingManager {
     max_retries: u32,
     retry_delay: Duration,
     boost_config: BoostConfig,
+    player_idle_config: PlayerIdleConfig,
 }
 
 impl MatchmakingManager {
     /// Create a new Redis matchmaking manager
     pub fn new(redis: impl Into<RedisConnection>) -> Result<Self> {
-        Self::new_with_boost_config(redis, BoostConfig::default())
+        Self::new_with_gameplay_config(redis, BoostConfig::default(), PlayerIdleConfig::default())
     }
 
     /// Create a matchmaking manager with the Boost balance resolved at server
@@ -608,6 +610,17 @@ impl MatchmakingManager {
         redis: impl Into<RedisConnection>,
         boost_config: BoostConfig,
     ) -> Result<Self> {
+        Self::new_with_gameplay_config(redis, boost_config, PlayerIdleConfig::default())
+    }
+
+    /// Create a matchmaking manager with every server-owned gameplay policy
+    /// resolved at startup. New matches snapshot these values and active games
+    /// never re-read process configuration.
+    pub fn new_with_gameplay_config(
+        redis: impl Into<RedisConnection>,
+        boost_config: BoostConfig,
+        player_idle_config: PlayerIdleConfig,
+    ) -> Result<Self> {
         boost_config
             .validate()
             .context("Invalid matchmaking Boost configuration")?;
@@ -616,11 +629,16 @@ impl MatchmakingManager {
             max_retries: 3,
             retry_delay: Duration::from_millis(500),
             boost_config,
+            player_idle_config,
         })
     }
 
     pub(crate) fn boost_config(&self) -> &BoostConfig {
         &self.boost_config
+    }
+
+    pub(crate) fn player_idle_config(&self) -> PlayerIdleConfig {
+        self.player_idle_config
     }
 
     /// Add a lobby to the matchmaking queue for multiple game types

--- a/server/src/player_idle.rs
+++ b/server/src/player_idle.rs
@@ -1,0 +1,129 @@
+use anyhow::{Context, Result, bail};
+
+pub const PLAYER_IDLE_GRACE_MS_ENV: &str = "SNAKETRON_PLAYER_IDLE_GRACE_MS";
+pub const PLAYER_IDLE_COUNTDOWN_MS_ENV: &str = "SNAKETRON_PLAYER_IDLE_COUNTDOWN_MS";
+
+const DEFAULT_PLAYER_IDLE_GRACE_MS: u32 = 10_000;
+const DEFAULT_PLAYER_IDLE_COUNTDOWN_MS: u32 = 10_000;
+
+/// Server-owned inactivity policy for newly created multiplayer matches.
+///
+/// The client receives only the resolved total timeout and countdown in the
+/// game snapshot. Keeping the two operator-facing phases here lets either be
+/// changed without rebuilding or redeploying the client.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PlayerIdleConfig {
+    idle_grace_ms: u32,
+    kick_countdown_ms: u32,
+}
+
+impl PlayerIdleConfig {
+    pub fn new(idle_grace_ms: u32, kick_countdown_ms: u32) -> Result<Self> {
+        if idle_grace_ms == 0 {
+            bail!("player idle grace period must be positive");
+        }
+        if kick_countdown_ms == 0 {
+            bail!("player idle kick countdown must be positive");
+        }
+        idle_grace_ms
+            .checked_add(kick_countdown_ms)
+            .context("player idle grace period plus kick countdown exceeds u32 milliseconds")?;
+
+        Ok(Self {
+            idle_grace_ms,
+            kick_countdown_ms,
+        })
+    }
+
+    pub fn idle_grace_ms(self) -> u32 {
+        self.idle_grace_ms
+    }
+
+    pub fn kick_countdown_ms(self) -> u32 {
+        self.kick_countdown_ms
+    }
+
+    pub fn total_timeout_ms(self) -> u32 {
+        // Every instance is created through `new` or the checked constants in
+        // `Default`, so this addition cannot overflow.
+        self.idle_grace_ms + self.kick_countdown_ms
+    }
+}
+
+impl Default for PlayerIdleConfig {
+    fn default() -> Self {
+        Self {
+            idle_grace_ms: DEFAULT_PLAYER_IDLE_GRACE_MS,
+            kick_countdown_ms: DEFAULT_PLAYER_IDLE_COUNTDOWN_MS,
+        }
+    }
+}
+
+/// Resolve optional environment values without reading process-global state,
+/// which keeps startup parsing deterministic and straightforward to test.
+pub fn resolve_player_idle_config(
+    idle_grace_ms: Option<&str>,
+    kick_countdown_ms: Option<&str>,
+) -> Result<PlayerIdleConfig> {
+    fn parse(name: &str, value: Option<&str>, default: u32) -> Result<u32> {
+        match value {
+            Some(value) => value
+                .trim()
+                .parse::<u32>()
+                .with_context(|| format!("{name} must be a positive number of milliseconds")),
+            None => Ok(default),
+        }
+    }
+
+    PlayerIdleConfig::new(
+        parse(
+            PLAYER_IDLE_GRACE_MS_ENV,
+            idle_grace_ms,
+            DEFAULT_PLAYER_IDLE_GRACE_MS,
+        )?,
+        parse(
+            PLAYER_IDLE_COUNTDOWN_MS_ENV,
+            kick_countdown_ms,
+            DEFAULT_PLAYER_IDLE_COUNTDOWN_MS,
+        )?,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_to_ten_seconds_idle_then_a_ten_second_countdown() {
+        let config = resolve_player_idle_config(None, None).unwrap();
+
+        assert_eq!(config.idle_grace_ms(), 10_000);
+        assert_eq!(config.kick_countdown_ms(), 10_000);
+        assert_eq!(config.total_timeout_ms(), 20_000);
+    }
+
+    #[test]
+    fn independently_configures_both_inactivity_phases() {
+        let config = resolve_player_idle_config(Some(" 12345 "), Some("6789")).unwrap();
+
+        assert_eq!(config.idle_grace_ms(), 12_345);
+        assert_eq!(config.kick_countdown_ms(), 6_789);
+        assert_eq!(config.total_timeout_ms(), 19_134);
+    }
+
+    #[test]
+    fn rejects_invalid_inactivity_configuration() {
+        for (grace, countdown) in [
+            (Some("0"), None),
+            (None, Some("0")),
+            (Some("ten"), None),
+            (None, Some("10.5")),
+            (Some("4294967295"), Some("1")),
+        ] {
+            assert!(
+                resolve_player_idle_config(grace, countdown).is_err(),
+                "accepted grace={grace:?}, countdown={countdown:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add server-side environment configuration for idle grace and kick countdown durations
- Validate inactivity settings at startup and snapshot the resolved policy into new matches
- Update client urgency calculations to use the configured warning duration
- Document defaults and match policy behavior
- Add coverage for configuration parsing, matchmaking snapshots, and idle presentation boundaries

## Testing

- Added Rust unit tests for configuration validation and match snapshotting
- Added client unit tests for configurable warning and urgency timing