### PR TITLE
Fix mobile Hold Boost recovery and pointer release handling

### DIFF
--- a/client/web/components/GameArena.css
+++ b/client/web/components/GameArena.css
@@ -101,6 +101,14 @@
   cursor: default;
 }
 
+/* Keep the button itself as the pointer-capture target. In particular, WebKit
+   can emit a transient lostpointercapture when implicit touch capture starts on
+   a nested SVG and explicit capture then moves to its parent button. */
+.game-boost-meter *,
+.touch-boost * {
+  pointer-events: none;
+}
+
 .game-boost-meter__canister {
   display: block;
   width: 38px;

--- a/client/web/components/GameArena.tsx
+++ b/client/web/components/GameArena.tsx
@@ -81,6 +81,97 @@ function useBoostPointerBinding(
   sendBoostDecision: (decision: BoostInputDecision) => void,
 ) {
   const pointerIdRef = useRef<number | null>(null);
+  const pointerTargetRef = useRef<HTMLButtonElement | null>(null);
+  const sendBoostDecisionRef = useRef(sendBoostDecision);
+  sendBoostDecisionRef.current = sendBoostDecision;
+
+  const finishPointer = useCallback((
+    pointerId: number,
+    preventDefault?: () => void,
+  ) => {
+    if (pointerIdRef.current !== pointerId) {
+      return;
+    }
+    pointerIdRef.current = null;
+
+    const pointerTarget = pointerTargetRef.current;
+    pointerTargetRef.current = null;
+    const controller = controllerRef.current;
+    if (!controller) {
+      return;
+    }
+
+    const decision = controller.handlePointerUp(pointerId, contextRef.current);
+    if (decision.preventDefault) {
+      preventDefault?.();
+    }
+    try {
+      if (pointerTarget?.hasPointerCapture(pointerId)) {
+        pointerTarget.releasePointerCapture(pointerId);
+      }
+    } catch {
+      // The browser may already have released capture during cancellation.
+    }
+    sendBoostDecisionRef.current(decision);
+  }, [contextRef, controllerRef]);
+
+  // Pointer capture is the fast path, but older embedded browsers can reject
+  // it and mobile lifecycle changes can retarget the final event. Observe the
+  // release at the window as a fallback so leaving or disabling the button
+  // cannot strand its Hold edge.
+  const finishPointerRef = useRef(finishPointer);
+  finishPointerRef.current = finishPointer;
+  useEffect(() => {
+    const finishGlobalPointer = (event: PointerEvent) => {
+      finishPointerRef.current(event.pointerId, () => {
+        if (event.cancelable) {
+          event.preventDefault();
+        }
+      });
+    };
+    const handleGlobalLostPointerCapture = (event: PointerEvent) => {
+      if (pointerIdRef.current !== event.pointerId) {
+        return;
+      }
+
+      const pointerTarget = pointerTargetRef.current;
+      try {
+        // WebKit can deliver an older lost-capture event after capture has
+        // already moved to the button. Do not let that stale event release a
+        // newer live hold that reused the same pointer id.
+        if (pointerTarget?.hasPointerCapture(event.pointerId)) {
+          return;
+        }
+      } catch {
+        // Without capture introspection, target identity is the safe fallback.
+      }
+      if (event.target !== pointerTarget && event.target !== document) {
+        return;
+      }
+      finishGlobalPointer(event);
+    };
+
+    window.addEventListener('pointerup', finishGlobalPointer, true);
+    window.addEventListener('pointercancel', finishGlobalPointer, true);
+    window.addEventListener('lostpointercapture', handleGlobalLostPointerCapture, true);
+    return () => {
+      window.removeEventListener('pointerup', finishGlobalPointer, true);
+      window.removeEventListener('pointercancel', finishGlobalPointer, true);
+      window.removeEventListener('lostpointercapture', handleGlobalLostPointerCapture, true);
+
+      const pointerId = pointerIdRef.current;
+      const pointerTarget = pointerTargetRef.current;
+      pointerIdRef.current = null;
+      pointerTargetRef.current = null;
+      try {
+        if (pointerId !== null && pointerTarget?.hasPointerCapture(pointerId)) {
+          pointerTarget.releasePointerCapture(pointerId);
+        }
+      } catch {
+        // Arena teardown has already cleared the controller's physical holds.
+      }
+    };
+  }, []);
 
   const onPointerDown = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
     const controller = controllerRef.current;
@@ -88,15 +179,20 @@ function useBoostPointerBinding(
       return;
     }
 
-    // One hold per button: a second finger landing on the same button must
-    // not claim the capture (its release would then be unmatchable) or
-    // inflate the controller's hold count past what this button can release.
-    if (pointerIdRef.current !== null) {
-      event.preventDefault();
-      return;
+    const heldPointerId = pointerIdRef.current;
+    if (heldPointerId !== null) {
+      // One live hold per button. If a controller-level safety reset already
+      // cleared this id, however, the DOM cache is stale and must not poison
+      // every later Hold press on this button.
+      if (controller.isPointerHeld(heldPointerId)) {
+        event.preventDefault();
+        return;
+      }
+      pointerIdRef.current = null;
+      pointerTargetRef.current = null;
     }
 
-    const decision = controller.handlePointerDown(contextRef.current);
+    const decision = controller.handlePointerDown(event.pointerId, contextRef.current);
     if (decision.preventDefault) {
       event.preventDefault();
     }
@@ -105,38 +201,19 @@ function useBoostPointerBinding(
     // is a physical fact the controller has already recorded, and skipping this
     // would drop the matching release and leave the hold latched on forever.
     pointerIdRef.current = event.pointerId;
+    pointerTargetRef.current = event.currentTarget;
     try {
       event.currentTarget.setPointerCapture(event.pointerId);
     } catch {
       // Synthetic and older embedded browsers may not expose pointer capture;
       // pointerup/cancel still delivers the matching release in the common path.
     }
-    sendBoostDecision(decision);
-  }, [contextRef, controllerRef, sendBoostDecision]);
+    sendBoostDecisionRef.current(decision);
+  }, [contextRef, controllerRef]);
 
   const onPointerRelease = useCallback((event: React.PointerEvent<HTMLButtonElement>) => {
-    if (pointerIdRef.current !== event.pointerId) {
-      return;
-    }
-    pointerIdRef.current = null;
-
-    const controller = controllerRef.current;
-    if (!controller) {
-      return;
-    }
-    const decision = controller.handlePointerUp(contextRef.current);
-    if (decision.preventDefault) {
-      event.preventDefault();
-    }
-    try {
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
-        event.currentTarget.releasePointerCapture(event.pointerId);
-      }
-    } catch {
-      // The browser may already have released capture during cancellation.
-    }
-    sendBoostDecision(decision);
-  }, [contextRef, controllerRef, sendBoostDecision]);
+    finishPointer(event.pointerId, () => event.preventDefault());
+  }, [finishPointer]);
 
   return { onPointerDown, onPointerRelease };
 }
