### PR TITLE
Hide ranking panels for quickmatch results

### DIFF
--- a/client/web/components/RatingRevealQA.tsx
+++ b/client/web/components/RatingRevealQA.tsx
@@ -110,19 +110,11 @@ const SCENARIOS: Array<{ id: string; label: string; state: MatchRatingState | nu
   },
   {
     id: 'quickmatch',
-    label: 'Quickmatch · casual',
-    state: {
-      phase: 'ready',
-      reveal: buildRatingReveal(
-        'Quickmatch',
-        '2v2',
-        snapshot(1190, 3, 1, null),
-        snapshot(1240, 4, 1, null),
-      ),
-    },
+    label: 'Quickmatch · no rating',
+    state: null,
   },
   { id: 'pending', label: 'Pending · tallying', state: { phase: 'pending' } },
-  // Solo and custom matches have no ladder: the card renders without a band.
+  // Quickmatch, solo, and custom matches render the card without a rating band.
   { id: 'none', label: 'No rating (solo/custom)', state: null },
 ];
 

--- a/client/web/hooks/useMatchRating.ts
+++ b/client/web/hooks/useMatchRating.ts
@@ -4,8 +4,8 @@ import { api } from '../services/api';
 import { loadRegionPreference } from '../utils/regionPreference';
 import {
   buildRatingReveal,
+  postMatchRatingGameTypeParam,
   queueModeParam,
-  ratedGameTypeParam,
   ratingHasSettled,
   snapshotFromResponse,
   RATING_POLL_INTERVAL_MS,
@@ -15,7 +15,7 @@ import {
 } from '../utils/ratingReveal';
 
 /**
- * Drives the post-match rating reveal for one game.
+ * Drives the competitive post-match rating reveal for one game.
  *
  * A baseline ranking snapshot is fetched while the match is still running;
  * after completion the endpoint is polled until the persisted MMR write
@@ -31,8 +31,11 @@ export const useMatchRating = (
 ): MatchRatingState => {
   const [state, setState] = useState<MatchRatingState>({ phase: 'idle' });
 
-  const gameTypeParam = ratedGameTypeParam(gameState?.game_type);
   const queueMode = gameState?.queue_mode ?? null;
+  const gameTypeParam = postMatchRatingGameTypeParam(
+    queueMode ?? undefined,
+    gameState?.game_type,
+  );
   const eligible = gameTypeParam !== null && queueMode !== null && userId !== undefined;
 
   // Baseline for the current gameId. `undefined` = not fetched yet;

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -614,6 +614,17 @@ test.beforeEach(async ({ page }) => {
         payload = { 'test-region': 1 };
       } else if (url === 'http://snaketron.test/api/health') {
         payload = { status: 'ok' };
+      } else if (url.includes('/api/leaderboard/me?') && window.__ratingFixture) {
+        const fixture = window.__ratingFixture;
+        fixture.requests.push(url);
+        if (fixture.requests.length === 1) {
+          payload = fixture.before;
+        } else {
+          while (!fixture.release) {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+          }
+          payload = fixture.after;
+        }
       } else {
         throw new Error(`Unexpected fetch in planned-drain test: ${url} (${init?.method || 'GET'})`);
       }
@@ -1958,6 +1969,54 @@ test('Boost fuel instrument keeps the Snaketron hierarchy across charge states',
   }
 });
 
+test('competitive results settle on the persisted regional ranking and remain visible', async ({ page }) => {
+  await page.addInitScript(() => {
+    window.__ratingFixture = {
+      before: { rank: 18, mmr: 1000, wins: 4, losses: 2, winRate: 66.7 },
+      after: { rank: 14, mmr: 1025, wins: 5, losses: 2, winRate: 71.4 },
+      requests: [],
+      release: false,
+    };
+  });
+
+  const liveFrame = completedBoostSnapshot(10, 1200);
+  const liveState = liveFrame.GameEvent.event.Snapshot.game_state;
+  liveState.status = { Started: { server_id: 1 } };
+  liveState.queue_mode = 'Competitive';
+  liveState.properties.score_limit = 50;
+  const socketIndex = await establishActiveGame(page, liveFrame);
+
+  await expect.poll(() => page.evaluate(() => window.__ratingFixture.requests.length)).toBe(1);
+  const [baselineUrl] = await page.evaluate(() => window.__ratingFixture.requests);
+  const baselineParams = new URL(baselineUrl).searchParams;
+  expect(Object.fromEntries(baselineParams)).toEqual({
+    queue_mode: 'competitive',
+    game_type: 'duel',
+    region: 'test-region',
+  });
+
+  const finalFrame = completedBoostSnapshot(11, 1201);
+  const finalState = finalFrame.GameEvent.event.Snapshot.game_state;
+  finalState.start_ms = liveState.start_ms;
+  finalState.queue_mode = 'Competitive';
+  finalState.properties.score_limit = 50;
+  await emitServerMessage(page, socketIndex, finalFrame);
+
+  const scoreCard = page.getByTestId('game-over-card');
+  const rating = scoreCard.getByTestId('rating-reveal');
+  await expect(scoreCard).toBeVisible();
+  await expect(rating).toHaveAttribute('data-phase', 'pending');
+  await expect.poll(() => page.evaluate(() => window.__ratingFixture.requests.length)).toBe(2);
+
+  await page.evaluate(() => {
+    window.__ratingFixture.release = true;
+  });
+  await expect(rating).toHaveAttribute('data-phase', 'settled');
+  await expect(rating.getByTestId('rating-reveal-value')).toHaveText('1025');
+  await expect(rating.getByTestId('rating-reveal-delta')).toHaveText('+25');
+  await expect(rating).toBeVisible();
+});
+
 test('Snaketron game shell restores the original scoreboard language and free-floating roster', async ({ page }) => {
   await page.setViewportSize({ width: 1280, height: 1200 });
   const liveFrame = completedBoostSnapshot(10, 1200);
@@ -2290,6 +2349,12 @@ test('Snaketron game shell restores the original scoreboard language and free-fl
   await emitServerMessage(page, socketIndex, finalFrame);
   const scoreCard = page.getByTestId('game-over-card');
   await expect(scoreCard).toBeVisible();
+  // Let completion effects flush: a Quickmatch result must never mount the
+  // competitive rating placeholder while its score card is open.
+  await page.evaluate(() => new Promise((resolve) => {
+    requestAnimationFrame(() => requestAnimationFrame(resolve));
+  }));
+  expect(await scoreCard.getByTestId('rating-reveal').count()).toBe(0);
   await expect(page.getByTestId('game-roster-band').getByRole('button')).toHaveCount(2);
   await expect(page.getByTestId('game-roster-band')
     .getByRole('button', { name: 'Score card' })).toHaveAttribute('aria-expanded', 'true');

--- a/client/web/tests/unit/ratingReveal.test.ts
+++ b/client/web/tests/unit/ratingReveal.test.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildRatingReveal,
   countDurationMs,
+  postMatchRatingGameTypeParam,
   queueModeParam,
   ratedGameTypeParam,
   ratingHasSettled,
@@ -90,6 +91,20 @@ test('only ladder game types map to a ranking query parameter', () => {
 
   assert.equal(queueModeParam('Competitive'), 'competitive');
   assert.equal(queueModeParam('Quickmatch'), 'quickmatch');
+});
+
+test('post-match rating progress is limited to competitive ladder matches', () => {
+  const duel: GameType = { TeamMatch: { per_team: 1 } };
+  const twoVTwo: GameType = { TeamMatch: { per_team: 2 } };
+  const ffa: GameType = { FreeForAll: { max_players: 8 } };
+
+  assert.equal(postMatchRatingGameTypeParam('Competitive', duel), 'duel');
+  assert.equal(postMatchRatingGameTypeParam('Competitive', twoVTwo), '2v2');
+  assert.equal(postMatchRatingGameTypeParam('Competitive', ffa), 'ffa');
+  assert.equal(postMatchRatingGameTypeParam('Quickmatch', duel), null);
+  assert.equal(postMatchRatingGameTypeParam('Quickmatch', twoVTwo), null);
+  assert.equal(postMatchRatingGameTypeParam('Quickmatch', ffa), null);
+  assert.equal(postMatchRatingGameTypeParam(undefined, duel), null);
 });
 
 test('snapshots require a persisted MMR value', () => {

--- a/client/web/utils/ratingReveal.ts
+++ b/client/web/utils/ratingReveal.ts
@@ -37,6 +37,18 @@ export const ratedGameTypeParam = (gameType: GameType | undefined): RatedGameTyp
   return null;
 };
 
+/**
+ * Visible post-match rating progress belongs to competitive ladders only.
+ * Quickmatch MMR may still exist for matchmaking, but it is not a player-facing
+ * rank and should never create a rating panel in the results card.
+ */
+export const postMatchRatingGameTypeParam = (
+  queueMode: QueueMode | undefined,
+  gameType: GameType | undefined,
+): RatedGameTypeParam | null => (
+  queueMode === 'Competitive' ? ratedGameTypeParam(gameType) : null
+);
+
 export const queueModeParam = (queueMode: QueueMode): 'competitive' | 'quickmatch' => (
   queueMode === 'Competitive' ? 'competitive' : 'quickmatch'
 );
@@ -136,7 +148,7 @@ export const buildRatingReveal = (
 };
 
 export type MatchRatingState =
-  /** Not a rated ladder match, or no authenticated player. */
+  /** No player-visible competitive ladder, or no authenticated player. */
   | { phase: 'idle' }
   /** Match finished; waiting for the persisted numbers to land. */
   | { phase: 'pending' }

--- a/server/src/api/leaderboard.rs
+++ b/server/src/api/leaderboard.rs
@@ -9,7 +9,7 @@ use tracing::{error, info, warn};
 
 use crate::api::middleware::AuthUser;
 use crate::db::Database;
-use crate::season::{Season, get_current_season};
+use crate::season::{Season, get_current_season, get_ranking_region};
 use common::{GameType, QueueMode};
 
 /// Query parameters for leaderboard endpoint
@@ -136,6 +136,10 @@ pub async fn get_leaderboard(
 
     // Get season (default to current)
     let season = query.season.unwrap_or_else(get_current_season);
+    let ranking_region = query
+        .region
+        .as_deref()
+        .map(|region| get_ranking_region(Some(region)));
 
     // Parse limit and offset with constraints
     let limit = query.limit.unwrap_or(25).clamp(1, 100);
@@ -148,7 +152,7 @@ pub async fn get_leaderboard(
     if matches!(game_type, GameType::Solo) {
         info!(
             "Fetching Solo high scores - region: {:?}, season: {}, limit: {}, offset: {}",
-            query.region.as_deref(),
+            ranking_region.as_deref(),
             season,
             limit,
             offset
@@ -158,7 +162,7 @@ pub async fn get_leaderboard(
             .db
             .get_high_scores(
                 &game_type,
-                query.region.as_deref(),
+                ranking_region.as_deref(),
                 season,
                 offset + fetch_limit,
             )
@@ -225,7 +229,7 @@ pub async fn get_leaderboard(
         .get_leaderboard(
             &queue_mode,
             Some(&game_type),
-            query.region.as_deref(), // Pass region if specified, None for global
+            ranking_region.as_deref(), // Pass region if specified, None for global
             season,
             offset + fetch_limit, // Fetch up to offset + limit + 1
         )
@@ -347,13 +351,14 @@ pub async fn get_my_ranking(
     // Get season (default to current)
     let season = query.season.unwrap_or_else(get_current_season);
 
-    // Get region (default to us-east-1 if not specified)
-    let region = query.region.as_deref().unwrap_or("us-east-1");
+    // Matchmaking exposes logical IDs such as `use1`, while the established
+    // ranking keyspace uses physical IDs such as `us-east-1`.
+    let region = get_ranking_region(query.region.as_deref());
 
     // Get user's ranking from database
     let ranking = match state
         .db
-        .get_user_ranking(auth_user.user_id, &queue_mode, &game_type, region, season)
+        .get_user_ranking(auth_user.user_id, &queue_mode, &game_type, &region, season)
         .await
     {
         Ok(Some(entry)) => {
@@ -363,7 +368,7 @@ pub async fn get_my_ranking(
                 .get_leaderboard(
                     &queue_mode,
                     Some(&game_type),
-                    Some(region),
+                    Some(&region),
                     season,
                     10000, // Large limit to get all entries
                 )

--- a/server/src/season.rs
+++ b/server/src/season.rs
@@ -7,11 +7,76 @@ pub fn get_current_season() -> Season {
     0
 }
 
-/// Get the region from environment or default
+fn resolve_storage_region(
+    snaketron_aws_region: Option<String>,
+    aws_region: Option<String>,
+    legacy_region: Option<String>,
+    snaketron_region_fallback: Option<String>,
+) -> String {
+    [
+        snaketron_aws_region,
+        aws_region,
+        legacy_region,
+        snaketron_region_fallback,
+    ]
+    .into_iter()
+    .flatten()
+    .find_map(|region| {
+        let region = region.trim();
+        (!region.is_empty()).then(|| region.to_string())
+    })
+    .unwrap_or_else(|| "us-east-1".to_string())
+}
+
+/// Get the physical region used by the existing ranking/high-score keyspace.
 pub fn get_region() -> String {
-    std::env::var("AWS_REGION")
-        .or_else(|_| std::env::var("REGION"))
-        .unwrap_or_else(|_| "us-east-1".to_string())
+    resolve_storage_region(
+        std::env::var("SNAKETRON_AWS_REGION").ok(),
+        std::env::var("AWS_REGION").ok(),
+        std::env::var("REGION").ok(),
+        std::env::var("SNAKETRON_REGION").ok(),
+    )
+}
+
+fn resolve_ranking_region(
+    requested_region: Option<&str>,
+    logical_server_region: Option<&str>,
+    storage_region: &str,
+) -> String {
+    let Some(requested) = requested_region
+        .map(str::trim)
+        .filter(|region| !region.is_empty())
+    else {
+        return storage_region.to_string();
+    };
+
+    if logical_server_region
+        .map(str::trim)
+        .is_some_and(|logical| requested.eq_ignore_ascii_case(logical))
+    {
+        return storage_region.to_string();
+    }
+
+    match requested.to_ascii_lowercase().as_str() {
+        "use1" => "us-east-1".to_string(),
+        "euw1" => "eu-west-1".to_string(),
+        "usw2" => "us-west-2".to_string(),
+        "aps2" => "ap-southeast-2".to_string(),
+        "ane1" => "ap-northeast-1".to_string(),
+        _ => requested.to_string(),
+    }
+}
+
+/// Translate the logical matchmaking region into the physical ranking
+/// keyspace without invalidating existing regional leaderboard rows.
+pub fn get_ranking_region(requested_region: Option<&str>) -> String {
+    let storage_region = get_region();
+    let logical_server_region = std::env::var("SNAKETRON_REGION").ok();
+    resolve_ranking_region(
+        requested_region,
+        logical_server_region.as_deref(),
+        &storage_region,
+    )
 }
 
 #[cfg(test)]
@@ -28,5 +93,54 @@ mod tests {
         // Test that we can get a region (might be from env or default)
         let region = get_region();
         assert!(!region.is_empty());
+    }
+
+    #[test]
+    fn dedicated_aws_region_wins_for_ranking_storage() {
+        assert_eq!(
+            resolve_storage_region(
+                Some("eu-west-1".to_string()),
+                Some("us-east-1".to_string()),
+                None,
+                Some("euw1".to_string()),
+            ),
+            "eu-west-1"
+        );
+    }
+
+    #[test]
+    fn storage_region_keeps_legacy_fallbacks() {
+        assert_eq!(
+            resolve_storage_region(None, Some("eu-west-1".to_string()), None, None),
+            "eu-west-1"
+        );
+        assert_eq!(
+            resolve_storage_region(None, None, Some("legacy".to_string()), None),
+            "legacy"
+        );
+        assert_eq!(
+            resolve_storage_region(Some("  ".to_string()), None, None, None),
+            "us-east-1"
+        );
+    }
+
+    #[test]
+    fn logical_matchmaking_regions_resolve_to_existing_ranking_regions() {
+        assert_eq!(
+            resolve_ranking_region(Some("us"), Some("us"), "us-east-1"),
+            "us-east-1"
+        );
+        assert_eq!(
+            resolve_ranking_region(Some("use1"), Some("euw1"), "eu-west-1"),
+            "us-east-1"
+        );
+        assert_eq!(
+            resolve_ranking_region(Some("eu-west-1"), Some("use1"), "us-east-1"),
+            "eu-west-1"
+        );
+        assert_eq!(
+            resolve_ranking_region(None, Some("use1"), "us-east-1"),
+            "us-east-1"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Restrict post-match rating reveals to competitive ladder matches
- Normalize logical matchmaking regions to physical ranking storage regions
- Preserve competitive rating settlement and remove quickmatch rating panels

## Testing

- Added unit tests for rating eligibility and region resolution
- Added Playwright coverage for competitive ranking settlement and quickmatch results