@@ -301,8 +378,8 @@ export default function GameArena() {
     if (!controller) {
       return;
     }
-    // Per-button pointer ids need no reset here: a release arriving after
-    // teardown finds physicalPointerDown already false and is ignored.
+    // Clearing controller-owned pointer ids also lets every retained DOM
+    // binding recognize and replace a stale cached id on its next press.
     const decision = controller.teardown(boostInputContextRef.current);
     if (decision.command) {
       sendBoostCommandRef.current(decision.command);

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -1498,6 +1498,82 @@ test('Boost HUD touch control starts and stops the local snake Boost', async ({ 
   ]);
 });
 
+test('mobile Hold recovers after a swallowed release and releases outside the button', async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await page.addInitScript(() => {
+    sessionStorage.setItem('snaketron:forced-input-surface', 'touch');
+  });
+  const socketIndex = await establishActiveGame(page);
+  await emitServerMessage(page, socketIndex, boostSnapshot(11, 6));
+
+  const logicalBoostCommands = async () => {
+    const deliveries = await socketMessages(page, socketIndex, 'GameCommandV2');
+    return [...new Map(deliveries.map((message) => {
+      const envelope = message.GameCommandV2;
+      return [envelope.command_id.sequence, envelope.command.command];
+    })).values()];
+  };
+  const boostButton = page.getByTestId('touch-boost-button');
+  await expect(boostButton).toBeVisible();
+  await expect(boostButton).toBeEnabled();
+
+  await boostButton.dispatchEvent('pointerdown', {
+    pointerId: 11,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    buttons: 1,
+    bubbles: true,
+    cancelable: true,
+  });
+  await expect.poll(logicalBoostCommands).toEqual([
+    { ActivateBoost: { snake_id: 0 } },
+  ]);
+
+  // Mobile can background the page without delivering this button's pointerup.
+  await page.evaluate(() => window.dispatchEvent(new Event('blur')));
+  await expect.poll(logicalBoostCommands).toEqual([
+    { ActivateBoost: { snake_id: 0 } },
+    { DeactivateBoost: { snake_id: 0 } },
+  ]);
+
+  // The stale pointer id from the interrupted gesture must not poison Hold.
+  await boostButton.dispatchEvent('pointerdown', {
+    pointerId: 12,
+    pointerType: 'touch',
+    isPrimary: true,
+    button: 0,
+    buttons: 1,
+    bubbles: true,
+    cancelable: true,
+  });
+  await expect.poll(logicalBoostCommands).toEqual([
+    { ActivateBoost: { snake_id: 0 } },
+    { DeactivateBoost: { snake_id: 0 } },
+    { ActivateBoost: { snake_id: 0 } },
+  ]);
+
+  // Capture may be unavailable in an embed; a window-level release is the
+  // fallback when the finger ends outside the physical button.
+  await page.evaluate(() => {
+    window.dispatchEvent(new PointerEvent('pointerup', {
+      pointerId: 12,
+      pointerType: 'touch',
+      isPrimary: true,
+      button: 0,
+      buttons: 0,
+      bubbles: true,
+      cancelable: true,
+    }));
+  });
+  await expect.poll(logicalBoostCommands).toEqual([
+    { ActivateBoost: { snake_id: 0 } },
+    { DeactivateBoost: { snake_id: 0 } },
+    { ActivateBoost: { snake_id: 0 } },
+    { DeactivateBoost: { snake_id: 0 } },
+  ]);
+});
+
 test('the focused Hold Boost control starts and stops on one Space hold', async ({ page }) => {
   const socketIndex = await establishActiveGame(page);
   await emitServerMessage(page, socketIndex, boostSnapshot(11, 6));

--- a/client/web/tests/unit/boostInput.test.ts
+++ b/client/web/tests/unit/boostInput.test.ts
@@ -343,16 +343,16 @@ test('a rejected Boost edge is not resent until the player supplies a new edge',
 test('Hold pointer edges start and stop Boost while its synthesized click is inert', () => {
   const controller = new BoostInputController('hold');
 
-  assert.deepEqual(controller.handlePointerDown(context()), {
+  assert.deepEqual(controller.handlePointerDown(11, context()), {
     preventDefault: true,
     command: 'ActivateBoost',
   });
   assert.equal(controller.handleButtonPress(context({ intent: true, active: true })).command, null);
-  assert.deepEqual(controller.handlePointerUp(context({ intent: true, active: true })), {
+  assert.deepEqual(controller.handlePointerUp(11, context({ intent: true, active: true })), {
     preventDefault: true,
     command: 'DeactivateBoost',
   });
-  assert.equal(controller.handlePointerUp(context()).command, null);
+  assert.equal(controller.handlePointerUp(11, context()).command, null);
 });
 
 // Touch surfaces render two physical Boost buttons (the arena meter and the
@@ -361,22 +361,22 @@ test('Hold pointer edges start and stop Boost while its synthesized click is ine
 test('a second button joining a Hold keeps Boost until the last release', () => {
   const controller = new BoostInputController('hold');
 
-  assert.equal(controller.handlePointerDown(context()).command, 'ActivateBoost');
+  assert.equal(controller.handlePointerDown(11, context()).command, 'ActivateBoost');
   assert.equal(
-    controller.handlePointerDown(context({ intent: true, active: true })).command,
+    controller.handlePointerDown(12, context({ intent: true, active: true })).command,
     null,
     'a second button joining the hold publishes nothing new',
   );
   assert.equal(
-    controller.handlePointerUp(context({ intent: true, active: true })).command,
+    controller.handlePointerUp(11, context({ intent: true, active: true })).command,
     null,
     'the first release must not end a hold another button still expresses',
   );
-  assert.deepEqual(controller.handlePointerUp(context({ intent: true, active: true })), {
+  assert.deepEqual(controller.handlePointerUp(12, context({ intent: true, active: true })), {
     preventDefault: true,
     command: 'DeactivateBoost',
   });
-  assert.equal(controller.handlePointerUp(context()).command, null);
+  assert.equal(controller.handlePointerUp(12, context()).command, null);
 });
 
 // The pointer equivalent of the disconnect case: the press is recorded even
@@ -384,7 +384,7 @@ test('a second button joining a Hold keeps Boost until the last release', () => 
 test('a pointer hold started while disconnected still releases cleanly', () => {
   const controller = new BoostInputController('hold');
 
-  assert.deepEqual(controller.handlePointerDown(context({ interactionActive: false })), {
+  assert.deepEqual(controller.handlePointerDown(11, context({ interactionActive: false })), {
     preventDefault: true,
     command: null,
   });
@@ -393,7 +393,32 @@ test('a pointer hold started while disconnected still releases cleanly', () => {
     'ActivateBoost',
   );
   assert.equal(
-    controller.handlePointerUp(context({ intent: true, active: true })).command,
+    controller.handlePointerUp(11, context({ intent: true, active: true })).command,
+    'DeactivateBoost',
+  );
+});
+
+// Mobile can hide the page or disable a button without delivering that
+// button's release. The binding uses controller ownership to distinguish a
+// live pointer from its stale cached id when play resumes.
+test('a safety release invalidates stale pointer ownership for the next Hold', () => {
+  const controller = new BoostInputController('hold');
+
+  assert.equal(controller.handlePointerDown(11, context()).command, 'ActivateBoost');
+  assert.equal(controller.isPointerHeld(11), true);
+  assert.equal(
+    controller.releaseHeld(context({ intent: true, active: true })).command,
+    'DeactivateBoost',
+  );
+  assert.equal(controller.isPointerHeld(11), false);
+
+  assert.equal(
+    controller.handlePointerDown(12, context({ intent: false, active: false })).command,
+    'ActivateBoost',
+  );
+  assert.equal(controller.isPointerHeld(12), true);
+  assert.equal(
+    controller.handlePointerUp(12, context({ intent: true, active: true })).command,
     'DeactivateBoost',
   );
 });
@@ -401,8 +426,8 @@ test('a pointer hold started while disconnected still releases cleanly', () => {
 test('Toggle pointer edges are inert and click changes the durable level', () => {
   const controller = new BoostInputController('toggle');
 
-  assert.equal(controller.handlePointerDown(context()).command, null);
-  assert.equal(controller.handlePointerUp(context()).command, null);
+  assert.equal(controller.handlePointerDown(11, context()).command, null);
+  assert.equal(controller.handlePointerUp(11, context()).command, null);
   assert.equal(controller.handleButtonPress(context()).command, 'ActivateBoost');
   assert.equal(
     controller.handleButtonPress(context({ intent: true, active: true })).command,
@@ -444,7 +469,7 @@ test('explicit teardown stops a latched Boost exactly once', () => {
   );
 
   const pending = new BoostInputController('hold');
-  pending.handlePointerDown(context());
+  pending.handlePointerDown(11, context());
   assert.equal(
     pending.teardown(context({ intent: true, interactionActive: false })).command,
     'DeactivateBoost',
@@ -452,8 +477,8 @@ test('explicit teardown stops a latched Boost exactly once', () => {
   );
 
   const deferredRelease = new BoostInputController('hold');
-  deferredRelease.handlePointerDown(context());
-  deferredRelease.handlePointerUp(context({ intent: true, interactionActive: false }));
+  deferredRelease.handlePointerDown(11, context());
+  deferredRelease.handlePointerUp(11, context({ intent: true, interactionActive: false }));
   assert.equal(
     deferredRelease.teardown(context({ intent: true, interactionActive: false })).command,
     'DeactivateBoost',

--- a/client/web/utils/boostInput.ts
+++ b/client/web/utils/boostInput.ts
@@ -248,14 +248,13 @@ export class BoostInputController {
   private mode: BoostInputMode;
   private physicalSpaceDown = false;
   /**
-   * Count, not boolean: the arena meter button and the mobile NOS button are
-   * both live on touch surfaces, and a level derived from "any pointer is
-   * down" must end on the LAST release, not the first. Each button's binding
-   * guarantees exactly one down/release pair per gesture (pointer capture +
-   * per-button pointer-id guard), so the count cannot drift under normal
-   * delivery; the blur/visibility/unmount safety nets zero it outright.
+   * Pointer identities, rather than a count, keep the controller and each DOM
+   * binding on one source of truth. Mobile browsers can omit a button-level
+   * release when the page blurs, the control is disabled, or pointer capture
+   * is unavailable. Safety resets clear this set; a binding can then recognize
+   * that its cached pointer id is stale and accept the next physical press.
    */
-  private physicalPointerHolds = 0;
+  private physicalPointerHolds = new Set<number>();
   /** Toggle mode's durable latch. Hold mode derives its level from the edges. */
   private toggleLatched = false;
   /** The level already published and not yet echoed back by the engine. */
@@ -277,10 +276,15 @@ export class BoostInputController {
     return this.physicalSpaceDown;
   }
 
+  /** Whether a DOM binding's cached pointer still owns a live Hold edge. */
+  isPointerHeld(pointerId: number): boolean {
+    return this.physicalPointerHolds.has(pointerId);
+  }
+
   /** The one definition of what the player is currently asking for. */
   private desiredLevel(): boolean {
     return this.mode === 'hold'
-      ? this.physicalSpaceDown || this.physicalPointerHolds > 0
+      ? this.physicalSpaceDown || this.physicalPointerHolds.size > 0
       : this.toggleLatched;
   }
 
@@ -419,26 +423,35 @@ export class BoostInputController {
     return this.decide(context, false);
   }
 
-  handlePointerDown(context: BoostInputContext): BoostInputDecision {
+  handlePointerDown(
+    pointerId: number,
+    context: BoostInputContext,
+  ): BoostInputDecision {
     if (this.mode !== 'hold' || context.gameOver) {
       return IGNORE_DECISION;
+    }
+
+    if (this.physicalPointerHolds.has(pointerId)) {
+      return SUPPRESS_DECISION;
     }
 
     this.reconciliationSuppressed = false;
     // A second button's press while another is held records a real physical
     // fact; sync() publishes nothing because the level is already true, and
     // the hold now ends only when the LAST button is released.
-    this.physicalPointerHolds += 1;
+    this.physicalPointerHolds.add(pointerId);
     return this.decide(context, true);
   }
 
-  handlePointerUp(context: BoostInputContext): BoostInputDecision {
-    if (this.mode !== 'hold' || this.physicalPointerHolds === 0) {
+  handlePointerUp(
+    pointerId: number,
+    context: BoostInputContext,
+  ): BoostInputDecision {
+    if (this.mode !== 'hold' || !this.physicalPointerHolds.delete(pointerId)) {
       return IGNORE_DECISION;
     }
 
     this.reconciliationSuppressed = false;
-    this.physicalPointerHolds -= 1;
     return this.decide(context, true);
   }
 
@@ -451,7 +464,7 @@ export class BoostInputController {
   releaseHeld(context: BoostInputContext): BoostInputDecision {
     this.reconciliationSuppressed = false;
     this.physicalSpaceDown = false;
-    this.physicalPointerHolds = 0;
+    this.physicalPointerHolds.clear();
     return this.decide(context, false);
   }
 
@@ -459,7 +472,7 @@ export class BoostInputController {
   cleanup(context: BoostInputContext): BoostInputDecision {
     this.reconciliationSuppressed = false;
     this.physicalSpaceDown = false;
-    this.physicalPointerHolds = 0;
+    this.physicalPointerHolds.clear();
     this.toggleLatched = false;
     return this.decide(context, false);
   }
@@ -474,7 +487,7 @@ export class BoostInputController {
   teardown(context: BoostInputContext): BoostInputDecision {
     this.reconciliationSuppressed = false;
     this.physicalSpaceDown = false;
-    this.physicalPointerHolds = 0;
+    this.physicalPointerHolds.clear();
     this.toggleLatched = false;
     return this.decide(context, false, true);
   }
@@ -498,7 +511,7 @@ export class BoostInputController {
    */
   handleRejectedCommand(command: BoostInputCommand): void {
     this.physicalSpaceDown = false;
-    this.physicalPointerHolds = 0;
+    this.physicalPointerHolds.clear();
     this.toggleLatched = command === 'DeactivateBoost';
     this.pendingLevel = null;
     this.reconciliationSuppressed = true;
@@ -517,7 +530,7 @@ export class BoostInputController {
   /** Drop all local state, e.g. when the arena switches to a different game. */
   reset(): void {
     this.physicalSpaceDown = false;
-    this.physicalPointerHolds = 0;
+    this.physicalPointerHolds.clear();
     this.toggleLatched = false;
     this.pendingLevel = null;
     this.interactionWasActive = false;


### PR DESCRIPTION
## Summary
- Track Hold pointers by ID to recover from swallowed mobile releases
- Add window-level pointer release fallbacks and guard against stale capture events
- Keep nested boost control graphics from stealing pointer capture
- Add unit and Playwright coverage for interrupted and outside-button releases

## Testing
- Not run (not requested)