### PR TITLE
Replace gateway state replication with stateless event routing

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -13,8 +13,12 @@ The authoritative game runs in a server-side executor
 ([game_executor.rs](server/src/game_executor.rs)) that advances a shared
 `GameEngine` by wall clock and publishes every event over the Redis Streams
 game bus ([game_bus.rs](server/src/game_bus.rs)).
-WebSocket servers hold replicas ([replication.rs](server/src/replication.rs))
-that apply those events and forward them to clients. The client runs the same
+WebSocket servers are stateless event routers
+([replication.rs](server/src/replication.rs)): they forward per-game events to
+locally subscribed sockets without reconstructing any game state — each
+socket's subscription tracks `stream_seq` continuity, suppresses deltas while
+"cold," and re-anchors on every authoritative `Snapshot` (joins first-frame
+from the fenced Redis recovery envelope). The client runs the same
 engine compiled to WASM: its **committed** state advances only when server
 events arrive; its **predicted** state (what the player sees) is rebuilt from
 committed and free-runs ahead on the local clock, bounded by a prediction cap.
@@ -43,6 +47,11 @@ committed hash + server timestamp. This one small message does three jobs:
 
 - **Divergence detection** — the client recomputes its own committed hash at
   that tick and compares. Two consecutive mismatches ⇒ automatic resync.
+  (Since the 2026-08 move to stateless gateway routing, this client-side check
+  is the *only* production fingerprint verifier: gateways no longer
+  reconstruct state, so `TickHash` heartbeats must always be forwarded
+  end-to-end, and desync visibility comes from the resync-request counters and
+  auto-uploaded client traces.)
 - **Liveness** — it arrives even when nothing is happening in the game, so
   "no message for 3 s" now reliably means the stream is dead, and the client
   shows a reconnect banner instead of simulating a ghost game.
@@ -52,9 +61,9 @@ committed hash + server timestamp. This one small message does three jobs:
 ### 3. Transport sequencing (`GameEventMessage.stream_seq`)
 
 The executor stamps every published message with a per-game, strictly
-monotonic sequence number. Every consumer (replica, client engine) checks
-contiguity: a gap means messages were lost and triggers an automatic snapshot
-resync instead of silent divergence. Duplicates and stale messages are
+monotonic sequence number. Every consumer (gateway subscription, client
+engine) checks contiguity: a gap means messages were lost and triggers an
+automatic snapshot resync instead of silent divergence. Duplicates and stale messages are
 skipped instead of double-applied. The Streams bus itself doesn't drop, so
 gaps can only come from the hops past it (broadcast fan-out lag, the
 WebSocket leg) or trim-horizon loss after a long outage — the counters
@@ -167,7 +176,12 @@ Fourteen distinct defects have been confirmed — the first thirteen by a
 multi-agent audit (each verified by an independent 3-lens panel against the
 code), the fourteenth from the enemy-snake respawn-desync report. The fixes
 landed together with this infrastructure; the chaos suite and the replay
-harness lock each one in:
+harness lock each one in. (Rows referencing replica state application predate
+the 2026-08 stateless-gateway change: gateways no longer apply events to local
+state, so those specific mechanisms were retired, while the properties they
+protected — subscribe-before-read, gap suppression until a fresh snapshot,
+Lagged surfacing as a client resync — live on in the per-subscription
+continuity rules of [replication.rs](server/src/replication.rs).)
 
 | Defect | Fix |
 |---|---|

--- a/server/src/executor_cluster.rs
+++ b/server/src/executor_cluster.rs
@@ -1425,7 +1425,7 @@ mod tests {
         )?;
         let lifecycle = LocalTaskLifecycle::new(format!("warming-{salt}"));
         lifecycle.mark_listener_bound();
-        lifecycle.mark_replicas_ready(false);
+        lifecycle.mark_event_readers_ready(false);
         lifecycle.mark_assignment_ready(true);
         lifecycle.mark_redis_success_now();
         lifecycle.activate();
@@ -1466,7 +1466,7 @@ mod tests {
             "executor membership must not bypass gateway replica readiness"
         );
 
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         tokio::time::timeout(Duration::from_secs(3), async {
             while !lifecycle.is_ready() {
                 lifecycle.mark_redis_success_now();
@@ -1517,7 +1517,7 @@ mod tests {
         )?;
         let lifecycle = LocalTaskLifecycle::new(format!("outage-{salt}"));
         lifecycle.mark_listener_bound();
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         lifecycle.mark_assignment_ready(true);
         lifecycle.mark_redis_success_now();
         lifecycle.activate();
@@ -1591,7 +1591,7 @@ mod tests {
         // Losing gateway replica hydration withdraws public HTTP readiness, but
         // must not remove executor placement: doing so would remove the owner
         // that can answer the replica's recovery snapshot request.
-        lifecycle.mark_replicas_ready(false);
+        lifecycle.mark_event_readers_ready(false);
         tokio::time::sleep(Duration::from_millis(250)).await;
         let members = store
             .list_live(chrono::Utc::now().timestamp_millis())
@@ -1602,7 +1602,7 @@ mod tests {
         assert_eq!(worker_state.load(Ordering::Acquire), STATE_ACTIVE);
         assert!(!lifecycle.is_ready());
 
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         tokio::time::timeout(Duration::from_secs(3), async {
             loop {
                 lifecycle.mark_redis_success_now();
@@ -1726,7 +1726,7 @@ mod tests {
         let lifecycle_b = LocalTaskLifecycle::new(format!("shared-outage-b-{salt}"));
         for lifecycle in [&lifecycle_a, &lifecycle_b] {
             lifecycle.mark_listener_bound();
-            lifecycle.mark_replicas_ready(true);
+            lifecycle.mark_event_readers_ready(true);
             lifecycle.mark_assignment_ready(true);
             lifecycle.mark_redis_success_now();
             lifecycle.activate();

--- a/server/src/game_executor_v2.rs
+++ b/server/src/game_executor_v2.rs
@@ -3247,7 +3247,7 @@ mod tests {
     };
     use crate::redis_keys::RedisKeys;
     use crate::redis_utils::RedisConnection;
-    use crate::replication::{GameStateReader, ReplicationManager};
+    use crate::replication::{GameEventRouter, SubscriptionUpdate};
     use common::{CommandId, Direction, GameCommand, GameState, GameType, Position, QueueMode};
     use redis::AsyncCommands;
 
@@ -7705,7 +7705,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn executor_snapshot_request_hydrates_replica_before_matching_readiness_barrier()
+    async fn executor_snapshot_request_reaches_subscribers_before_matching_readiness_barrier()
     -> Result<()> {
         tokio::time::timeout(Duration::from_secs(15), async {
             let mut harness = CrashBoundaryHarness::new_with_redis_url(
@@ -7715,13 +7715,14 @@ mod tests {
             .await?;
             harness.defer_game_start().await?;
             let event_stream = RedisKeys::stream_events(harness.partition);
-            let replica_cancel = CancellationToken::new();
-            let replica_manager = ReplicationManager::new(
+            let router_cancel = CancellationToken::new();
+            let event_router = GameEventRouter::new(
                 vec![harness.partition],
-                replica_cancel.clone(),
+                router_cancel.clone(),
                 harness.bus.clone(),
             )
             .await?;
+            let mut subscription = event_router.subscribe_to_game(harness.game_id).await;
             let request_stream = RedisKeys::stream_snapshot_requests(harness.partition);
             let completion_id = tokio::time::timeout(Duration::from_secs(2), async {
                 loop {
@@ -7741,18 +7742,11 @@ mod tests {
                 }
             })
             .await
-            .context("replica did not publish its readiness snapshot request")??;
+            .context("router did not publish its readiness barrier request")??;
 
             assert!(
-                replica_manager
-                    .get_game_state(harness.game_id)
-                    .await
-                    .is_none(),
-                "replica replayed the pre-subscription activation snapshot"
-            );
-            assert!(
-                !replica_manager.is_ready().await,
-                "replica became ready before the requested snapshot was published"
+                !event_router.is_ready().await,
+                "router became ready before the requested snapshot was published"
             );
 
             let executor_cancel = CancellationToken::new();
@@ -7764,41 +7758,41 @@ mod tests {
                 Arc::new(UnusedDatabase::default()),
                 RecoveryConfig {
                     // Leave a deterministic window in which the executor's
-                    // activation snapshot has hydrated the replica, but the
-                    // readiness request still awaits an ordinary checkpoint.
+                    // activation snapshot has reached local subscribers, but
+                    // the readiness request still awaits an ordinary
+                    // checkpoint.
                     checkpoint_interval: Duration::from_secs(5),
                     ..RecoveryConfig::default()
                 },
                 executor_cancel,
             );
             tokio::time::timeout(Duration::from_secs(4), async {
-                while replica_manager
-                    .get_game_state(harness.game_id)
-                    .await
-                    .is_none()
-                {
-                    tokio::time::sleep(Duration::from_millis(10)).await;
+                loop {
+                    match subscription.next().await {
+                        Some(SubscriptionUpdate::Event(event))
+                            if matches!(event.event, GameEvent::Snapshot { .. }) =>
+                        {
+                            break Result::<()>::Ok(());
+                        }
+                        Some(_) => {}
+                        None => anyhow::bail!("subscription closed before activation snapshot"),
+                    }
                 }
             })
             .await
-            .context("executor activation snapshot did not hydrate the real replica")?;
+            .context("executor activation snapshot did not reach the subscription")??;
             assert!(
-                !replica_manager.is_ready().await,
+                !event_router.is_ready().await,
                 "activation snapshot bypassed the matching readiness barrier"
             );
 
             tokio::time::timeout(Duration::from_secs(6), async {
-                while !replica_manager.is_ready().await {
+                while !event_router.is_ready().await {
                     tokio::time::sleep(Duration::from_millis(10)).await;
                 }
             })
             .await
-            .context("replica did not become ready after its matching snapshot barrier")?;
-            let replicated = replica_manager
-                .get_game_state(harness.game_id)
-                .await
-                .context("matching barrier arrived before the requested snapshot was applied")?;
-            assert!(matches!(replicated.status, GameStatus::Started { .. }));
+            .context("router did not become ready after its matching barrier")?;
 
             let entries: redis::streams::StreamRangeReply =
                 harness.raw.xrange_all(&event_stream).await?;
@@ -7834,8 +7828,9 @@ mod tests {
                 "matching readiness barrier preceded its requested snapshot"
             );
 
-            replica_cancel.cancel();
-            replica_manager.wait().await?;
+            drop(subscription);
+            router_cancel.cancel();
+            event_router.wait().await?;
             executor.handoff().await?;
             executor_task
                 .await

--- a/server/src/game_server.rs
+++ b/server/src/game_server.rs
@@ -27,7 +27,7 @@ use crate::{
     db::{Database, ServerRegistration},
     matchmaking::{run_game_created_outbox_loop, run_matchmaking_loop},
     redis_keys::RedisKeys,
-    replication::ReplicationManager,
+    replication::GameEventRouter,
     ws_server::JwtVerifier,
 };
 use serde::Deserialize;
@@ -240,7 +240,7 @@ pub struct GameServer {
     /// Optional replay listener
     // replay_listener: Option<Arc<ReplayListener>>,
     /// Replication manager for game state
-    replication_manager: Arc<ReplicationManager>,
+    event_router: Arc<GameEventRouter>,
     /// Shared health/drain state.
     lifecycle: TaskLifecycle,
     /// Any critical task exiting before cancellation is process-fatal.
@@ -645,45 +645,45 @@ impl GameServer {
             }
         }));
 
-        // Start replication manager for all partitions BEFORE game executors
-        info!("Starting replication manager for game state replication");
-        let replication_partitions: Vec<u32> = (0..PARTITION_COUNT).collect();
-        let replication_manager = Arc::new(
-            ReplicationManager::new(
-                replication_partitions,
+        // Start the event router for all partitions BEFORE game executors
+        info!("Starting stateless game event router");
+        let router_partitions: Vec<u32> = (0..PARTITION_COUNT).collect();
+        let event_router = Arc::new(
+            GameEventRouter::new(
+                router_partitions,
                 cancellation_token.clone(),
                 game_bus.clone(),
             )
             .await
-            .context("Failed to create replication manager")?,
+            .context("Failed to create game event router")?,
         );
 
-        // Keep replica readiness truthful while workers anchor asynchronously.
+        // Keep reader readiness truthful while workers anchor asynchronously.
         // A task launched during a Valkey outage stays live/unready and the
         // workers retry locally; an actually terminated reader remains fatal.
-        let replication_monitor = replication_manager.clone();
-        let replication_lifecycle = lifecycle.clone();
-        let replication_token = cancellation_token.clone();
-        let replication_fatal_tx = fatal_tx.clone();
+        let router_monitor = event_router.clone();
+        let router_lifecycle = lifecycle.clone();
+        let router_token = cancellation_token.clone();
+        let router_fatal_tx = fatal_tx.clone();
         handles.push(tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_millis(250));
             loop {
                 tokio::select! {
-                    _ = replication_token.cancelled() => break,
+                    _ = router_token.cancelled() => break,
                     _ = interval.tick() => {
-                        let ready = replication_monitor.is_ready().await;
-                        replication_lifecycle.mark_replicas_ready(ready);
-                        if replication_monitor.has_failed_worker() {
+                        let ready = router_monitor.is_ready().await;
+                        router_lifecycle.mark_event_readers_ready(ready);
+                        if router_monitor.has_failed_worker() {
                             // A cancellation can complete every worker while
                             // this monitor is suspended inside `is_ready()`.
                             // Recheck after that await so normal shutdown is
                             // not misclassified as a critical worker failure.
-                            if replication_token.is_cancelled() {
+                            if router_token.is_cancelled() {
                                 break;
                             }
-                            replication_lifecycle.mark_critical_failure();
-                            let _ = replication_fatal_tx.send(anyhow::anyhow!(
-                                "a partition replication worker exited unexpectedly"
+                            router_lifecycle.mark_critical_failure();
+                            let _ = router_fatal_tx.send(anyhow::anyhow!(
+                                "a partition event reader exited unexpectedly"
                             ));
                             break;
                         }
@@ -791,7 +791,7 @@ impl GameServer {
         }));
 
         // Note: HTTP server will be started separately in main.rs
-        // This is because it needs both the replication manager and JWT verifier
+        // This is because it needs both the event router and JWT verifier
         info!("HTTP server will be started externally at {}", http_addr);
 
         // Production startup preserves the existing grace period before
@@ -814,7 +814,7 @@ impl GameServer {
             pubsub_manager.clone(),
             game_bus.clone(),
             matchmaking_manager.clone(),
-            replication_manager.clone(),
+            event_router.clone(),
             cancellation_token.clone(),
             server_id,
             region.clone(),
@@ -856,7 +856,7 @@ impl GameServer {
             cancellation_token,
             handles,
             // replay_listener,
-            replication_manager,
+            event_router,
             lifecycle,
             fatal_rx,
             fatal_tx,
@@ -876,9 +876,9 @@ impl GameServer {
         &self.cancellation_token
     }
 
-    /// Get the replication manager
-    pub fn replication_manager(&self) -> &Arc<ReplicationManager> {
-        &self.replication_manager
+    /// Get the game event router
+    pub fn event_router(&self) -> &Arc<GameEventRouter> {
+        &self.event_router
     }
 
     pub fn lifecycle(&self) -> &TaskLifecycle {

--- a/server/src/http_server.rs
+++ b/server/src/http_server.rs
@@ -32,7 +32,7 @@ use crate::lifecycle::TaskLifecycle;
 use crate::lobby_manager::LobbyManager;
 use crate::redis_keys::RedisKeys;
 use crate::region_cache::RegionCache;
-use crate::replication::ReplicationManager;
+use crate::replication::GameEventRouter;
 use crate::user_cache::UserCache;
 use crate::ws_server::{JwtVerifier, handle_websocket};
 
@@ -149,7 +149,7 @@ pub struct HttpServerState {
     pub matchmaking_manager:
         Arc<tokio::sync::Mutex<crate::matchmaking_manager::MatchmakingManager>>,
     /// Replication manager for game state
-    pub replication_manager: Arc<ReplicationManager>,
+    pub event_router: Arc<GameEventRouter>,
     /// Cancellation token for graceful shutdown
     pub cancellation_token: tokio_util::sync::CancellationToken,
     /// Active WebSocket connection count
@@ -183,7 +183,7 @@ pub async fn install_http_application(
     pubsub_manager: Arc<crate::pubsub_manager::PubSubManager>,
     game_bus: Arc<GameBus>,
     matchmaking_manager: Arc<tokio::sync::Mutex<crate::matchmaking_manager::MatchmakingManager>>,
-    replication_manager: Arc<ReplicationManager>,
+    event_router: Arc<GameEventRouter>,
     cancellation_token: tokio_util::sync::CancellationToken,
     server_id: u64,
     region: String,
@@ -205,7 +205,7 @@ pub async fn install_http_application(
         pubsub_manager,
         game_bus,
         matchmaking_manager,
-        replication_manager,
+        event_router,
         cancellation_token: cancellation_token.clone(),
         connection_count: connection_count.clone(),
         server_id,
@@ -470,7 +470,7 @@ async fn websocket_handler(
                 state.pubsub_manager,
                 state.game_bus,
                 state.matchmaking_manager,
-                state.replication_manager,
+                state.event_router,
                 state.cancellation_token,
                 state.lobby_manager,
                 state.region,
@@ -725,7 +725,7 @@ mod deferred_http_tests {
         assert_eq!(warming.status(), reqwest::StatusCode::SERVICE_UNAVAILABLE);
         assert!(!task.is_finished());
 
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         lifecycle.mark_assignment_ready(true);
         lifecycle.mark_membership_ready(true);
         lifecycle.mark_redis_success_now();

--- a/server/src/lifecycle.rs
+++ b/server/src/lifecycle.rs
@@ -55,7 +55,7 @@ struct TaskLifecycleInner {
     task_boot_id: String,
     phase: AtomicU8,
     listener_bound: AtomicBool,
-    replicas_ready: AtomicBool,
+    event_readers_ready: AtomicBool,
     membership_ready: AtomicBool,
     assignment_ready: AtomicBool,
     critical_failure: AtomicBool,
@@ -76,7 +76,7 @@ impl TaskLifecycle {
                 task_boot_id: task_boot_id.into(),
                 phase: AtomicU8::new(PHASE_STARTING),
                 listener_bound: AtomicBool::new(false),
-                replicas_ready: AtomicBool::new(false),
+                event_readers_ready: AtomicBool::new(false),
                 membership_ready: AtomicBool::new(false),
                 assignment_ready: AtomicBool::new(false),
                 critical_failure: AtomicBool::new(false),
@@ -117,8 +117,10 @@ impl TaskLifecycle {
         self.inner.listener_bound.load(Ordering::Acquire)
     }
 
-    pub fn mark_replicas_ready(&self, ready: bool) {
-        self.inner.replicas_ready.store(ready, Ordering::Release);
+    pub fn mark_event_readers_ready(&self, ready: bool) {
+        self.inner
+            .event_readers_ready
+            .store(ready, Ordering::Release);
     }
 
     pub fn mark_membership_ready(&self, ready: bool) {
@@ -235,10 +237,10 @@ impl TaskLifecycle {
     /// Local prerequisites for publishing this task as executor-placement
     /// eligible. Membership freshness itself is deliberately excluded: the
     /// heartbeat publishes ACTIVE only after these predicates converge, then
-    /// that successful write supplies the final readiness bit. Gateway replica
-    /// hydration is deliberately excluded too: executors must be able to start
-    /// and answer the snapshot barrier that makes a first/replacement gateway
-    /// ready.
+    /// that successful write supplies the final readiness bit. Gateway
+    /// event-reader readiness is deliberately excluded too: executors must be
+    /// able to start and answer the reader barrier that makes a
+    /// first/replacement gateway ready.
     pub fn is_assignment_eligible(&self) -> bool {
         if self.inner.phase.load(Ordering::Acquire) != PHASE_ACTIVE
             || !self.inner.listener_bound.load(Ordering::Acquire)
@@ -257,7 +259,8 @@ impl TaskLifecycle {
     }
 
     pub fn is_ready(&self) -> bool {
-        if !self.is_assignment_eligible() || !self.inner.replicas_ready.load(Ordering::Acquire) {
+        if !self.is_assignment_eligible() || !self.inner.event_readers_ready.load(Ordering::Acquire)
+        {
             return false;
         }
         self.inner.membership_ready.load(Ordering::Acquire)
@@ -280,20 +283,20 @@ mod tests {
         assert!(!lifecycle.is_ready());
 
         lifecycle.mark_listener_bound();
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         lifecycle.mark_assignment_ready(true);
         lifecycle.mark_membership_ready(true);
         lifecycle.mark_redis_success_now();
         lifecycle.activate();
         assert!(lifecycle.is_ready());
 
-        lifecycle.mark_replicas_ready(false);
+        lifecycle.mark_event_readers_ready(false);
         assert!(lifecycle.is_assignment_eligible());
         assert!(!lifecycle.is_ready());
     }
 
     #[test]
-    fn executor_eligibility_does_not_wait_for_gateway_replica_hydration() {
+    fn executor_eligibility_does_not_wait_for_gateway_event_readers() {
         let lifecycle = TaskLifecycle::new("boot-a");
         lifecycle.mark_listener_bound();
         lifecycle.mark_assignment_ready(true);
@@ -305,7 +308,7 @@ mod tests {
 
         lifecycle.mark_membership_ready(true);
         assert!(!lifecycle.is_ready());
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         assert!(lifecycle.is_ready());
     }
 
@@ -313,7 +316,7 @@ mod tests {
     fn readiness_always_requires_cluster_workers() {
         let lifecycle = TaskLifecycle::new("boot-a");
         lifecycle.mark_listener_bound();
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         lifecycle.mark_redis_success_now();
         lifecycle.activate();
         assert!(!lifecycle.is_ready());
@@ -327,7 +330,7 @@ mod tests {
     fn draining_is_immediately_unready_and_broadcasts_once() {
         let lifecycle = TaskLifecycle::new("boot-a");
         lifecycle.mark_listener_bound();
-        lifecycle.mark_replicas_ready(true);
+        lifecycle.mark_event_readers_ready(true);
         lifecycle.mark_redis_success_now();
         lifecycle.activate();
         let mut drain_rx = lifecycle.subscribe_to_drain();

--- a/server/src/otel_metrics.rs
+++ b/server/src/otel_metrics.rs
@@ -39,7 +39,6 @@ const COMBO_REMAINING_WINDOW_BUCKETS_MS: &[f64] = &[
 
 struct OtelMetrics {
     fenced_write_rejections: Counter<u64>,
-    recovery_fingerprint_divergences: Counter<u64>,
     planned_drain_failures: Counter<u64>,
     command_claims: Counter<u64>,
     command_acks: Counter<u64>,
@@ -378,11 +377,6 @@ impl OtelMetrics {
                 "snaketron.fenced_write_rejections",
                 "Rejected writes from stale executor owners",
             ),
-            recovery_fingerprint_divergences: counter(
-                &meter,
-                "snaketron.recovery_fingerprint_divergences",
-                "Recovered states that diverged from their deterministic fingerprint",
-            ),
             planned_drain_failures: counter(
                 &meter,
                 "snaketron.planned_drain_failures",
@@ -720,10 +714,6 @@ macro_rules! counter_recorder {
 }
 
 counter_recorder!(record_fenced_write_rejection, fenced_write_rejections);
-counter_recorder!(
-    record_recovery_fingerprint_divergence,
-    recovery_fingerprint_divergences
-);
 counter_recorder!(record_planned_drain_failure, planned_drain_failures);
 counter_recorder!(record_command_claims, command_claims);
 counter_recorder!(record_command_acks, command_acks);

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -1,508 +1,378 @@
+//! Stateless gateway event routing.
+//!
+//! Every task tails all partition event streams and forwards per-game events
+//! to locally subscribed sockets. Nothing here retains a reconstructed
+//! `GameState`: the only live authoritative state in the region is the lease
+//! holder's actor state, and the only durable copy is its fenced Redis
+//! recovery envelope. Joins first-frame from that envelope (the "recovery
+//! bridge") and re-anchor on the next authoritative `Snapshot`; everything in
+//! between is governed by the per-subscription continuity rules in
+//! [`GameEventSubscription`].
+
 use crate::game_bus::{GameBus, PartitionEvent, PartitionEventSubscription};
-use crate::game_executor::PARTITION_COUNT;
-use anyhow::{Context, Result};
+use anyhow::Result;
 use common::{GameEvent, GameEventMessage, GameState, GameStatus};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicI64, Ordering};
-use tokio::sync::{RwLock, broadcast};
+use tokio::sync::{Mutex, RwLock, broadcast};
 use tokio_util::sync::CancellationToken;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, info, warn};
 
-/// A replicated state and the transport sequence already reflected in it.
-/// Keeping both values in one lock-protected entry makes it impossible for a
-/// subscriber to receive state S+1 stamped with watermark S.
-#[derive(Clone)]
-struct ReplicatedGame {
-    game_state: GameState,
-    stream_seq: u64,
-}
-
-type ReplicaStore = Arc<RwLock<HashMap<u32, ReplicatedGame>>>;
-
-fn is_stateful_unknown_event(event: &GameEventMessage) -> bool {
-    !(event.stream_seq == 0 && matches!(&event.event, GameEvent::CommandRejected { .. }))
-}
-
-async fn replica_snapshot(store: &ReplicaStore, game_id: u32) -> Option<(GameState, u64)> {
-    let replicas = store.read().await;
-    replicas
-        .get(&game_id)
-        .map(|replica| (replica.game_state.clone(), replica.stream_seq))
-}
-
-/// Game event broadcast channels
+/// Per-game broadcast channels, created only when a local socket subscribes.
+/// A game with no local subscriber has no entry and costs nothing.
 pub type GameEventBroadcasters = Arc<RwLock<HashMap<u32, broadcast::Sender<GameEventMessage>>>>;
 
-/// Tracks the replication status
+/// How often a cold subscription (or a fresh join) may publish a targeted
+/// snapshot request, per game, per gateway — coalesced across every local
+/// socket waiting on that game.
+const TARGETED_REQUEST_INTERVAL_MS: i64 = 500;
+
+/// Tracks one partition reader's readiness.
 #[derive(Debug, Clone)]
 pub struct ReplicationStatus {
     pub partition_id: u32,
     pub is_ready: bool,
 }
 
-/// A wrapper around broadcast::Receiver that filters out events already
-/// contained in the snapshot handed out alongside it.
-///
-/// State-bearing events use the transport-level `stream_seq`. A zero sequence
-/// is reserved for out-of-band terminal command rejections, which do not mutate
-/// replica state and are safe to forward by stable command identity.
-pub struct FilteredEventReceiver {
-    inner: broadcast::Receiver<GameEventMessage>,
-    min_stream_seq: u64,
-    game_id: u32,
+/// Pure pacing state for targeted snapshot requests: at most one publish per
+/// game per [`TARGETED_REQUEST_INTERVAL_MS`] on this gateway, regardless of
+/// how many sockets are waiting on the game.
+#[derive(Default)]
+struct RequestPacer {
+    last_request_ms: HashMap<u32, i64>,
 }
 
-impl FilteredEventReceiver {
-    /// Create a new FilteredEventReceiver
-    pub fn new(
-        inner: broadcast::Receiver<GameEventMessage>,
-        min_stream_seq: u64,
-        game_id: u32,
-    ) -> Self {
+impl RequestPacer {
+    /// Entries are pruned opportunistically so the map stays bounded by the
+    /// number of games requested in the last interval, not ever requested.
+    const PRUNE_THRESHOLD: usize = 256;
+
+    fn should_publish(&mut self, game_id: u32, now_ms: i64) -> bool {
+        if let Some(&last) = self.last_request_ms.get(&game_id)
+            && now_ms >= last
+            && now_ms - last < TARGETED_REQUEST_INTERVAL_MS
+        {
+            return false;
+        }
+        if self.last_request_ms.len() >= Self::PRUNE_THRESHOLD {
+            self.last_request_ms
+                .retain(|_, last| now_ms - *last < TARGETED_REQUEST_INTERVAL_MS);
+        }
+        self.last_request_ms.insert(game_id, now_ms);
+        true
+    }
+}
+
+/// Shared targeted-snapshot request path. The pacer is claimed before the
+/// publish so concurrent callers coalesce even while an XADD is in flight.
+///
+/// `bus` is `None` only in unit tests that exercise pure subscription
+/// continuity; production construction always supplies one.
+pub struct SnapshotRequester {
+    bus: Option<Arc<GameBus>>,
+    pacer: Mutex<RequestPacer>,
+}
+
+impl SnapshotRequester {
+    fn new(bus: Arc<GameBus>) -> Self {
         Self {
-            inner,
-            min_stream_seq,
-            game_id,
+            bus: Some(bus),
+            pacer: Mutex::new(RequestPacer::default()),
         }
     }
 
-    /// Receive the next event that passes the filter.
-    ///
-    /// `Err(Lagged(n))` is surfaced to the caller instead of being silently
-    /// swallowed: a lagged receiver has lost events, and the caller must
-    /// resync its downstream consumer (e.g. send a fresh snapshot). The
-    /// receiver stays usable afterwards and continues from the oldest
-    /// retained message.
-    pub async fn recv(&mut self) -> Result<GameEventMessage, broadcast::error::RecvError> {
+    #[cfg(test)]
+    pub(crate) fn detached() -> Self {
+        Self {
+            bus: None,
+            pacer: Mutex::new(RequestPacer::default()),
+        }
+    }
+
+    /// Ask the executor to republish one game's snapshot. Returns whether this
+    /// call published a request; `false` means a recent caller already did.
+    pub async fn request_game_snapshot(&self, game_id: u32) -> Result<bool> {
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        if !self.pacer.lock().await.should_publish(game_id, now_ms) {
+            return Ok(false);
+        }
+        let Some(bus) = &self.bus else {
+            return Ok(true);
+        };
+        bus.request_game_snapshot(game_id).await?;
+        Ok(true)
+    }
+}
+
+/// Continuity state of one socket's subscription to one game.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Continuity {
+    /// No trusted anchor: sequenced deltas are suppressed until a `Snapshot`
+    /// (or a contiguous continuation of an explicit [`anchor`]) arrives.
+    Cold,
+    Live {
+        last_stream_seq: u64,
+    },
+}
+
+/// What [`GameEventSubscription::next`] hands the forwarding loop.
+#[derive(Debug)]
+pub enum SubscriptionUpdate {
+    /// Forward this event to the socket.
+    Event(GameEventMessage),
+    /// The subscription lost continuity (gap or broadcast lag) and suppressed
+    /// delivery until the next snapshot; a targeted request is already paced.
+    /// Any in-flight work tied to the previous snapshot is now stale.
+    WentCold,
+}
+
+/// One socket's ordered, continuity-checked view of a game's event stream.
+///
+/// The router holds no game state, so continuity is a per-subscription
+/// property with these rules (they are load-bearing — see the PRD's gateway
+/// event-router requirements):
+/// - a subscription is cold until it forwards an authoritative `Snapshot`;
+///   while cold, sequenced deltas are suppressed and the targeted snapshot
+///   request is re-paced on the shared 500 ms cadence;
+/// - every `Snapshot` re-anchors the watermark unconditionally, because a
+///   restarted or failed-over executor begins a new `stream_seq` sequence;
+/// - `stream_seq == 0` events are out-of-band terminal `CommandRejected`
+///   messages, forwarded by stable command identity even while cold;
+/// - a sequence gap or local broadcast lag returns the subscription to cold
+///   rather than forwarding unverified continuations.
+pub struct GameEventSubscription {
+    inner: broadcast::Receiver<GameEventMessage>,
+    game_id: u32,
+    requester: Arc<SnapshotRequester>,
+    continuity: Continuity,
+}
+
+impl GameEventSubscription {
+    /// Build a subscription over a bare channel with a detached requester,
+    /// for unit tests of continuity behavior.
+    #[cfg(test)]
+    pub(crate) fn for_test(inner: broadcast::Receiver<GameEventMessage>, game_id: u32) -> Self {
+        Self {
+            inner,
+            game_id,
+            requester: Arc::new(SnapshotRequester::detached()),
+            continuity: Continuity::Cold,
+        }
+    }
+
+    /// Adopt a known-good watermark — the recovery bridge snapshot's — so
+    /// deltas contiguous with the checkpointed envelope forward immediately
+    /// without waiting for a live snapshot. Any lost event in between
+    /// surfaces as an ordinary gap and re-anchors through a snapshot.
+    pub fn anchor(&mut self, stream_seq: u64) {
+        self.continuity = Continuity::Live {
+            last_stream_seq: stream_seq,
+        };
+    }
+
+    /// Receive the next forwardable event, or `None` when the game's channel
+    /// is gone (terminal teardown, or the reader worker failed — which is
+    /// task-fatal anyway).
+    pub async fn next(&mut self) -> Option<SubscriptionUpdate> {
         loop {
-            let event = self.inner.recv().await?;
+            let received = if self.continuity == Continuity::Cold {
+                tokio::select! {
+                    biased;
+                    received = self.inner.recv() => received,
+                    _ = tokio::time::sleep(std::time::Duration::from_millis(
+                        TARGETED_REQUEST_INTERVAL_MS as u64,
+                    )) => {
+                        self.request_snapshot().await;
+                        continue;
+                    }
+                }
+            } else {
+                self.inner.recv().await
+            };
+
+            let event_msg = match received {
+                Ok(event_msg) => event_msg,
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    warn!(
+                        game_id = self.game_id,
+                        skipped, "Game subscription lagged; going cold until a fresh snapshot"
+                    );
+                    if self.go_cold().await {
+                        return Some(SubscriptionUpdate::WentCold);
+                    }
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => return None,
+            };
 
             // Snapshots re-anchor the stream unconditionally. A restarted
             // executor (failover/resume) begins a NEW stream_seq sequence
             // starting near 1; filtering its snapshot as "stale" against the
             // old stream's high watermark would wedge this subscriber — and
-            // its client — forever. Forward the snapshot and adopt its
-            // stream as the new baseline (mirrors the client engine, which
-            // also resets its watermark on every snapshot).
-            if matches!(&event.event, GameEvent::Snapshot { .. }) {
-                self.min_stream_seq = event.stream_seq;
-                debug!(
-                    "Forwarding snapshot for game {} and re-anchoring stream (stream_seq {})",
-                    self.game_id, event.stream_seq
-                );
-                return Ok(event);
+            // its client — forever.
+            if matches!(event_msg.event, GameEvent::Snapshot { .. }) {
+                self.continuity = Continuity::Live {
+                    last_stream_seq: event_msg.stream_seq,
+                };
+                return Some(SubscriptionUpdate::Event(event_msg));
             }
 
-            let is_fresh = if event.stream_seq > 0 {
-                event.stream_seq > self.min_stream_seq
-            } else {
-                matches!(&event.event, GameEvent::CommandRejected { .. })
-            };
-
-            if is_fresh {
-                debug!(
-                    "Forwarding event for game {} (sequence {}, stream_seq {})",
-                    self.game_id, event.sequence, event.stream_seq
-                );
-                return Ok(event);
+            if event_msg.stream_seq == 0 {
+                // A zero sequence is reserved for out-of-band terminal command
+                // rejections, which carry their own stable command identity
+                // and must reach the player even during warm-up. Any other
+                // unsequenced event cannot be ordered and is dropped.
+                if matches!(event_msg.event, GameEvent::CommandRejected { .. }) {
+                    return Some(SubscriptionUpdate::Event(event_msg));
+                }
+                continue;
             }
-            debug!(
-                "Filtering out stale or unsequenced state event for game {} (sequence {}, stream_seq {} <= {})",
-                self.game_id, event.sequence, event.stream_seq, self.min_stream_seq
+
+            match self.continuity {
+                Continuity::Cold => {
+                    // A delta cannot be applied to unknown client state; the
+                    // paced targeted request will re-anchor with a snapshot.
+                    debug!(
+                        game_id = self.game_id,
+                        stream_seq = event_msg.stream_seq,
+                        "Suppressing delta while subscription is cold"
+                    );
+                    continue;
+                }
+                Continuity::Live { last_stream_seq } => {
+                    if event_msg.stream_seq <= last_stream_seq {
+                        // Duplicate or stale relative to the anchor.
+                        continue;
+                    }
+                    if event_msg.stream_seq == last_stream_seq + 1 {
+                        self.continuity = Continuity::Live {
+                            last_stream_seq: event_msg.stream_seq,
+                        };
+                        return Some(SubscriptionUpdate::Event(event_msg));
+                    }
+                    warn!(
+                        game_id = self.game_id,
+                        expected = last_stream_seq + 1,
+                        got = event_msg.stream_seq,
+                        "Game subscription detected stream gap; going cold until a fresh snapshot"
+                    );
+                    if self.go_cold().await {
+                        return Some(SubscriptionUpdate::WentCold);
+                    }
+                    continue;
+                }
+            }
+        }
+    }
+
+    /// Returns whether this was a live→cold transition (worth reporting).
+    async fn go_cold(&mut self) -> bool {
+        let was_live = self.continuity != Continuity::Cold;
+        self.continuity = Continuity::Cold;
+        self.request_snapshot().await;
+        was_live
+    }
+
+    async fn request_snapshot(&self) {
+        if let Err(error) = self.requester.request_game_snapshot(self.game_id).await {
+            warn!(
+                game_id = self.game_id,
+                %error,
+                "Failed to publish targeted snapshot request"
             );
         }
     }
 }
 
-/// PartitionReplica subscribes to partition events on the game bus and maintains game states
-pub struct PartitionReplica {
+/// Forward an event to the game's local subscribers, if any, and tear the
+/// channel down once nothing further can be broadcast for the game.
+async fn forward_event(channels: &GameEventBroadcasters, event_msg: GameEventMessage) {
+    let game_id = event_msg.game_id;
+    let is_terminal_snapshot = matches!(
+        &event_msg.event,
+        GameEvent::Snapshot { game_state }
+            if matches!(game_state.status, GameStatus::Complete { .. })
+    );
+
+    let delivery_failed = {
+        let channels = channels.read().await;
+        match channels.get(&game_id) {
+            // SendError means the last receiver is gone — normal as
+            // clients finish or switch generations.
+            Some(sender) => sender.send(event_msg).is_err(),
+            None => false,
+        }
+    };
+
+    if is_terminal_snapshot {
+        // The fenced completion transaction made the terminal state durable
+        // before this event was published, and nothing further will be
+        // broadcast for the game. Receivers drain the terminal snapshot
+        // first, then observe Closed.
+        if channels.write().await.remove(&game_id).is_some() {
+            info!(
+                game_id,
+                "Forwarded terminal snapshot; dropped game broadcaster"
+            );
+        }
+        return;
+    }
+
+    if delivery_failed {
+        let mut channels = channels.write().await;
+        // Re-check under the write lock: a new subscriber may have attached
+        // to this exact sender since the failed send.
+        if let Some(sender) = channels.get(&game_id)
+            && sender.receiver_count() == 0
+        {
+            channels.remove(&game_id);
+            debug!(game_id, "Dropped game broadcaster with no subscribers");
+        }
+    }
+}
+
+/// One partition's resumable event reader: anchors on the ordered event
+/// stream, proves readiness through the boot-unique barrier marker, then
+/// forwards each game's events to its local broadcast channel.
+pub struct PartitionEventRouter {
     partition_id: u32,
     bus: Arc<GameBus>,
-    replica_store: ReplicaStore,
-    game_event_broadcasters: GameEventBroadcasters,
+    channels: GameEventBroadcasters,
     status: Arc<RwLock<ReplicationStatus>>,
     cancellation_token: CancellationToken,
-    /// Wall-clock ms of the last gap-triggered snapshot request, for
-    /// rate-limiting self-heal requests under sustained loss.
-    last_gap_request_ms: std::sync::atomic::AtomicI64,
-    /// A delta after a stream gap cannot be applied to or broadcast from stale
-    /// state. Keep the game cold until an authoritative snapshot reanchors it.
-    cold_games: RwLock<HashSet<u32>>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ContinuityAction {
-    Apply,
-    SuppressGap { expected: u64 },
-    SuppressWhileCold,
-}
-
-fn continuity_action(
-    cold_games: &mut HashSet<u32>,
-    game_id: u32,
-    last_stream_seq: u64,
-    incoming_stream_seq: u64,
-    is_snapshot: bool,
-) -> ContinuityAction {
-    if is_snapshot {
-        cold_games.remove(&game_id);
-        return ContinuityAction::Apply;
-    }
-    if cold_games.contains(&game_id) {
-        return ContinuityAction::SuppressWhileCold;
-    }
-    if last_stream_seq > 0 && incoming_stream_seq > last_stream_seq.saturating_add(1) {
-        cold_games.insert(game_id);
-        return ContinuityAction::SuppressGap {
-            expected: last_stream_seq.saturating_add(1),
-        };
-    }
-    ContinuityAction::Apply
-}
-
-impl PartitionReplica {
+impl PartitionEventRouter {
     fn new(
         partition_id: u32,
         bus: Arc<GameBus>,
-        replica_store: ReplicaStore,
-        game_event_broadcasters: GameEventBroadcasters,
+        channels: GameEventBroadcasters,
         cancellation_token: CancellationToken,
     ) -> Self {
         let status = Arc::new(RwLock::new(ReplicationStatus {
             partition_id,
-            // Readiness becomes true only after the durable stream readers are
-            // subscribed and the initial snapshot request was accepted.
+            // Readiness becomes true only after the reader is anchored and
+            // its boot-unique barrier marker was consumed in order.
             is_ready: false,
         }));
 
         Self {
             partition_id,
             bus,
-            replica_store,
-            game_event_broadcasters,
+            channels,
             status,
             cancellation_token,
-            last_gap_request_ms: std::sync::atomic::AtomicI64::new(0),
-            cold_games: RwLock::new(HashSet::new()),
         }
     }
 
-    /// Get the current replication status
     pub fn status(&self) -> Arc<RwLock<ReplicationStatus>> {
         self.status.clone()
     }
 
-    async fn evict_game(&self, game_id: u32) {
-        {
-            let mut replicas = self.replica_store.write().await;
-            replicas.remove(&game_id);
-        }
-        {
-            let mut broadcasters = self.game_event_broadcasters.write().await;
-            broadcasters.remove(&game_id);
-        }
-        self.cold_games.write().await.remove(&game_id);
-        info!(
-            "Game {} durably completed; evicted from replication cache and dropped broadcasters",
-            game_id
-        );
-    }
-
-    /// Process a game event and update the game state
-    async fn process_event(&self, event_msg: GameEventMessage) -> Result<bool> {
-        let game_id = event_msg.game_id;
-        debug!(
-            "Processing game event for game {} in partition {}",
-            game_id, self.partition_id
-        );
-
-        // A snapshot is the only object allowed to thaw a cold replica, so it
-        // must be structurally valid before continuity bookkeeping removes the
-        // cold marker. Rejecting here also prevents an envelope/internal tick
-        // mismatch from being broadcast as a valid re-anchor.
-        if let GameEvent::Snapshot { game_state } = &event_msg.event {
-            let validation = if game_state.tick != event_msg.tick {
-                Err(anyhow::anyhow!(
-                    "snapshot envelope tick {} does not match state tick {}",
-                    event_msg.tick,
-                    game_state.tick
-                ))
-            } else {
-                game_state.validate_boost_invariants()
-            };
-            if let Err(error) = validation {
-                self.cold_games.write().await.insert(game_id);
-                warn!(
-                    game_id,
-                    partition = self.partition_id,
-                    tick = event_msg.tick,
-                    %error,
-                    "Replica rejected malformed snapshot; waiting for a fresh snapshot"
-                );
-                self.request_snapshots_rate_limited().await;
-                return Ok(false);
-            }
-        }
-
-        // Transport-integrity check, kept as defense-in-depth. The Streams
-        // bus itself doesn't drop, but a gap can still appear past it (trim
-        // horizon after a long outage, broadcast-lag downstream): a gap in
-        // stream_seq means this replica lost messages and its state can no
-        // longer be trusted, so ask the executor for fresh snapshots. Stale
-        // or duplicate messages are dropped instead of double-applied. On a
-        // healthy system this path sits idle (see DEBUGGING.md).
-        let is_snapshot = matches!(&event_msg.event, GameEvent::Snapshot { .. });
-        let last_stream_seq = if event_msg.stream_seq > 0 {
-            let replicas = self.replica_store.read().await;
-            replicas
-                .get(&game_id)
-                .map(|replica| replica.stream_seq)
-                .unwrap_or(0)
-        } else {
-            0
-        };
-        let continuity = {
-            let mut cold_games = self.cold_games.write().await;
-            continuity_action(
-                &mut cold_games,
-                game_id,
-                last_stream_seq,
-                event_msg.stream_seq,
-                is_snapshot,
-            )
-        };
-        match continuity {
-            ContinuityAction::Apply => {}
-            ContinuityAction::SuppressGap { expected } => {
-                warn!(
-                    "Replica for partition {} detected stream gap for game {}: expected {}, got {} ({} messages lost); suppressing deltas until a snapshot",
-                    self.partition_id,
-                    game_id,
-                    expected,
-                    event_msg.stream_seq,
-                    event_msg.stream_seq.saturating_sub(expected)
-                );
-                self.request_snapshots_rate_limited().await;
-                return Ok(false);
-            }
-            ContinuityAction::SuppressWhileCold => {
-                debug!(
-                    "Replica for partition {} suppressing game {} delta at stream_seq {} while waiting for a recovery snapshot",
-                    self.partition_id, game_id, event_msg.stream_seq
-                );
-                self.request_snapshots_rate_limited().await;
-                return Ok(false);
-            }
-        }
-
-        if event_msg.stream_seq > 0 {
-            let last = last_stream_seq;
-            if !is_snapshot && last > 0 && event_msg.stream_seq <= last {
-                debug!(
-                    "Replica for partition {} dropping stale message for game {} (stream_seq {} <= {})",
-                    self.partition_id, game_id, event_msg.stream_seq, last
-                );
-                return Ok(false);
-            }
-        }
-
-        let mut fingerprint_divergence = None;
-        let mut invalid_transition = None;
-        {
-            // State mutation and its watermark update share this one write
-            // guard. A subscriber therefore observes either the complete old
-            // pair or the complete new pair, never a mixture of the two.
-            let mut replicas = self.replica_store.write().await;
-            match &event_msg.event {
-                GameEvent::Snapshot { game_state } => {
-                    debug!(
-                        "Received snapshot for game {} at tick {} (stream_seq {})",
-                        game_id, event_msg.tick, event_msg.stream_seq
-                    );
-                    let stream_seq = if event_msg.stream_seq > 0 {
-                        event_msg.stream_seq
-                    } else {
-                        replicas
-                            .get(&game_id)
-                            .map(|replica| replica.stream_seq)
-                            .unwrap_or(0)
-                    };
-                    replicas.insert(
-                        game_id,
-                        ReplicatedGame {
-                            game_state: game_state.clone(),
-                            stream_seq,
-                        },
-                    );
-                }
-                _ => {
-                    let expected_fingerprint = match &event_msg.event {
-                        GameEvent::TickHash { hash, .. } => Some(*hash),
-                        _ => None,
-                    };
-                    if let Some(replica) = replicas.get_mut(&game_id) {
-                        // Catch-up and delta application are one transaction:
-                        // an invalid delta must not leave the replica advanced
-                        // to its tick or half-apply a pad/snake transition.
-                        let mut candidate = replica.game_state.clone();
-                        while candidate.tick < event_msg.tick {
-                            if let Err(error) = candidate.tick_forward(true) {
-                                invalid_transition = Some(format!(
-                                    "failed to derive tick {} while applying event at tick {}: {error}",
-                                    candidate.tick.saturating_add(1),
-                                    event_msg.tick
-                                ));
-                                break;
-                            }
-                        }
-
-                        if invalid_transition.is_none() {
-                            if let Some(expected) = expected_fingerprint {
-                                let actual = candidate.sync_hash();
-                                if actual != expected {
-                                    fingerprint_divergence = Some((expected, actual));
-                                }
-                            } else if let Err(error) =
-                                candidate.try_apply_replicated_event(event_msg.event.clone())
-                            {
-                                invalid_transition = Some(error.to_string());
-                            }
-                        }
-
-                        if invalid_transition.is_none() && fingerprint_divergence.is_none() {
-                            replica.game_state = candidate;
-                            if event_msg.stream_seq > 0 {
-                                replica.stream_seq = event_msg.stream_seq;
-                            }
-                            debug!(
-                                "Applied event to game {} state: {:?}",
-                                game_id, event_msg.event
-                            );
-                        }
-                    } else {
-                        if is_stateful_unknown_event(&event_msg) {
-                            // A newly started replica subscribes before its
-                            // requested snapshots arrive, so state deltas for
-                            // not-yet-anchored games are expected during warmup.
-                            // The explicit gap path above remains WARN-level.
-                            debug!("Received state event for unknown game {}", game_id);
-                        } else {
-                            // A rejection is an out-of-band command outcome and
-                            // does not mutate replica state. Missing stateful
-                            // events still warn, so this expected race can stay
-                            // at debug without masking a cold replica.
-                            debug!(
-                                "Received command rejection for unknown local replica {}",
-                                game_id
-                            );
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Some(error) = invalid_transition {
-            self.cold_games.write().await.insert(game_id);
-            warn!(
-                game_id,
-                partition = self.partition_id,
-                tick = event_msg.tick,
-                %error,
-                "Replica rejected malformed delta atomically; suppressing deltas until a fresh snapshot"
-            );
-            self.request_snapshots_rate_limited().await;
-            return Ok(false);
-        }
-
-        if let Some((expected, actual)) = fingerprint_divergence {
-            crate::resilience_metrics::record_recovery_fingerprint_divergence(1);
-            self.cold_games.write().await.insert(game_id);
-            warn!(
-                game_id,
-                partition = self.partition_id,
-                tick = event_msg.tick,
-                expected,
-                actual,
-                "Replica fingerprint diverged; suppressing deltas until a fresh snapshot"
-            );
-            self.request_snapshots_rate_limited().await;
-            return Ok(false);
-        }
-
-        // Broadcast the event to any local subscribers
-        {
-            let broadcasters = self.game_event_broadcasters.read().await;
-            if let Some(sender) = broadcasters.get(&game_id) {
-                match sender.send(event_msg.clone()) {
-                    Ok(receiver_count) => {
-                        if receiver_count == 0 {
-                            debug!("No receivers for game {} broadcast", game_id);
-                        }
-                    }
-                    Err(_) => {
-                        // Tokio broadcast returns SendError whenever the last
-                        // socket receiver has gone away. That is normal as
-                        // clients finish or switch generations.
-                        debug!("No receivers for game {} broadcast", game_id);
-                    }
-                }
-            }
-        }
-
-        Ok(true)
-    }
-
-    async fn process_received_event(&self, event: GameEventMessage) -> Result<()> {
-        let game_id = event.game_id;
-        let is_terminal_snapshot = matches!(
-            &event.event,
-            GameEvent::Snapshot { game_state }
-                if matches!(game_state.status, GameStatus::Complete { .. })
-        );
-        let applied = self.process_event(event).await?;
-        if applied && is_terminal_snapshot {
-            // The fenced completion transaction writes the immutable
-            // completion record, recovery envelope, stored snapshot, and
-            // pending-effect index before appending this event.
-            // `process_event` broadcasts before returning.
-            self.evict_game(game_id).await;
-        }
-        Ok(())
-    }
-
-    /// Ask the executor to republish snapshots for this partition, at most
-    /// once per second, so sustained loss doesn't turn into a request storm.
-    async fn request_snapshots_rate_limited(&self) {
-        use std::sync::atomic::Ordering;
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let last = self.last_gap_request_ms.load(Ordering::Relaxed);
-        if now_ms - last < 1000 {
-            return;
-        }
-        if self
-            .last_gap_request_ms
-            .compare_exchange(last, now_ms, Ordering::Relaxed, Ordering::Relaxed)
-            .is_err()
-        {
-            return; // Another task just requested.
-        }
-        if let Err(e) = self
-            .bus
-            .request_partition_snapshots(self.partition_id)
-            .await
-        {
-            error!(
-                "Failed to request snapshots for partition {} after stream gap: {}",
-                self.partition_id, e
-            );
-        }
-    }
-
-    /// Run the replication worker
+    /// Run the partition reader.
     pub async fn run(self) -> Result<()> {
         info!(
-            "Starting replication worker for partition {}",
+            "Starting event router worker for partition {}",
             self.partition_id
         );
 
@@ -521,7 +391,7 @@ impl PartitionReplica {
                 Err(error) => warn!(
                     partition = self.partition_id,
                     %error,
-                    "Replication stream anchor unavailable; retrying locally"
+                    "Event stream anchor unavailable; retrying locally"
                 ),
             }
             tokio::select! {
@@ -540,7 +410,11 @@ impl PartitionReplica {
         // appended. Retry the boot-unique request until the executor publishes
         // its completion marker after every active actor's requested snapshot.
         // The marker shares this exact ordered stream, so observing it proves
-        // all preceding snapshots were applied; empty partitions work too.
+        // an anchored reader that saw every preceding snapshot in order (the
+        // reader forwards them without retaining state); empty partitions work
+        // too. The request/marker wire shape is version-stable: old executors
+        // answering it with the full fan-out remain a correct, strictly
+        // stronger response, so no protocol bump accompanies this contract.
         let completion_id = uuid::Uuid::new_v4().to_string();
         let mut request_retry = tokio::time::interval(std::time::Duration::from_secs(2));
         request_retry.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
@@ -562,32 +436,18 @@ impl PartitionReplica {
                         warn!(
                             partition = self.partition_id,
                             %error,
-                            "Initial replication snapshot request unavailable; retrying locally"
+                            "Initial reader barrier request unavailable; retrying locally"
                         );
                     }
                 }
                 event = event_receiver.recv() => {
                     match event {
                         Some(PartitionEvent::Game(event)) => {
-                            self.process_received_event(event).await.with_context(|| {
-                                format!(
-                                    "partition {} failed to apply an event before its readiness barrier",
-                                    self.partition_id
-                                )
-                            })?;
+                            forward_event(&self.channels, event).await;
                         }
                         Some(PartitionEvent::SnapshotBarrier {
                             completion_id: observed,
-                        }) if observed == completion_id => {
-                            if self.cold_games.read().await.is_empty() {
-                                break;
-                            }
-                            warn!(
-                                partition = self.partition_id,
-                                %completion_id,
-                                "Ignoring readiness barrier while replicated games remain cold"
-                            );
-                        }
+                        }) if observed == completion_id => break,
                         Some(PartitionEvent::SnapshotBarrier { .. }) => {}
                         Some(PartitionEvent::Discontinuity {
                             resume_id,
@@ -599,7 +459,7 @@ impl PartitionReplica {
                             oldest_id
                         ),
                         None => anyhow::bail!(
-                            "partition {} subscription closed before initial snapshot barrier",
+                            "partition {} subscription closed before initial reader barrier",
                             self.partition_id
                         ),
                     }
@@ -611,32 +471,23 @@ impl PartitionReplica {
         info!(
             partition = self.partition_id,
             %completion_id,
-            "Initial replication snapshot barrier applied"
+            "Initial reader barrier consumed"
         );
 
-        // Main event processing loop
+        // Main forwarding loop.
         loop {
             tokio::select! {
                 biased;
 
                 _ = self.cancellation_token.cancelled() => {
-                    info!("Replication worker for partition {} shutting down", self.partition_id);
+                    info!("Event router worker for partition {} shutting down", self.partition_id);
                     break;
                 }
 
-                // Process events from partition subscription
                 event = event_receiver.recv() => {
                     match event {
                         Some(PartitionEvent::Game(event)) => {
-                            if let Err(error) = self.process_received_event(event).await {
-                                self.status.write().await.is_ready = false;
-                                return Err(error).with_context(|| {
-                                    format!(
-                                        "partition {} failed to apply an event after readiness",
-                                        self.partition_id
-                                    )
-                                });
-                            }
+                            forward_event(&self.channels, event).await;
                         }
                         Some(PartitionEvent::SnapshotBarrier { .. }) => {}
                         Some(PartitionEvent::Discontinuity {
@@ -670,239 +521,100 @@ impl PartitionReplica {
     }
 }
 
-/// Manager for running multiple replicas
-pub struct ReplicationManager {
+/// Stateless per-task router over all partition event streams.
+pub struct GameEventRouter {
     workers: Vec<tokio::task::JoinHandle<Result<()>>>,
-    replica_store: ReplicaStore,
-    game_event_broadcasters: GameEventBroadcasters,
+    channels: GameEventBroadcasters,
     statuses: Arc<RwLock<HashMap<u32, Arc<RwLock<ReplicationStatus>>>>>,
-    bus: Arc<GameBus>,
-    /// Coalesce partition-wide cold-join snapshot requests across all local
-    /// WebSocket connections. A request republishes every active game in the
-    /// partition, so issuing one per reconnecting player would amplify a
-    /// scale event unnecessarily.
-    last_on_demand_request_ms: Vec<AtomicI64>,
+    requester: Arc<SnapshotRequester>,
 }
 
-/// API for querying replicated game states
-// Internal trait: callers never need extra auto trait bounds on the futures.
-#[allow(async_fn_in_trait)]
-pub trait GameStateReader: Send + Sync {
-    /// Get a game state by ID
-    async fn get_game_state(&self, game_id: u32) -> Option<GameState>;
-
-    /// Get all game states for a partition
-    async fn get_partition_games(&self, partition_id: u32) -> Vec<(u32, GameState)>;
-
-    /// Check if replication is ready
-    async fn is_ready(&self) -> bool;
-}
-
-impl GameStateReader for ReplicationManager {
-    async fn get_game_state(&self, game_id: u32) -> Option<GameState> {
-        replica_snapshot(&self.replica_store, game_id)
-            .await
-            .map(|(game_state, _)| game_state)
-    }
-
-    async fn get_partition_games(&self, partition_id: u32) -> Vec<(u32, GameState)> {
-        let replicas = self.replica_store.read().await;
-        replicas
-            .iter()
-            .filter(|(game_id, _)| *game_id % PARTITION_COUNT == partition_id)
-            .map(|(id, replica)| (*id, replica.game_state.clone()))
-            .collect()
-    }
-
-    async fn is_ready(&self) -> bool {
-        ReplicationManager::is_ready(self).await
-    }
-}
-
-impl ReplicationManager {
-    /// Request fresh snapshots for a partition, coalesced to at most one
-    /// request every 500ms on this gateway. Returns `true` when this call
-    /// published a request and `false` when a concurrent/recent caller already
-    /// did so.
-    pub async fn request_partition_snapshots(&self, partition_id: u32) -> Result<bool> {
-        const REQUEST_INTERVAL_MS: i64 = 500;
-
-        let Some(last_request) = self.last_on_demand_request_ms.get(partition_id as usize) else {
-            anyhow::bail!("invalid partition {partition_id} for snapshot request");
-        };
-        let now_ms = chrono::Utc::now().timestamp_millis();
-        let previous_ms = last_request.load(Ordering::Relaxed);
-        if now_ms >= previous_ms && now_ms - previous_ms < REQUEST_INTERVAL_MS {
-            return Ok(false);
-        }
-        if last_request
-            .compare_exchange(previous_ms, now_ms, Ordering::Relaxed, Ordering::Relaxed)
-            .is_err()
-        {
-            return Ok(false);
-        }
-
-        self.bus.request_partition_snapshots(partition_id).await?;
-        Ok(true)
-    }
-
-    /// Ask the executor to refresh one game for a cold JoinGame. Actor-side
-    /// checkpoint coalescing absorbs duplicate requests from the two players;
-    /// unlike a partition request, this cannot republish every unrelated game
-    /// and multiply recovery payloads across all connected sockets.
-    pub async fn request_game_snapshot(&self, game_id: u32) -> Result<()> {
-        self.bus.request_game_snapshot(game_id).await
-    }
-
-    /// Load the most recently published game snapshot from Redis.
-    ///
-    /// Durably completed games are deliberately evicted from the in-memory replication cache,
-    /// while their final snapshot remains in Redis for a short grace period. Callers can use
-    /// this method before falling back to durable storage.
-    pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
-        self.bus.get_stored_snapshot(game_id).await
-    }
-
-    /// Subscribe to game events for a specific game.
-    /// Returns the current game state, its transport watermark (the
-    /// stream_seq already reflected in that state — stamp it onto snapshots
-    /// derived from the state), and a receiver for subsequent events.
-    ///
-    /// Ordering matters: the broadcast subscription is created BEFORE the
-    /// state is read. A broadcast receiver only sees messages sent after
-    /// `subscribe()`, so subscribing first guarantees no event between
-    /// snapshot and subscription can be missed; events already contained in
-    /// the snapshot are dropped by the stream_seq filter instead.
-    pub async fn subscribe_to_game(
-        &self,
-        game_id: u32,
-    ) -> Result<(GameState, u64, FilteredEventReceiver)> {
-        let receiver = {
-            let mut broadcasters = self.game_event_broadcasters.write().await;
-            broadcasters
-                .entry(game_id)
-                .or_insert_with(|| {
-                    let (tx, _) = broadcast::channel(1028);
-                    tx
-                })
-                .subscribe()
-        };
-
-        let (game_state, watermark) = replica_snapshot(&self.replica_store, game_id)
-            .await
-            .context("Game not available in replication manager")?;
-
-        let filtered_receiver = FilteredEventReceiver {
-            inner: receiver,
-            min_stream_seq: watermark,
-            game_id,
-        };
-
-        Ok((game_state, watermark, filtered_receiver))
-    }
-
-    /// Last transport stream_seq applied to the replica state of a game.
-    pub async fn get_stream_seq(&self, game_id: u32) -> u64 {
-        let replicas = self.replica_store.read().await;
-        replicas
-            .get(&game_id)
-            .map(|replica| replica.stream_seq)
-            .unwrap_or(0)
-    }
-
-    /// Get a game state (replicas are always ready; no readiness gate)
-    pub async fn get_game_state_when_ready(&self, game_id: u32) -> Option<GameState> {
-        self.get_game_state(game_id).await
-    }
-
-    /// Wait for a game to become available in the replication manager
-    /// Returns the game state once available, or an error if timeout is reached
-    pub async fn wait_for_game(&self, game_id: u32, timeout_secs: u64) -> Result<GameState> {
-        use tokio::time::{Duration, timeout};
-
-        let deadline = timeout(Duration::from_secs(timeout_secs), async {
-            let mut backoff_ms = 10;
-            const MAX_BACKOFF_MS: u64 = 500;
-
-            loop {
-                // Check if game is available
-                if let Some(game_state) = self.get_game_state(game_id).await {
-                    debug!("Game {} found in replication manager", game_id);
-                    return Ok(game_state);
-                }
-
-                // Wait with exponential backoff
-                debug!(
-                    "Game {} not yet available, waiting {}ms",
-                    game_id, backoff_ms
-                );
-                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
-
-                // Increase backoff for next iteration
-                backoff_ms = (backoff_ms * 2).min(MAX_BACKOFF_MS);
-            }
-        });
-
-        match deadline.await {
-            Ok(result) => result,
-            Err(_) => {
-                error!(
-                    "Timeout waiting for game {} to become available after {} seconds",
-                    game_id, timeout_secs
-                );
-                Err(anyhow::anyhow!(
-                    "Game {} did not become available within {} seconds",
-                    game_id,
-                    timeout_secs
-                ))
-            }
-        }
-    }
-
-    /// Create and start replication workers for specified partitions
+impl GameEventRouter {
+    /// Create and start reader workers for the specified partitions.
     pub async fn new(
         partitions: Vec<u32>,
         cancellation_token: CancellationToken,
         bus: Arc<GameBus>,
     ) -> Result<Self> {
-        let replica_store = Arc::new(RwLock::new(HashMap::new()));
-        let game_event_broadcasters = Arc::new(RwLock::new(HashMap::new()));
+        let channels: GameEventBroadcasters = Arc::new(RwLock::new(HashMap::new()));
         let statuses = Arc::new(RwLock::new(HashMap::new()));
+        let requester = Arc::new(SnapshotRequester::new(bus.clone()));
         let mut workers = Vec::new();
 
         for partition_id in partitions {
-            // Create worker
-            let worker = PartitionReplica::new(
+            let worker = PartitionEventRouter::new(
                 partition_id,
                 bus.clone(),
-                replica_store.clone(),
-                game_event_broadcasters.clone(),
+                channels.clone(),
                 cancellation_token.clone(),
             );
 
-            // Store status reference
             {
                 let mut status_map = statuses.write().await;
                 status_map.insert(partition_id, worker.status());
             }
 
-            // Spawn worker task
             let handle = tokio::spawn(worker.run());
             workers.push(handle);
         }
 
         Ok(Self {
             workers,
-            replica_store,
-            game_event_broadcasters,
+            channels,
             statuses,
-            bus,
-            last_on_demand_request_ms: (0..PARTITION_COUNT).map(|_| AtomicI64::new(0)).collect(),
+            requester,
         })
     }
 
-    /// Check that every configured stream reader reached its subscription
-    /// anchor and that none of the worker tasks has exited unexpectedly.
+    /// Subscribe to a game's events. Infallible: the per-game channel is
+    /// created on demand, and the subscription starts cold — the caller
+    /// provides the first frame (recovery bridge or live snapshot) and may
+    /// [`GameEventSubscription::anchor`] on its watermark.
+    ///
+    /// Registering the receiver here, BEFORE requesting or sending any
+    /// snapshot, guarantees no event between snapshot and subscription can be
+    /// missed; the per-subscription continuity rules drop the overlap instead.
+    pub async fn subscribe_to_game(&self, game_id: u32) -> GameEventSubscription {
+        let receiver = {
+            let mut channels = self.channels.write().await;
+            // Opportunistically drop channels whose last subscriber left, so
+            // abandoned games do not accumulate entries.
+            channels.retain(|id, sender| *id == game_id || sender.receiver_count() > 0);
+            channels
+                .entry(game_id)
+                .or_insert_with(|| broadcast::channel(1028).0)
+                .subscribe()
+        };
+
+        GameEventSubscription {
+            inner: receiver,
+            game_id,
+            requester: self.requester.clone(),
+            continuity: Continuity::Cold,
+        }
+    }
+
+    /// Ask the executor to republish one game's snapshot, coalesced to at
+    /// most one request per game per 500 ms on this gateway. Actor-side
+    /// checkpoint coalescing bounds the executor's output independently.
+    pub async fn request_game_snapshot(&self, game_id: u32) -> Result<bool> {
+        self.requester.request_game_snapshot(game_id).await
+    }
+
+    /// Load the most recently checkpointed game snapshot from Redis. Live
+    /// games update it on every checkpoint; durably completed games leave
+    /// their terminal snapshot in it for a short grace period.
+    pub async fn get_stored_snapshot(&self, game_id: u32) -> Result<Option<GameState>> {
+        let bus = self
+            .requester
+            .bus
+            .as_ref()
+            .expect("production router always has a bus");
+        bus.get_stored_snapshot(game_id).await
+    }
+
+    /// Check that every configured stream reader consumed its boot-unique
+    /// barrier and that none of the worker tasks has exited unexpectedly.
     pub async fn is_ready(&self) -> bool {
         if self.workers.is_empty() || self.workers.iter().any(|worker| worker.is_finished()) {
             return false;
@@ -927,7 +639,7 @@ impl ReplicationManager {
         self.workers.iter().any(|worker| worker.is_finished())
     }
 
-    /// Get status of all workers
+    /// Get status of all workers.
     pub async fn get_status(&self) -> HashMap<u32, ReplicationStatus> {
         let mut result = HashMap::new();
         let statuses = self.statuses.read().await;
@@ -938,7 +650,7 @@ impl ReplicationManager {
         result
     }
 
-    /// Wait for all workers to complete
+    /// Wait for all workers to complete.
     pub async fn wait(self) -> Result<()> {
         for worker in self.workers {
             worker.await??;
@@ -950,9 +662,8 @@ impl ReplicationManager {
 #[cfg(test)]
 mod tests {
     use super::{
-        ContinuityAction, FilteredEventReceiver, GameEventBroadcasters, PartitionReplica,
-        ReplicaStore, ReplicatedGame, continuity_action, is_stateful_unknown_event,
-        replica_snapshot,
+        GameEventBroadcasters, GameEventRouter, PartitionEventRouter, RequestPacer,
+        SnapshotRequester, SubscriptionUpdate, TARGETED_REQUEST_INTERVAL_MS,
     };
     use crate::game_bus::{GameBus, SnapshotRequest};
     use crate::game_executor::PARTITION_COUNT;
@@ -960,9 +671,8 @@ mod tests {
     use common::{GameEvent, GameEventMessage, GameState, GameStatus, GameType, QueueMode};
     use redis::AsyncCommands;
     use redis::streams::StreamRangeReply;
-    use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
-    use tokio::sync::{Barrier, RwLock, broadcast};
+    use tokio::sync::broadcast;
     use tokio_util::sync::CancellationToken;
 
     fn event(sequence: u64, stream_seq: u64) -> GameEventMessage {
@@ -998,23 +708,106 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn filter_drops_stale_and_passes_fresh_by_stream_seq() {
-        let (tx, rx) = broadcast::channel(16);
-        let mut filtered = FilteredEventReceiver::new(rx, 500, 1);
+    fn terminal_snapshot(game_id: u32, stream_seq: u64) -> GameEventMessage {
+        let mut state = GameState::new(10, 10, GameType::Solo, QueueMode::Quickmatch, None, 0);
+        state.status = GameStatus::Complete {
+            winning_snake_id: None,
+        };
+        GameEventMessage {
+            game_id,
+            tick: state.tick,
+            sequence: state.event_sequence,
+            stream_seq,
+            user_id: None,
+            event: GameEvent::Snapshot { game_state: state },
+        }
+    }
 
-        tx.send(event(0, 400)).unwrap(); // stale: absorbed by the snapshot
-        tx.send(event(999, 0)).unwrap(); // invalid: state events must be sequenced
-        tx.send(event(0, 501)).unwrap(); // fresh
-        let got = filtered.recv().await.unwrap();
-        assert_eq!(got.stream_seq, 501);
+    async fn test_bus(db: u32) -> (Arc<GameBus>, redis::Client, CancellationToken) {
+        let client = redis::Client::open(format!("redis://127.0.0.1:6379/{db}?protocol=resp3"))
+            .expect("valid local Redis URL");
+        let (push_tx, _push_rx) = broadcast::channel(8);
+        let manager = crate::redis_utils::create_connection_manager(client.clone(), push_tx)
+            .await
+            .expect("local Redis is required for routing tests");
+        let token = CancellationToken::new();
+        let bus = Arc::new(
+            GameBus::new(
+                manager.clone(),
+                (0..PARTITION_COUNT)
+                    .map(|_| manager.clone().into())
+                    .collect(),
+                (0..PARTITION_COUNT)
+                    .map(|_| manager.clone().into())
+                    .collect(),
+                manager.clone(),
+                manager,
+                client.clone(),
+                token.clone(),
+            )
+            .expect("test GameBus"),
+        );
+        (bus, client, token)
+    }
+
+    fn test_subscription() -> (
+        broadcast::Sender<GameEventMessage>,
+        super::GameEventSubscription,
+    ) {
+        let (tx, rx) = broadcast::channel(16);
+        (tx, super::GameEventSubscription::for_test(rx, 1))
+    }
+
+    fn expect_event(update: Option<SubscriptionUpdate>) -> GameEventMessage {
+        match update {
+            Some(SubscriptionUpdate::Event(event)) => event,
+            other => panic!("expected a forwarded event, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn targeted_requests_coalesce_per_game_and_stay_bounded() {
+        let mut pacer = RequestPacer::default();
+
+        assert!(pacer.should_publish(1, 1_000));
+        assert!(!pacer.should_publish(1, 1_000 + TARGETED_REQUEST_INTERVAL_MS - 1));
+        assert!(pacer.should_publish(2, 1_200), "games pace independently");
+        assert!(pacer.should_publish(1, 1_000 + TARGETED_REQUEST_INTERVAL_MS));
+
+        // A clock that moved backwards must not wedge the pacer forever.
+        assert!(pacer.should_publish(3, 5_000));
+        assert!(pacer.should_publish(3, 4_000));
+
+        // The map prunes expired entries rather than growing with every game
+        // ever requested.
+        let now = 100_000;
+        for game_id in 100..(100 + RequestPacer::PRUNE_THRESHOLD as u32) {
+            assert!(pacer.should_publish(game_id, now));
+        }
+        assert!(pacer.should_publish(9_999, now + TARGETED_REQUEST_INTERVAL_MS));
+        assert!(pacer.last_request_ms.len() <= 2);
     }
 
     #[tokio::test]
-    async fn snapshot_re_anchors_stream_after_executor_restart() {
-        // Subscriber anchored to the OLD executor's stream at watermark 500.
-        let (tx, rx) = broadcast::channel(16);
-        let mut filtered = FilteredEventReceiver::new(rx, 500, 1);
+    async fn cold_subscription_suppresses_deltas_until_snapshot_reanchors() {
+        let (tx, mut subscription) = test_subscription();
+
+        tx.send(event(1, 41)).unwrap(); // suppressed: no anchor yet
+        tx.send(snapshot(2, 42)).unwrap();
+        tx.send(event(3, 43)).unwrap();
+
+        let got = expect_event(subscription.next().await);
+        assert!(matches!(got.event, GameEvent::Snapshot { .. }));
+        assert_eq!(got.stream_seq, 42);
+
+        let got = expect_event(subscription.next().await);
+        assert_eq!(got.stream_seq, 43);
+    }
+
+    #[tokio::test]
+    async fn snapshot_reanchors_unconditionally_across_stream_epochs() {
+        let (tx, mut subscription) = test_subscription();
+        subscription.anchor(500);
 
         // A restarted executor begins a new stream: snapshot at stream_seq 2,
         // then ordinary events 3, 4. Without re-anchoring, ALL of these would
@@ -1024,24 +817,51 @@ mod tests {
         tx.send(event(8, 2)).unwrap(); // duplicate/stale vs the new anchor
         tx.send(event(9, 4)).unwrap();
 
-        let got = filtered.recv().await.unwrap();
+        let got = expect_event(subscription.next().await);
         assert!(matches!(got.event, GameEvent::Snapshot { .. }));
         assert_eq!(got.stream_seq, 2);
-
-        let got = filtered.recv().await.unwrap();
-        assert_eq!(got.stream_seq, 3);
-
-        // The stale seq-2 event is skipped; next delivered is 4.
-        let got = filtered.recv().await.unwrap();
-        assert_eq!(got.stream_seq, 4);
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 3);
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 4);
     }
 
     #[tokio::test]
-    async fn unsequenced_terminal_rejections_are_forwarded_out_of_band() {
+    async fn bridge_anchor_forwards_contiguous_deltas_without_a_live_snapshot() {
+        let (tx, mut subscription) = test_subscription();
+        subscription.anchor(100);
+
+        tx.send(event(1, 100)).unwrap(); // already folded into the bridge
+        tx.send(event(2, 101)).unwrap();
+        tx.send(event(3, 102)).unwrap();
+
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 101);
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 102);
+    }
+
+    #[tokio::test]
+    async fn gap_goes_cold_and_recovers_on_the_requested_snapshot() {
+        let (tx, mut subscription) = test_subscription();
+        subscription.anchor(100);
+
+        tx.send(event(1, 105)).unwrap(); // gap: 101..=104 lost
+        tx.send(event(2, 106)).unwrap(); // suppressed while cold
+        tx.send(snapshot(3, 107)).unwrap();
+        tx.send(event(4, 108)).unwrap();
+
+        assert!(matches!(
+            subscription.next().await,
+            Some(SubscriptionUpdate::WentCold)
+        ));
+        let got = expect_event(subscription.next().await);
+        assert!(matches!(got.event, GameEvent::Snapshot { .. }));
+        assert_eq!(got.stream_seq, 107);
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 108);
+    }
+
+    #[tokio::test]
+    async fn zero_seq_terminal_rejections_pass_even_while_cold() {
         use common::ClientCommandIdentityV2;
 
-        let (tx, rx) = broadcast::channel(16);
-        let mut filtered = FilteredEventReceiver::new(rx, 10, 1);
+        let (tx, mut subscription) = test_subscription();
 
         let mut rejection = event(0, 0);
         rejection.user_id = Some(7);
@@ -1056,113 +876,111 @@ mod tests {
             command_id_client: None,
             session_rejected_from: None,
         };
+        tx.send(event(1, 0)).unwrap(); // unsequenced state event: dropped
         tx.send(rejection).unwrap();
-        let got = filtered.recv().await.unwrap();
+
+        let got = expect_event(subscription.next().await);
         assert!(matches!(got.event, GameEvent::CommandRejected { .. }));
-        assert!(!is_stateful_unknown_event(&got));
-    }
-
-    #[test]
-    fn unknown_state_events_are_distinguished_from_out_of_band_rejections() {
-        assert!(is_stateful_unknown_event(&event(1, 1)));
-        assert!(is_stateful_unknown_event(&snapshot(1, 1)));
     }
 
     #[tokio::test]
-    async fn replica_snapshot_never_observes_state_without_its_watermark() {
-        let old_state = GameState::new(
-            60,
-            40,
-            GameType::TeamMatch { per_team: 1 },
-            QueueMode::Quickmatch,
-            None,
-            10,
-        );
-        let mut new_state = old_state.clone();
-        new_state.start_ms = 11;
+    async fn lagged_subscription_goes_cold_once_and_reanchors() {
+        let (tx, mut subscription) = test_subscription();
+        subscription.anchor(0);
 
-        let store: ReplicaStore = Arc::new(RwLock::new(HashMap::from([(
-            1,
-            ReplicatedGame {
-                game_state: old_state,
-                stream_seq: 10,
-            },
-        )])));
-        let state_is_updated = Arc::new(Barrier::new(2));
-        let finish_update = Arc::new(Barrier::new(2));
+        // Overflow the 16-slot channel so the receiver observes Lagged.
+        for stream_seq in 1..=40u64 {
+            tx.send(event(stream_seq, stream_seq)).unwrap();
+        }
+        assert!(matches!(
+            subscription.next().await,
+            Some(SubscriptionUpdate::WentCold)
+        ));
 
-        // Stop a writer at the exact old-race point: state S+1 has been
-        // written, but its watermark has not. The reader must remain blocked
-        // on the shared entry lock until the pair is complete.
-        let writer = {
-            let store = store.clone();
-            let state_is_updated = state_is_updated.clone();
-            let finish_update = finish_update.clone();
-            tokio::spawn(async move {
-                let mut replicas = store.write().await;
-                let replica = replicas.get_mut(&1).expect("replica");
-                replica.game_state = new_state;
-                state_is_updated.wait().await;
-                finish_update.wait().await;
-                replica.stream_seq = 11;
-            })
-        };
-
-        state_is_updated.wait().await;
-        let reader = {
-            let store = store.clone();
-            tokio::spawn(async move { replica_snapshot(&store, 1).await.expect("snapshot") })
-        };
-        tokio::task::yield_now().await;
-        assert!(
-            !reader.is_finished(),
-            "snapshot reader must not observe a half-updated replica entry"
-        );
-
-        finish_update.wait().await;
-        writer.await.expect("writer task");
-        let (observed_state, observed_stream_seq) = reader.await.expect("reader task");
-        assert_eq!(observed_state.start_ms, 11);
-        assert_eq!(observed_stream_seq, 11);
+        tx.send(snapshot(41, 41)).unwrap();
+        let got = expect_event(subscription.next().await);
+        assert!(matches!(got.event, GameEvent::Snapshot { .. }));
+        assert_eq!(got.stream_seq, 41);
     }
 
     #[tokio::test]
-    async fn readiness_waits_for_matching_barrier_after_applying_snapshot() -> anyhow::Result<()> {
+    async fn subscription_ends_when_the_channel_closes() {
+        let (tx, mut subscription) = test_subscription();
+        subscription.anchor(0);
+        tx.send(event(1, 1)).unwrap();
+        drop(tx);
+
+        assert_eq!(expect_event(subscription.next().await).stream_seq, 1);
+        assert!(subscription.next().await.is_none());
+    }
+
+    #[tokio::test]
+    async fn terminal_snapshot_is_forwarded_before_channel_teardown() {
+        let channels: GameEventBroadcasters = Default::default();
+        let manager = GameEventRouter {
+            workers: Vec::new(),
+            channels: channels.clone(),
+            statuses: Default::default(),
+            requester: Arc::new(SnapshotRequester::detached()),
+        };
+        let mut subscription = manager.subscribe_to_game(1).await;
+
+        super::forward_event(&channels, terminal_snapshot(1, 7)).await;
+
+        let got = expect_event(subscription.next().await);
+        assert_eq!(got.stream_seq, 7);
+        assert!(matches!(
+            got.event,
+            GameEvent::Snapshot { game_state }
+                if matches!(game_state.status, GameStatus::Complete { .. })
+        ));
+        assert!(subscription.next().await.is_none());
+        assert!(channels.read().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn abandoned_channels_are_pruned_without_disturbing_live_ones() {
+        let manager = GameEventRouter {
+            workers: Vec::new(),
+            channels: Default::default(),
+            statuses: Default::default(),
+            requester: Arc::new(SnapshotRequester::detached()),
+        };
+
+        let abandoned = manager.subscribe_to_game(7).await;
+        let _live = manager.subscribe_to_game(8).await;
+        drop(abandoned);
+
+        let _fresh = manager.subscribe_to_game(9).await;
+        let channels = manager.channels.read().await;
+        assert!(!channels.contains_key(&7), "abandoned channel pruned");
+        assert!(channels.contains_key(&8), "live channel retained");
+        assert!(channels.contains_key(&9));
+    }
+
+    #[tokio::test]
+    async fn readiness_waits_for_matching_barrier_and_forwards_preceding_snapshots()
+    -> anyhow::Result<()> {
         tokio::time::timeout(std::time::Duration::from_secs(10), async {
-            let client = redis::Client::open("redis://127.0.0.1:6379/9?protocol=resp3")?;
-            let (push_tx, _push_rx) = broadcast::channel(8);
-            let manager =
-                crate::redis_utils::create_connection_manager(client.clone(), push_tx).await?;
-            let token = CancellationToken::new();
-            let bus = Arc::new(GameBus::new(
-                manager.clone(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                manager.clone(),
-                manager,
-                client.clone(),
-                token.clone(),
-            )?);
+            let (bus, client, token) = test_bus(9).await;
             let partition = 1;
             let event_stream = RedisKeys::stream_events(partition);
             let request_stream = RedisKeys::stream_snapshot_requests(partition);
             let mut redis = client.get_multiplexed_async_connection().await?;
             let _: i64 = redis.del(&[&event_stream, &request_stream]).await?;
 
-            let replica_store: ReplicaStore = Arc::new(RwLock::new(HashMap::new()));
-            let replica = PartitionReplica::new(
-                partition,
-                bus,
-                replica_store.clone(),
-                Arc::new(RwLock::new(HashMap::new())),
-                token.clone(),
-            );
-            let status = replica.status();
-            let worker = tokio::spawn(replica.run());
+            let channels: GameEventBroadcasters = Default::default();
+            let manager = GameEventRouter {
+                workers: Vec::new(),
+                channels: channels.clone(),
+                statuses: Default::default(),
+                requester: Arc::new(SnapshotRequester::new(bus.clone())),
+            };
+            let mut subscription = manager.subscribe_to_game(1).await;
+
+            let worker = PartitionEventRouter::new(partition, bus, channels, token.clone());
+            let status = worker.status();
+            let worker = tokio::spawn(worker.run());
 
             let request = loop {
                 let entries: StreamRangeReply =
@@ -1192,14 +1010,17 @@ mod tests {
                 .query_async(&mut redis)
                 .await?;
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
-            assert!(!status.read().await.is_ready);
+            assert!(
+                !status.read().await.is_ready,
+                "a foreign barrier must not satisfy this boot's readiness proof"
+            );
 
-            let snapshot = snapshot(1, 1);
+            let pre_barrier_snapshot = snapshot(1, 1);
             let _: String = redis::cmd("XADD")
                 .arg(&event_stream)
                 .arg("*")
                 .arg("data")
-                .arg(serde_json::to_vec(&snapshot)?)
+                .arg(serde_json::to_vec(&pre_barrier_snapshot)?)
                 .query_async(&mut redis)
                 .await?;
             let _: String = redis::cmd("XADD")
@@ -1216,13 +1037,11 @@ mod tests {
                 }
                 tokio::time::sleep(std::time::Duration::from_millis(10)).await;
             }
-            let replicated = replica_store
-                .read()
-                .await
-                .get(&snapshot.game_id)
-                .cloned()
-                .expect("snapshot was applied before readiness");
-            assert_eq!(replicated.stream_seq, snapshot.stream_seq);
+
+            // The reader forwarded (not retained) the pre-barrier snapshot.
+            let got = expect_event(subscription.next().await);
+            assert!(matches!(got.event, GameEvent::Snapshot { .. }));
+            assert_eq!(got.stream_seq, pre_barrier_snapshot.stream_seq);
 
             token.cancel();
             worker.await??;
@@ -1230,218 +1049,5 @@ mod tests {
             Ok::<(), anyhow::Error>(())
         })
         .await?
-    }
-
-    #[tokio::test]
-    async fn terminal_snapshot_is_broadcast_before_replica_eviction() {
-        let client = redis::Client::open("redis://127.0.0.1:6379/1?protocol=resp3")
-            .expect("valid local Redis URL");
-        let (push_tx, _push_rx) = broadcast::channel(8);
-        let manager = crate::redis_utils::create_connection_manager(client.clone(), push_tx)
-            .await
-            .expect("local Redis is required for replication tests");
-        let bus = Arc::new(
-            GameBus::new(
-                manager.clone(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                manager.clone(),
-                manager,
-                client,
-                CancellationToken::new(),
-            )
-            .expect("test GameBus"),
-        );
-
-        let replica_store: ReplicaStore = Arc::new(RwLock::new(HashMap::new()));
-        let (event_tx, mut event_rx) = broadcast::channel(8);
-        let broadcasters: GameEventBroadcasters =
-            Arc::new(RwLock::new(HashMap::from([(1, event_tx)])));
-        let replica = PartitionReplica::new(
-            1,
-            bus,
-            replica_store.clone(),
-            broadcasters.clone(),
-            CancellationToken::new(),
-        );
-        let mut state = GameState::new(10, 10, GameType::Solo, QueueMode::Quickmatch, None, 0);
-        state.status = GameStatus::Complete {
-            winning_snake_id: None,
-        };
-        let terminal = GameEventMessage {
-            game_id: 1,
-            tick: state.tick,
-            sequence: state.event_sequence,
-            stream_seq: 1,
-            user_id: None,
-            event: GameEvent::Snapshot { game_state: state },
-        };
-
-        replica
-            .process_received_event(terminal.clone())
-            .await
-            .expect("terminal event processes");
-
-        let received = event_rx
-            .recv()
-            .await
-            .expect("existing receiver gets terminal snapshot");
-        assert_eq!(received.game_id, terminal.game_id);
-        assert_eq!(received.stream_seq, terminal.stream_seq);
-        assert!(matches!(
-            received.event,
-            GameEvent::Snapshot { game_state }
-                if matches!(game_state.status, GameStatus::Complete { .. })
-        ));
-        assert!(matches!(
-            event_rx.recv().await,
-            Err(broadcast::error::RecvError::Closed)
-        ));
-        assert!(replica_store.read().await.is_empty());
-        assert!(broadcasters.read().await.is_empty());
-    }
-
-    #[tokio::test]
-    async fn malformed_boost_messages_are_atomic_and_keep_replica_cold_until_valid_snapshot() {
-        let client = redis::Client::open("redis://127.0.0.1:6379/1?protocol=resp3")
-            .expect("valid local Redis URL");
-        let (push_tx, _push_rx) = broadcast::channel(8);
-        let manager = crate::redis_utils::create_connection_manager(client.clone(), push_tx)
-            .await
-            .expect("local Redis is required for replication tests");
-        let token = CancellationToken::new();
-        let bus = Arc::new(
-            GameBus::new(
-                manager.clone(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                (0..PARTITION_COUNT)
-                    .map(|_| manager.clone().into())
-                    .collect(),
-                manager.clone(),
-                manager,
-                client,
-                token.clone(),
-            )
-            .expect("test GameBus"),
-        );
-
-        let mut state = GameState::new(
-            60,
-            40,
-            GameType::TeamMatch { per_team: 1 },
-            QueueMode::Quickmatch,
-            None,
-            0,
-        );
-        state.add_player(7, None).expect("add player");
-        let game_id = 1;
-        let store: ReplicaStore = Arc::new(RwLock::new(HashMap::from([(
-            game_id,
-            ReplicatedGame {
-                game_state: state.clone(),
-                stream_seq: 10,
-            },
-        )])));
-        let (event_tx, mut event_rx) = broadcast::channel(8);
-        let replica = PartitionReplica::new(
-            1,
-            bus,
-            store.clone(),
-            Arc::new(RwLock::new(HashMap::from([(game_id, event_tx)]))),
-            token.clone(),
-        );
-        // Keep this unit test self-contained: malformed-state behavior still
-        // marks the game cold, while the already-recent request timestamp
-        // suppresses an external snapshot-request write.
-        replica.last_gap_request_ms.store(
-            chrono::Utc::now().timestamp_millis(),
-            std::sync::atomic::Ordering::Relaxed,
-        );
-        let before = serde_json::to_value(&state).unwrap();
-        let footprint_cell = state.arena.boost_pads[0].footprint_cells()[3];
-
-        let malformed_delta = GameEventMessage {
-            game_id,
-            tick: state.tick,
-            sequence: 1,
-            stream_seq: 11,
-            user_id: None,
-            event: GameEvent::FoodSpawned {
-                position: footprint_cell,
-            },
-        };
-        assert!(!replica.process_event(malformed_delta).await.unwrap());
-        let (observed, watermark) = replica_snapshot(&store, game_id).await.unwrap();
-        assert_eq!(serde_json::to_value(observed).unwrap(), before);
-        assert_eq!(watermark, 10);
-        assert!(replica.cold_games.read().await.contains(&game_id));
-        assert!(matches!(
-            event_rx.try_recv(),
-            Err(broadcast::error::TryRecvError::Empty)
-        ));
-
-        let mut malformed_state = state.clone();
-        malformed_state.arena.food.push(footprint_cell);
-        let malformed_snapshot = GameEventMessage {
-            game_id,
-            tick: malformed_state.tick,
-            sequence: 2,
-            stream_seq: 12,
-            user_id: None,
-            event: GameEvent::Snapshot {
-                game_state: malformed_state,
-            },
-        };
-        assert!(!replica.process_event(malformed_snapshot).await.unwrap());
-        assert!(replica.cold_games.read().await.contains(&game_id));
-        assert_eq!(replica_snapshot(&store, game_id).await.unwrap().1, 10);
-
-        let valid_snapshot = GameEventMessage {
-            game_id,
-            tick: state.tick,
-            sequence: 3,
-            stream_seq: 13,
-            user_id: None,
-            event: GameEvent::Snapshot { game_state: state },
-        };
-        assert!(replica.process_event(valid_snapshot).await.unwrap());
-        assert!(!replica.cold_games.read().await.contains(&game_id));
-        assert_eq!(replica_snapshot(&store, game_id).await.unwrap().1, 13);
-        assert!(matches!(
-            event_rx.recv().await.unwrap().event,
-            GameEvent::Snapshot { .. }
-        ));
-        token.cancel();
-    }
-
-    #[test]
-    fn stream_gap_suppresses_deltas_until_snapshot_reanchors() {
-        let mut cold_games = HashSet::new();
-
-        assert_eq!(
-            continuity_action(&mut cold_games, 1, 100, 105, false),
-            ContinuityAction::SuppressGap { expected: 101 }
-        );
-        assert!(cold_games.contains(&1));
-        assert_eq!(
-            continuity_action(&mut cold_games, 1, 100, 106, false),
-            ContinuityAction::SuppressWhileCold
-        );
-
-        assert_eq!(
-            continuity_action(&mut cold_games, 1, 100, 107, true),
-            ContinuityAction::Apply
-        );
-        assert!(!cold_games.contains(&1));
-        assert_eq!(
-            continuity_action(&mut cold_games, 1, 107, 108, false),
-            ContinuityAction::Apply
-        );
     }
 }

--- a/server/src/replication.rs
+++ b/server/src/replication.rs
@@ -116,6 +116,11 @@ enum Continuity {
 }
 
 /// What [`GameEventSubscription::next`] hands the forwarding loop.
+///
+/// This value is consumed immediately by the caller's `match` and never
+/// stored. Boxing the event would add a heap allocation to every live game
+/// event only to reduce stack padding on the cold `WentCold` arm.
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug)]
 pub enum SubscriptionUpdate {
     /// Forward this event to the socket.

--- a/server/src/resilience_metrics.rs
+++ b/server/src/resilience_metrics.rs
@@ -49,7 +49,6 @@ const MATCHMAKING_QUEUE_COUNT: usize = crate::matchmaking_manager::MATCHMAKING_G
 #[derive(Default)]
 struct Counters {
     fenced_write_rejections: AtomicU64,
-    recovery_fingerprint_divergences: AtomicU64,
     planned_drain_failures: AtomicU64,
     command_claims: AtomicU64,
     command_acks: AtomicU64,
@@ -137,10 +136,6 @@ macro_rules! counter_fn {
 }
 
 counter_fn!(record_fenced_write_rejection, fenced_write_rejections);
-counter_fn!(
-    record_recovery_fingerprint_divergence,
-    recovery_fingerprint_divergences
-);
 counter_fn!(record_planned_drain_failure, planned_drain_failures);
 counter_fn!(record_command_claims, command_claims);
 counter_fn!(record_command_acks, command_acks);
@@ -582,7 +577,6 @@ pub fn record_redis_request(latency: Duration, failed: bool) {
 #[derive(Default)]
 struct CounterSnapshot {
     fenced_write_rejections: u64,
-    recovery_fingerprint_divergences: u64,
     planned_drain_failures: u64,
     command_claims: u64,
     command_acks: u64,
@@ -658,9 +652,6 @@ fn take_counter_snapshot() -> CounterSnapshot {
     let counters = counters();
     CounterSnapshot {
         fenced_write_rejections: counters.fenced_write_rejections.swap(0, Ordering::Relaxed),
-        recovery_fingerprint_divergences: counters
-            .recovery_fingerprint_divergences
-            .swap(0, Ordering::Relaxed),
         planned_drain_failures: counters.planned_drain_failures.swap(0, Ordering::Relaxed),
         command_claims: counters.command_claims.swap(0, Ordering::Relaxed),
         command_acks: counters.command_acks.swap(0, Ordering::Relaxed),
@@ -1579,11 +1570,6 @@ fn emf_document(
         (
             "FencedWriteRejections",
             counters.fenced_write_rejections,
-            "Count",
-        ),
-        (
-            "RecoveryFingerprintDivergences",
-            counters.recovery_fingerprint_divergences,
             "Count",
         ),
         (

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -2383,6 +2383,58 @@ async fn notify_durable_active_game_after_auth(
     Ok(())
 }
 
+/// Publish a readiness confirmation once the game provably exists.
+///
+/// A hint-driven client can confirm readiness milliseconds after the
+/// matchmaking commit — before the outbox scanner has delivered `GameCreated`
+/// into the partition command stream. Publishing immediately would let the
+/// confirmation precede `GameCreated` in that stream and be quarantined as
+/// targeting an inactive game. The fenced recovery envelope is written by the
+/// same incorporation that creates the actor, so its existence is durable
+/// proof the confirmation can no longer outrun creation. The wait fails open
+/// at its deadline: a confirmation the executor cannot attribute costs the
+/// player nothing worse than waiting out the readiness deadline.
+async fn publish_player_ready_after_game_exists(
+    game_bus: Arc<GameBus>,
+    cluster_namespace: ClusterNamespace,
+    game_id: u32,
+    user_id: u32,
+) {
+    let partition_id = game_id % PARTITION_COUNT;
+    let deadline = tokio::time::Instant::now() + COLD_JOIN_WARMUP_TIMEOUT;
+    loop {
+        match game_bus.get_recovery(&cluster_namespace, game_id).await {
+            Ok(Some(_)) => break,
+            Ok(None) => {}
+            Err(error) => {
+                warn!(game_id, user_id, %error, "Failed to check game existence before readiness");
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            warn!(
+                game_id,
+                user_id, "Publishing readiness without game-existence proof after bounded wait"
+            );
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    let event = StreamEvent::PlayerReadySubmitted { game_id, user_id };
+    match game_bus
+        .publish_player_ready_unless_completed(&cluster_namespace, partition_id, game_id, &event)
+        .await
+    {
+        Ok(true) => {}
+        Ok(false) => {
+            debug!(game_id, user_id, "Readiness arrived after the game completed");
+        }
+        Err(error) => {
+            warn!(game_id, user_id, %error, "Failed to publish readiness confirmation");
+        }
+    }
+}
+
 fn recovery_bridge_snapshot(envelope: &RecoveryEnvelopeV2, user_id: u32) -> GameEventMessage {
     // Despite its historical name, `next_event_stream_sequence` is the last
     // sequence already emitted and checkpointed. The actor increments it
@@ -4502,31 +4554,16 @@ async fn process_ws_message(
                                 "Discarding untrusted game id on a readiness confirmation"
                             );
                         }
-                        let partition_id = game_id % PARTITION_COUNT;
-                        let event = StreamEvent::PlayerReadySubmitted { game_id, user_id };
-                        // A dropped confirmation costs the player nothing worse
-                        // than waiting out the readiness deadline, so unlike a
-                        // gameplay command this must not tear down the socket.
-                        match game_bus
-                            .publish_player_ready_unless_completed(
-                                cluster_namespace,
-                                partition_id,
-                                game_id,
-                                &event,
-                            )
-                            .await
-                        {
-                            Ok(true) => {}
-                            Ok(false) => {
-                                debug!(
-                                    game_id,
-                                    user_id, "Readiness arrived after the game completed"
-                                );
-                            }
-                            Err(error) => {
-                                warn!(game_id, user_id, %error, "Failed to publish readiness confirmation");
-                            }
-                        }
+                        // Runs detached: the game-existence wait below must not
+                        // stall this connection's message loop, and a dropped
+                        // confirmation costs the player nothing worse than
+                        // waiting out the readiness deadline.
+                        tokio::spawn(publish_player_ready_after_game_exists(
+                            game_bus.clone(),
+                            cluster_namespace.clone(),
+                            game_id,
+                            user_id,
+                        ));
                     } else {
                         warn!(
                             user_id = metadata.user_id,

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -2463,6 +2463,33 @@ async fn send_recovery_bridge_snapshot(
     ws_tx.send(Message::Text(json.into())).await.is_ok()
 }
 
+/// Load the game's durable terminal state, if one exists. Absence, failure,
+/// malformed data, or a non-terminal record all return `None`: none of those
+/// prove anything about a live game, so callers fall back to normal warm-up.
+async fn load_durable_terminal_state(db: &Arc<dyn Database>, game_id: u32) -> Option<GameState> {
+    let database_game_id = i32::try_from(game_id).ok()?;
+    match db.get_game_by_id(database_game_id).await {
+        Ok(Some(game)) => {
+            let game_state_json = game.game_state?;
+            match serde_json::from_value::<GameState>(game_state_json) {
+                Ok(game_state) if matches!(game_state.status, GameStatus::Complete { .. }) => {
+                    Some(game_state)
+                }
+                Ok(_) => None,
+                Err(error) => {
+                    warn!(game_id, %error, "Ignoring malformed durable game state during warm-up");
+                    None
+                }
+            }
+        }
+        Ok(None) => None,
+        Err(error) => {
+            warn!(game_id, %error, "Durable game lookup failed during warm-up");
+            None
+        }
+    }
+}
+
 /// How the join warm-up anchored the socket's first authoritative frame.
 enum FirstFrame {
     /// A frame was sent; enter the forwarding loop. `live_proven` is false
@@ -2532,6 +2559,25 @@ async fn anchor_first_frame(
             if !matches!(envelope.game_state.status, GameStatus::Complete { .. })
                 && game_state_records_user(&envelope.game_state, user_id) =>
         {
+            // Completion persistence can win the race with cleanup of the
+            // preceding active Redis state. The durable terminal record is
+            // the authority for a completed game, so a non-terminal envelope
+            // may bridge only after that record is confirmed absent or
+            // non-terminal — otherwise the client would be stranded on a
+            // stale active frame with no live stream behind it.
+            if let Some(terminal_state) = load_durable_terminal_state(db, game_id).await {
+                send_completed_game_snapshot(
+                    ws_tx,
+                    game_bus,
+                    cluster_namespace,
+                    game_id,
+                    user_id,
+                    &terminal_state,
+                    "database snapshot",
+                )
+                .await;
+                return FirstFrame::Served;
+            }
             if !send_recovery_bridge_snapshot(ws_tx, &envelope, user_id).await {
                 return FirstFrame::Unavailable;
             }

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -2427,7 +2427,10 @@ async fn publish_player_ready_after_game_exists(
     {
         Ok(true) => {}
         Ok(false) => {
-            debug!(game_id, user_id, "Readiness arrived after the game completed");
+            debug!(
+                game_id,
+                user_id, "Readiness arrived after the game completed"
+            );
         }
         Err(error) => {
             warn!(game_id, user_id, %error, "Failed to publish readiness confirmation");

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -1126,6 +1126,7 @@ async fn handle_websocket_connection(
                                         &lifecycle,
                                         socket_generation,
                                         &cluster_namespace,
+                                        &cancellation_token,
                                     ).await {
                                         Ok(mut new_state) => {
                                             // Check if we're entering a game or lobby
@@ -2394,16 +2395,29 @@ async fn notify_durable_active_game_after_auth(
 /// proof the confirmation can no longer outrun creation. The wait fails open
 /// at its deadline: a confirmation the executor cannot attribute costs the
 /// player nothing worse than waiting out the readiness deadline.
+///
+/// The wait deliberately outlives its socket — a player who confirms and
+/// immediately reconnects has still confirmed — but not its server: it is
+/// bound to the task cancellation token so shutdown cannot be raced by a
+/// publish on a retiring gateway's connections. Abandoning is safe because a
+/// drained client re-joins elsewhere and re-confirms well inside
+/// `MATCH_READY_WINDOW_MS`.
 async fn publish_player_ready_after_game_exists(
     game_bus: Arc<GameBus>,
     cluster_namespace: ClusterNamespace,
     game_id: u32,
     user_id: u32,
+    cancellation_token: CancellationToken,
 ) {
     let partition_id = game_id % PARTITION_COUNT;
     let deadline = tokio::time::Instant::now() + COLD_JOIN_WARMUP_TIMEOUT;
     loop {
-        match game_bus.get_recovery(&cluster_namespace, game_id).await {
+        let recovery = tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => return,
+            recovery = game_bus.get_recovery(&cluster_namespace, game_id) => recovery,
+        };
+        match recovery {
             Ok(Some(_)) => break,
             Ok(None) => {}
             Err(error) => {
@@ -2417,7 +2431,11 @@ async fn publish_player_ready_after_game_exists(
             );
             break;
         }
-        tokio::time::sleep(Duration::from_millis(100)).await;
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => return,
+            _ = tokio::time::sleep(Duration::from_millis(100)) => {}
+        }
     }
 
     let event = StreamEvent::PlayerReadySubmitted { game_id, user_id };
@@ -3736,6 +3754,7 @@ async fn process_ws_message(
     lifecycle: &TaskLifecycle,
     socket_generation: u64,
     cluster_namespace: &ClusterNamespace,
+    cancellation_token: &CancellationToken,
 ) -> Result<ConnectionState> {
     use tracing::debug;
     let state_str = match &state {
@@ -4612,6 +4631,7 @@ async fn process_ws_message(
                             cluster_namespace.clone(),
                             game_id,
                             user_id,
+                            cancellation_token.clone(),
                         ));
                     } else {
                         warn!(

--- a/server/src/ws_server.rs
+++ b/server/src/ws_server.rs
@@ -17,7 +17,6 @@ use crate::recovery::{
 };
 use crate::redis_keys::RedisKeys;
 use crate::redis_utils::RedisConnection;
-use crate::replication::GameStateReader;
 use crate::user_cache::UserCache;
 use anyhow::{Context, Result, anyhow};
 use chrono::Utc;
@@ -754,7 +753,7 @@ pub async fn handle_websocket(
     pubsub_manager: Arc<PubSubManager>,
     game_bus: Arc<GameBus>,
     matchmaking_manager: Arc<Mutex<MatchmakingManager>>,
-    replication_manager: Arc<crate::replication::ReplicationManager>,
+    event_router: Arc<crate::replication::GameEventRouter>,
     cancellation_token: CancellationToken,
     lobby_manager: Arc<crate::lobby_manager::LobbyManager>,
     region: String,
@@ -773,7 +772,7 @@ pub async fn handle_websocket(
         matchmaking_manager,
         jwt_verifier,
         cancellation_token,
-        replication_manager,
+        event_router,
         redis,
         redis_url,
         lobby_manager,
@@ -834,7 +833,7 @@ async fn handle_websocket_connection(
     matchmaking_manager: Arc<Mutex<MatchmakingManager>>,
     jwt_verifier: Arc<dyn JwtVerifier>,
     cancellation_token: CancellationToken,
-    replication_manager: Arc<crate::replication::ReplicationManager>,
+    event_router: Arc<crate::replication::GameEventRouter>,
     redis: RedisConnection,
     redis_url: String,
     lobby_manager: Arc<crate::lobby_manager::LobbyManager>,
@@ -1051,7 +1050,7 @@ async fn handle_websocket_connection(
                                             )
                                             .await;
                                             let ws_tx_clone = ws_tx.clone();
-                                            let replication_manager_clone = replication_manager.clone();
+                                            let event_router_clone = event_router.clone();
                                             let db_clone = db.clone();
                                             let game_bus_clone = game_bus.clone();
                                             let cluster_namespace_clone = cluster_namespace.clone();
@@ -1060,7 +1059,7 @@ async fn handle_websocket_connection(
                                                     resync_game_id,
                                                     user_id,
                                                     ws_tx_clone,
-                                                    replication_manager_clone,
+                                                    event_router_clone,
                                                     db_clone,
                                                     game_bus_clone,
                                                     cluster_namespace_clone,
@@ -1118,7 +1117,7 @@ async fn handle_websocket_connection(
                                         &ws_tx,
                                         &game_bus,
                                         &matchmaking_manager,
-                                        &replication_manager,
+                                        &event_router,
                                         &redis,
                                         &redis_url,
                                         &lobby_manager,
@@ -1161,7 +1160,7 @@ async fn handle_websocket_connection(
                                                     }
 
                                                     let ws_tx_clone = ws_tx.clone();
-                                                    let replication_manager_clone = replication_manager.clone();
+                                                    let event_router_clone = event_router.clone();
                                                     let db_clone = db.clone();
                                                     let game_bus_clone = game_bus.clone();
                                                     let cluster_namespace_clone = cluster_namespace.clone();
@@ -1171,7 +1170,7 @@ async fn handle_websocket_connection(
                                                             game_id,
                                                             user_id,
                                                             ws_tx_clone,
-                                                            replication_manager_clone,
+                                                            event_router_clone,
                                                             db_clone,
                                                             game_bus_clone,
                                                             cluster_namespace_clone,
@@ -1787,7 +1786,7 @@ type CommandOutcomeReplay =
 enum GameSubscriptionInput {
     SocketClosed,
     CommandOutcomes(Option<ResolvedCommandState>),
-    Event(Result<GameEventMessage, broadcast::error::RecvError>),
+    Update(Option<crate::replication::SubscriptionUpdate>),
 }
 
 fn start_command_outcome_replay(
@@ -1812,7 +1811,7 @@ async fn wait_for_command_outcome_replay(
 
 async fn next_game_subscription_input(
     ws_tx: &mpsc::Sender<Message>,
-    rx: &mut crate::replication::FilteredEventReceiver,
+    subscription: &mut crate::replication::GameEventSubscription,
     replay: &mut Option<CommandOutcomeReplay>,
 ) -> GameSubscriptionInput {
     tokio::select! {
@@ -1820,7 +1819,7 @@ async fn next_game_subscription_input(
         outcomes = wait_for_command_outcome_replay(replay) => {
             GameSubscriptionInput::CommandOutcomes(outcomes)
         }
-        event = rx.recv() => GameSubscriptionInput::Event(event),
+        update = subscription.next() => GameSubscriptionInput::Update(update),
     }
 }
 
@@ -1837,7 +1836,7 @@ enum GameJoinAuthorizationError {
 impl std::fmt::Display for GameJoinAuthorizationError {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Warming => formatter.write_str("game replica is warming"),
+            Self::Warming => formatter.write_str("game stream is warming"),
             Self::Denied(reason) => formatter.write_str(reason),
         }
     }
@@ -1934,48 +1933,37 @@ async fn has_durable_recovery_failure(
 }
 
 /// A targeted snapshot request can be missed while no executor owns the
-/// partition. Keep requesting this game through the bounded takeover window.
-async fn wait_for_live_game_after_snapshot_request(
+/// partition, and a just-committed match has no recovery envelope until its
+/// `GameCreated` is consumed and checkpointed. Keep requesting the game and
+/// polling the fenced envelope through the bounded takeover window; the
+/// envelope is the only authoritative state a gateway can read directly.
+async fn wait_for_authoritative_state_after_snapshot_request(
     game_id: u32,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     game_bus: &Arc<GameBus>,
     cluster_namespace: &ClusterNamespace,
 ) -> Option<GameState> {
     let partition_id = game_id % PARTITION_COUNT;
     let deadline = tokio::time::Instant::now() + COLD_JOIN_WARMUP_TIMEOUT;
-    let mut next_snapshot_request_at = tokio::time::Instant::now();
-    let mut check_recovery = true;
 
     loop {
-        if let Some(game_state) = replication_manager.get_game_state_when_ready(game_id).await {
-            return Some(game_state);
+        // The router coalesces to one publish per game per 500 ms across
+        // every caller on this gateway.
+        if let Err(error) = event_router.request_game_snapshot(game_id).await {
+            warn!(game_id, partition_id, %error, "Failed to request cold-join snapshot");
         }
+
+        match game_bus.get_recovery(cluster_namespace, game_id).await {
+            Ok(Some(envelope)) => return Some(envelope.game_state),
+            Ok(None) => {}
+            Err(error) => {
+                warn!(game_id, %error, "Failed to load recovery during cold-join warm-up");
+            }
+        }
+
         if tokio::time::Instant::now() >= deadline {
             return None;
         }
-
-        let now = tokio::time::Instant::now();
-        if now >= next_snapshot_request_at {
-            next_snapshot_request_at = now + Duration::from_millis(500);
-            match replication_manager.request_game_snapshot(game_id).await {
-                Ok(()) => check_recovery = true,
-                Err(error) => {
-                    warn!(game_id, partition_id, %error, "Failed to request cold-join snapshots");
-                }
-            }
-        }
-
-        if check_recovery {
-            match game_bus.get_recovery(cluster_namespace, game_id).await {
-                Ok(Some(envelope)) => return Some(envelope.game_state),
-                Ok(None) => {}
-                Err(error) => {
-                    warn!(game_id, %error, "Failed to load recovery during cold-join warm-up");
-                }
-            }
-            check_recovery = false;
-        }
-
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
 }
@@ -2013,18 +2001,36 @@ fn command_outcomes_for_user(
         .collect()
 }
 
+/// Returns whether the durable `ActiveMatch` roster records this user as a
+/// participant (player or lobby-split spectator). The roster is written
+/// atomically at match commit, so it authorizes matchmade joins without any
+/// game-state read. Legacy and custom games have no roster and fall through
+/// to the recovery envelope.
+fn active_match_records_user(active_match: Option<&ActiveMatch>, user_id: u32) -> bool {
+    active_match.is_some_and(|active_match| {
+        active_match
+            .players
+            .iter()
+            .chain(active_match.spectators.iter())
+            .any(|player| player.user_id == user_id)
+    })
+}
+
 /// Resolve and authorize a JoinGame request before it changes connection state.
 ///
-/// Live games are authoritative in replication memory. Completed games may instead live in the
-/// short Redis reload cache or DynamoDB. Returning success means the requested user was present in
-/// the canonical state from one of those sources; callers may then enable game events and chat.
+/// Gateways hold no game state, so authorization comes from durable sources
+/// only: the `ActiveMatch` roster for matchmade games, the fenced recovery
+/// envelope for anything live, and the short Redis reload cache or DynamoDB
+/// for completed games. Returning success means the requested user was present
+/// in one of those canonical sources; callers may then enable game events and
+/// chat.
 #[allow(clippy::too_many_arguments)]
 async fn authorize_game_join_inner(
     game_id: u32,
     user_id: u32,
     matchmaking_pool: MatchmakingPool,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     game_bus: &Arc<GameBus>,
     cluster_namespace: &ClusterNamespace,
     db: &Arc<dyn Database>,
@@ -2037,16 +2043,8 @@ async fn authorize_game_join_inner(
         })?;
     validate_game_matchmaking_pool(matchmaking_pool, active_match.as_ref())?;
 
-    if let Some(game_state) = replication_manager.get_game_state_when_ready(game_id).await {
-        if game_state_records_user(&game_state, user_id) {
-            return Ok(());
-        }
-
-        warn!(
-            "Denied live game {} join to user {}: user is not a recorded participant",
-            game_id, user_id
-        );
-        return Err(game_join_denied("This game is unavailable"));
+    if active_match_records_user(active_match.as_ref(), user_id) {
+        return Ok(());
     }
 
     if has_durable_recovery_failure(game_id, game_bus, cluster_namespace).await {
@@ -2055,11 +2053,10 @@ async fn authorize_game_join_inner(
         ));
     }
 
-    // During executor failover the authoritative recovery envelope can be
-    // available before this gateway's replica has consumed the takeover
-    // snapshot. It is sufficient for participant authorization; the event
-    // subscription below still waits for a fresh replica or uses this same
-    // recovery snapshot as its bridge.
+    // The fenced recovery envelope is the authoritative participant record
+    // for live games without a roster (legacy/custom), and for any user the
+    // roster does not list. The event subscription later uses this same
+    // envelope as its bridge snapshot.
     match game_bus.get_recovery(cluster_namespace, game_id).await {
         Ok(Some(envelope)) => {
             if game_state_records_user(&envelope.game_state, user_id) {
@@ -2077,7 +2074,7 @@ async fn authorize_game_join_inner(
         }
     }
 
-    let cached_active_state = match replication_manager.get_stored_snapshot(game_id).await {
+    let cached_active_state = match event_router.get_stored_snapshot(game_id).await {
         Ok(Some(game_state)) if matches!(game_state.status, GameStatus::Complete { .. }) => {
             if game_state_records_user(&game_state, user_id) {
                 return Ok(());
@@ -2148,10 +2145,11 @@ async fn authorize_game_join_inner(
 
     // Repeat the request while waiting: a request written during the lease gap
     // is intentionally not relied upon. This also covers the short interval
-    // after atomic matchmaking commit but before GameCreated is consumed.
-    if let Some(live_game_state) = wait_for_live_game_after_snapshot_request(
+    // after atomic matchmaking commit but before GameCreated is consumed and
+    // its initial envelope checkpointed.
+    if let Some(live_game_state) = wait_for_authoritative_state_after_snapshot_request(
         game_id,
-        replication_manager,
+        event_router,
         game_bus,
         cluster_namespace,
     )
@@ -2261,7 +2259,7 @@ async fn authorize_game_join(
     user_id: u32,
     matchmaking_pool: MatchmakingPool,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     game_bus: &Arc<GameBus>,
     cluster_namespace: &ClusterNamespace,
     db: &Arc<dyn Database>,
@@ -2273,7 +2271,7 @@ async fn authorize_game_join(
             user_id,
             matchmaking_pool,
             matchmaking_manager,
-            replication_manager,
+            event_router,
             game_bus,
             cluster_namespace,
             db,
@@ -2304,7 +2302,7 @@ async fn notify_durable_active_game_after_auth(
     matchmaking_pool: MatchmakingPool,
     ws_tx: &mpsc::Sender<Message>,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     game_bus: &Arc<GameBus>,
     cluster_namespace: &ClusterNamespace,
     db: &Arc<dyn Database>,
@@ -2337,7 +2335,7 @@ async fn notify_durable_active_game_after_auth(
         user_id,
         matchmaking_pool,
         matchmaking_manager,
-        replication_manager,
+        event_router,
         game_bus,
         cluster_namespace,
         db,
@@ -2413,30 +2411,209 @@ async fn send_recovery_bridge_snapshot(
     ws_tx.send(Message::Text(json.into())).await.is_ok()
 }
 
-async fn send_recovery_bridge_if_available(
+/// How the join warm-up anchored the socket's first authoritative frame.
+enum FirstFrame {
+    /// A frame was sent; enter the forwarding loop. `live_proven` is false
+    /// when the frame was the recovery-envelope bridge: the command-outcome
+    /// replay (whose `CommandOutcomesComplete` barrier is a make-before-break
+    /// promotion signal) must then wait for the first live event, so a
+    /// candidate socket never retires the old usable socket for a bridge that
+    /// might have no subsequent event stream.
+    Anchored { live_proven: bool },
+    /// The game is durably complete and was fully served; end the task.
+    Served,
+    /// No authoritative frame arrived in the bounded window; the client was
+    /// told to retry (or that the game failed) and the task ends.
+    Unavailable,
+}
+
+/// Produce the socket's first authoritative frame and anchor the subscription.
+///
+/// Order of preference: the durable terminal snapshot (completed reload), the
+/// fenced recovery-envelope bridge (bounded staleness of one checkpoint
+/// interval, anchors contiguous live deltas immediately), then a live
+/// `Snapshot` arriving through the already-registered subscription. If none
+/// arrives inside the bounded window, fall back to the database for terminal
+/// state, else tell the client to retry with `GameWarming`.
+#[allow(clippy::too_many_arguments)]
+async fn anchor_first_frame(
     game_id: u32,
     user_id: u32,
     ws_tx: &mpsc::Sender<Message>,
+    subscription: &mut crate::replication::GameEventSubscription,
+    event_router: &Arc<crate::replication::GameEventRouter>,
+    db: &Arc<dyn Database>,
     game_bus: &Arc<GameBus>,
     cluster_namespace: &ClusterNamespace,
-) -> bool {
+) -> FirstFrame {
+    // Completed games have no live event flow to wait for; serve the durable
+    // terminal snapshot immediately.
+    match event_router.get_stored_snapshot(game_id).await {
+        Ok(Some(game_state))
+            if matches!(game_state.status, GameStatus::Complete { .. })
+                && game_state_records_user(&game_state, user_id) =>
+        {
+            send_completed_game_snapshot(
+                ws_tx,
+                game_bus,
+                cluster_namespace,
+                game_id,
+                user_id,
+                &game_state,
+                "stored Redis snapshot",
+            )
+            .await;
+            return FirstFrame::Served;
+        }
+        Ok(_) => {}
+        Err(error) => {
+            warn!(game_id, %error, "Failed to inspect stored snapshot during warm-up");
+        }
+    }
+
+    // Bridge from the fenced recovery envelope: an immediate first frame with
+    // a trusted watermark. Contiguous live deltas then forward without any
+    // extra snapshot; a lost event in between surfaces as a gap and re-anchors
+    // through the targeted-request path.
     match game_bus.get_recovery(cluster_namespace, game_id).await {
         Ok(Some(envelope))
             if !matches!(envelope.game_state.status, GameStatus::Complete { .. })
                 && game_state_records_user(&envelope.game_state, user_id) =>
         {
-            // Bridge the replica warm-up window immediately from the fenced
-            // recovery envelope, then attach to the live replica. Deliberately
-            // withhold CommandOutcomesComplete until that live subscription
-            // exists: a planned replacement socket treats the barrier as its
-            // promotion signal and must not retire the old usable socket for a
-            // bridge that might have no subsequent event stream.
-            send_recovery_bridge_snapshot(ws_tx, &envelope, user_id).await
+            if !send_recovery_bridge_snapshot(ws_tx, &envelope, user_id).await {
+                return FirstFrame::Unavailable;
+            }
+            subscription.anchor(envelope.next_event_stream_sequence);
+            return FirstFrame::Anchored { live_proven: false };
         }
-        Ok(_) => false,
+        Ok(_) => {}
         Err(error) => {
-            warn!(game_id, user_id, %error, "Failed to load recovery during replica warm-up");
-            false
+            warn!(game_id, user_id, %error, "Failed to load recovery during warm-up");
+        }
+    }
+
+    // No envelope yet (creation race or ownership gap). Request a targeted
+    // snapshot and wait for the live stream to anchor us; the subscription
+    // re-paces the request internally while cold.
+    if let Err(error) = event_router.request_game_snapshot(game_id).await {
+        warn!(game_id, %error, "Failed to request warm-up snapshot");
+    }
+    let warmup = tokio::time::timeout(COLD_JOIN_WARMUP_TIMEOUT, async {
+        loop {
+            match subscription.next().await {
+                Some(crate::replication::SubscriptionUpdate::Event(event_msg)) => {
+                    if matches!(event_msg.event, GameEvent::Snapshot { .. }) {
+                        break Some(event_msg);
+                    }
+                    // A zero-seq terminal rejection still reaches the player
+                    // during warm-up; nothing else passes while cold.
+                    let json = serde_json::to_string(&WSMessage::GameEvent(event_msg)).unwrap();
+                    if ws_tx.send(Message::Text(json.into())).await.is_err() {
+                        break None;
+                    }
+                }
+                Some(crate::replication::SubscriptionUpdate::WentCold) => {}
+                None => break None,
+            }
+        }
+    })
+    .await;
+
+    if let Ok(Some(mut snapshot_event)) = warmup {
+        snapshot_event.user_id = Some(user_id);
+        let terminal = matches!(
+            &snapshot_event.event,
+            GameEvent::Snapshot { game_state }
+                if matches!(game_state.status, GameStatus::Complete { .. })
+        );
+        let json = serde_json::to_string(&WSMessage::GameEvent(snapshot_event)).unwrap();
+        if ws_tx.send(Message::Text(json.into())).await.is_err() {
+            return FirstFrame::Unavailable;
+        }
+        if terminal {
+            if send_command_outcomes(
+                ws_tx,
+                game_bus,
+                cluster_namespace,
+                game_id,
+                user_id,
+                Some(TERMINAL_COMMAND_REJECTION_REASON),
+            )
+            .await
+            {
+                info!(game_id, "Warm-up reached terminal state directly");
+            }
+            return FirstFrame::Served;
+        }
+        return FirstFrame::Anchored { live_proven: true };
+    }
+
+    // Nothing live arrived. Durably completed games remain readable from the
+    // database after their Redis grace period.
+    let Ok(database_game_id) = i32::try_from(game_id) else {
+        warn!("Game ID {} is outside the durable database range", game_id);
+        send_game_load_failed(ws_tx, game_id, "This game was not found or has expired").await;
+        return FirstFrame::Unavailable;
+    };
+    match db.get_game_by_id(database_game_id).await {
+        Ok(Some(game)) => {
+            if let Some(game_state_json) = game.game_state {
+                match serde_json::from_value::<GameState>(game_state_json) {
+                    Ok(game_state) if matches!(game_state.status, GameStatus::Complete { .. }) => {
+                        send_completed_game_snapshot(
+                            ws_tx,
+                            game_bus,
+                            cluster_namespace,
+                            game_id,
+                            user_id,
+                            &game_state,
+                            "database snapshot",
+                        )
+                        .await;
+                        return FirstFrame::Served;
+                    }
+                    Ok(_) => {
+                        info!(
+                            game_id,
+                            "Durable game is non-terminal with no live stream; returning retryable warm-up"
+                        );
+                        send_game_warming(ws_tx, game_id).await;
+                        return FirstFrame::Unavailable;
+                    }
+                    Err(e) => {
+                        error!("Failed to deserialize game state from database: {}", e);
+                        send_game_load_failed(
+                            ws_tx,
+                            game_id,
+                            "The saved game data could not be loaded",
+                        )
+                        .await;
+                        return FirstFrame::Unavailable;
+                    }
+                }
+            }
+            info!(
+                game_id,
+                "Durable game has no terminal state and no live stream; returning retryable warm-up"
+            );
+            send_game_warming(ws_tx, game_id).await;
+            FirstFrame::Unavailable
+        }
+        Ok(None) => {
+            // Authorization already proved this game from durable evidence.
+            // Missing completion persistence here is therefore a failover
+            // race, not definitive proof that it expired.
+            info!(
+                game_id,
+                "Authorized game is not yet durable and has no live stream; returning retryable warm-up"
+            );
+            send_game_warming(ws_tx, game_id).await;
+            FirstFrame::Unavailable
+        }
+        Err(e) => {
+            error!("Failed to fetch game {} from database: {}", game_id, e);
+            send_game_warming(ws_tx, game_id).await;
+            FirstFrame::Unavailable
         }
     }
 }
@@ -2446,7 +2623,7 @@ async fn subscribe_to_game_events(
     game_id: u32,
     user_id: u32,
     ws_tx: mpsc::Sender<Message>,
-    replication_manager: Arc<crate::replication::ReplicationManager>,
+    event_router: Arc<crate::replication::GameEventRouter>,
     db: Arc<dyn Database>,
     game_bus: Arc<GameBus>,
     cluster_namespace: ClusterNamespace,
@@ -2456,272 +2633,47 @@ async fn subscribe_to_game_events(
         game_id, user_id
     );
 
-    let mut initial_subscription = replication_manager.subscribe_to_game(game_id).await;
-    if initial_subscription.is_err() {
-        let partition_id = game_id % PARTITION_COUNT;
-        if let Err(error) = replication_manager.request_game_snapshot(game_id).await {
-            warn!(game_id, partition_id, %error, "Failed to request subscription snapshots");
-        }
-        let mut next_snapshot_request_at = tokio::time::Instant::now() + Duration::from_millis(500);
+    // Register the receiver BEFORE any snapshot work: a broadcast receiver
+    // only sees messages sent after it exists, so subscribing first
+    // guarantees no event between first frame and subscription can be
+    // missed; the subscription's continuity rules drop the overlap instead.
+    let mut subscription = event_router.subscribe_to_game(game_id).await;
 
-        let mut recovery_bridge_sent = send_recovery_bridge_if_available(
-            game_id,
-            user_id,
-            &ws_tx,
-            &game_bus,
-            &cluster_namespace,
-        )
-        .await;
-
-        // Completed games intentionally leave replication memory. Avoid
-        // spending the takeover wait on a game that already has its terminal
-        // Redis snapshot.
-        match replication_manager.get_stored_snapshot(game_id).await {
-            Ok(Some(game_state))
-                if matches!(game_state.status, GameStatus::Complete { .. })
-                    && game_state_records_user(&game_state, user_id) =>
-            {
-                send_completed_game_snapshot(
-                    &ws_tx,
-                    &game_bus,
-                    &cluster_namespace,
-                    game_id,
-                    user_id,
-                    &game_state,
-                    "stored Redis snapshot",
-                )
-                .await;
-                return;
-            }
-            Ok(_) => {}
-            Err(error) => {
-                warn!(game_id, %error, "Failed to inspect stored snapshot during warm-up");
-            }
-        }
-
-        // Reissue requests throughout the lease gap. A request appended before
-        // the new owner anchors its request reader is not a correctness signal.
-        let deadline = tokio::time::Instant::now() + COLD_JOIN_WARMUP_TIMEOUT;
-        while initial_subscription.is_err() && tokio::time::Instant::now() < deadline {
-            tokio::time::sleep(Duration::from_millis(100)).await;
-            initial_subscription = replication_manager.subscribe_to_game(game_id).await;
-            if initial_subscription.is_ok() {
-                break;
-            }
-
-            let now = tokio::time::Instant::now();
-            if now >= next_snapshot_request_at {
-                next_snapshot_request_at = now + Duration::from_millis(500);
-                match replication_manager.request_game_snapshot(game_id).await {
-                    Ok(()) if !recovery_bridge_sent => {
-                        recovery_bridge_sent = send_recovery_bridge_if_available(
-                            game_id,
-                            user_id,
-                            &ws_tx,
-                            &game_bus,
-                            &cluster_namespace,
-                        )
-                        .await;
-                    }
-                    Ok(()) => {}
-                    Err(error) => {
-                        warn!(game_id, partition_id, %error, "Failed to retry subscription snapshots");
-                    }
-                }
-            }
-        }
-    }
-
-    let (game_state, stream_watermark, mut rx) = match initial_subscription {
-        Ok(result) => result,
-        Err(e) => {
-            // Durably completed games are eventually evicted from replication memory. Their
-            // final snapshot remains in Redis briefly, so check that grace-period cache before
-            // the durable database fallback.
-            info!(
-                "Failed to subscribe to game {} from memory, checking stored snapshot: {}",
-                game_id, e
-            );
-
-            match replication_manager.get_stored_snapshot(game_id).await {
-                Ok(Some(game_state))
-                    if matches!(game_state.status, GameStatus::Complete { .. }) =>
-                {
-                    send_completed_game_snapshot(
-                        &ws_tx,
-                        &game_bus,
-                        &cluster_namespace,
-                        game_id,
-                        user_id,
-                        &game_state,
-                        "stored Redis snapshot",
-                    )
-                    .await;
-                    return;
-                }
-                Ok(Some(_)) => {
-                    // During a rolling deploy or a failed terminal cache write, Redis can still
-                    // contain the preceding active snapshot. Prefer the durable completed record
-                    // instead of stranding the client on a stale, non-terminal frame with no live
-                    // subscription.
-                    debug!(
-                        "Ignoring non-complete stored Redis snapshot for game {}, checking database",
-                        game_id
-                    );
-                }
-                Ok(None) => {
-                    debug!("No stored Redis snapshot found for game {}", game_id);
-                }
-                Err(e) => {
-                    warn!(
-                        "Failed to load stored Redis snapshot for game {}, checking database: {}",
-                        game_id, e
-                    );
-                }
-            }
-
-            let Ok(database_game_id) = i32::try_from(game_id) else {
-                warn!("Game ID {} is outside the durable database range", game_id);
-                send_game_load_failed(&ws_tx, game_id, "This game was not found or has expired")
-                    .await;
-                return;
-            };
-
-            match db.get_game_by_id(database_game_id).await {
-                Ok(Some(game)) => {
-                    if let Some(game_state_json) = game.game_state {
-                        match serde_json::from_value::<GameState>(game_state_json) {
-                            Ok(game_state)
-                                if matches!(game_state.status, GameStatus::Complete { .. }) =>
-                            {
-                                send_completed_game_snapshot(
-                                    &ws_tx,
-                                    &game_bus,
-                                    &cluster_namespace,
-                                    game_id,
-                                    user_id,
-                                    &game_state,
-                                    "database snapshot",
-                                )
-                                .await;
-
-                                // Return early - we can't subscribe to future events without memory state
-                                return;
-                            }
-                            Ok(_) => {
-                                info!(
-                                    game_id,
-                                    "Durable game is non-terminal while its replica is unavailable; returning retryable warm-up"
-                                );
-                                send_game_warming(&ws_tx, game_id).await;
-                                return;
-                            }
-                            Err(e) => {
-                                error!("Failed to deserialize game state from database: {}", e);
-                                send_game_load_failed(
-                                    &ws_tx,
-                                    game_id,
-                                    "The saved game data could not be loaded",
-                                )
-                                .await;
-                                return;
-                            }
-                        }
-                    } else {
-                        info!(
-                            game_id,
-                            "Durable game has no terminal state while its replica is unavailable; returning retryable warm-up"
-                        );
-                        send_game_warming(&ws_tx, game_id).await;
-                        return;
-                    }
-                }
-                Ok(None) => {
-                    // Authorization already proved this game from live/recovery
-                    // state. Missing completion persistence here is therefore a
-                    // failover race, not definitive evidence that it expired.
-                    info!(
-                        game_id,
-                        "Authorized game is not yet durable while its replica is unavailable; returning retryable warm-up"
-                    );
-                    send_game_warming(&ws_tx, game_id).await;
-                    return;
-                }
-                Err(e) => {
-                    error!("Failed to fetch game {} from database: {}", game_id, e);
-                    send_game_warming(&ws_tx, game_id).await;
-                    return;
-                }
-            }
-        }
-    };
-
-    if matches!(game_state.status, GameStatus::Complete { .. }) {
-        send_completed_game_snapshot(
-            &ws_tx,
-            &game_bus,
-            &cluster_namespace,
-            game_id,
-            user_id,
-            &game_state,
-            "replication cache",
-        )
-        .await;
-        return;
-    }
-
-    // Send the snapshot, stamped with the replica's transport watermark so
-    // the client's gap detection starts from the right point.
-    let snapshot_event = GameEventMessage {
+    let anchor_result = anchor_first_frame(
         game_id,
-        tick: game_state.tick,
-        sequence: 0,
-        stream_seq: stream_watermark,
-        user_id: Some(user_id),
-        event: GameEvent::Snapshot {
-            game_state: game_state.clone(),
-        },
+        user_id,
+        &ws_tx,
+        &mut subscription,
+        &event_router,
+        &db,
+        &game_bus,
+        &cluster_namespace,
+    )
+    .await;
+    let mut live_proven = match anchor_result {
+        FirstFrame::Anchored { live_proven } => live_proven,
+        FirstFrame::Served | FirstFrame::Unavailable => return,
     };
-    let json = serde_json::to_string(&WSMessage::GameEvent(snapshot_event)).unwrap();
-    if let Err(e) = ws_tx.try_send(Message::Text(json.into())) {
-        match e {
-            mpsc::error::TrySendError::Full(msg) => {
-                warn!(
-                    "WebSocket send channel full (capacity 1024) for game {}, blocking send",
-                    game_id
-                );
-                if ws_tx.send(msg).await.is_err() {
-                    error!(
-                        "WebSocket send channel closed for game {}, stopping event subscription",
-                        game_id
-                    );
-                    return;
-                }
-            }
-            mpsc::error::TrySendError::Closed(_) => {
-                debug!(
-                    "WebSocket send channel closed for game {}, stopping event subscription",
-                    game_id
-                );
-                return;
-            }
-        }
-    }
 
     // Loading recovery outcomes can take several bounded Redis attempts. Keep
     // that I/O concurrent with the live broadcast receiver so a fresh
     // snapshot never stalls CommandScheduled delivery. The replay result still
     // returns through this one forwarding loop, which preserves socket order.
-    let mut command_outcome_replay = Some(start_command_outcome_replay(
-        game_bus.clone(),
-        cluster_namespace.clone(),
-        game_id,
-        user_id,
-    ));
+    // A bridge-anchored socket starts the replay only once the first live
+    // event proves the stream flows (see `FirstFrame::Anchored`).
+    let mut command_outcome_replay = live_proven.then(|| {
+        start_command_outcome_replay(
+            game_bus.clone(),
+            cluster_namespace.clone(),
+            game_id,
+            user_id,
+        )
+    });
 
     loop {
         let input =
-            next_game_subscription_input(&ws_tx, &mut rx, &mut command_outcome_replay).await;
+            next_game_subscription_input(&ws_tx, &mut subscription, &mut command_outcome_replay)
+                .await;
         let event_msg = match input {
             GameSubscriptionInput::SocketClosed => {
                 debug!(
@@ -2745,117 +2697,34 @@ async fn subscribe_to_game_events(
                 }
                 continue;
             }
-            GameSubscriptionInput::Event(Ok(event_msg)) => event_msg,
-            GameSubscriptionInput::Event(Err(
-                tokio::sync::broadcast::error::RecvError::Lagged(skipped),
+            GameSubscriptionInput::Update(Some(crate::replication::SubscriptionUpdate::Event(
+                event_msg,
+            ))) => event_msg,
+            GameSubscriptionInput::Update(Some(
+                crate::replication::SubscriptionUpdate::WentCold,
             )) => {
-                // Any barrier for the old snapshot is now stale. Dropping the
-                // in-flight future cancels its Redis read; only the replay
-                // paired with the replacement snapshot may emit a barrier.
+                // The subscription lost continuity (gap or broadcast lag) and
+                // already paced a targeted snapshot request; nothing is
+                // forwarded until the fresh snapshot re-anchors the client.
+                // Any barrier for the previous snapshot is now stale, and
+                // dropping the in-flight future cancels its Redis read; only
+                // the replay paired with the replacement snapshot may emit a
+                // barrier.
                 drop(command_outcome_replay.take());
-
-                // This connection fell behind the broadcast and lost events.
-                // Recover by sending a fresh snapshot (with its watermark) so
-                // the client re-anchors instead of silently diverging.
-                warn!(
-                    "Event forwarder for game {} (user {}) lagged, {} events lost; resyncing client with fresh snapshot",
-                    game_id, user_id, skipped
-                );
-                match replication_manager.subscribe_to_game(game_id).await {
-                    Ok((state, watermark, new_rx)) => {
-                        rx = new_rx;
-                        let terminal = matches!(state.status, GameStatus::Complete { .. });
-                        let resync = GameEventMessage {
-                            game_id,
-                            tick: state.tick,
-                            sequence: 0,
-                            stream_seq: watermark,
-                            user_id: Some(user_id),
-                            event: GameEvent::Snapshot { game_state: state },
-                        };
-                        let json = serde_json::to_string(&WSMessage::GameEvent(resync)).unwrap();
-                        if ws_tx.send(Message::Text(json.into())).await.is_err() {
-                            debug!(
-                                "WebSocket send channel closed for game {} during lag resync",
-                                game_id
-                            );
-                            return;
-                        }
-                        if terminal {
-                            if !send_command_outcomes(
-                                &ws_tx,
-                                &game_bus,
-                                &cluster_namespace,
-                                game_id,
-                                user_id,
-                                Some(TERMINAL_COMMAND_REJECTION_REASON),
-                            )
-                            .await
-                            {
-                                return;
-                            }
-                            info!(
-                                game_id,
-                                "Lag resync reached terminal state after durable outcome replay"
-                            );
-                            return;
-                        }
-                        command_outcome_replay = Some(start_command_outcome_replay(
-                            game_bus.clone(),
-                            cluster_namespace.clone(),
-                            game_id,
-                            user_id,
-                        ));
-                        continue;
-                    }
-                    Err(e) => {
-                        // Game likely completed and was evicted mid-lag.
-                        error!(
-                            "Failed to resubscribe to game {} after lag: {}; ending subscription",
-                            game_id, e
-                        );
-                        return;
-                    }
-                }
+                continue;
             }
-            GameSubscriptionInput::Event(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+            GameSubscriptionInput::Update(None) => {
                 drop(command_outcome_replay.take());
-                // Broadcaster dropped. If the game is still live in the
-                // replica, hand the client one last authoritative snapshot so
-                // it can at least resync via RequestResync; either way, log
-                // loudly — a silent exit here is how ghost games are born.
-                if let Some(state) = replication_manager.get_game_state(game_id).await {
-                    let terminal = matches!(state.status, GameStatus::Complete { .. });
-                    error!(
-                        "Event broadcaster closed for live game {} (user {}); sending final snapshot",
-                        game_id, user_id
-                    );
-                    let final_snapshot = GameEventMessage {
-                        game_id,
-                        tick: state.tick,
-                        sequence: 0,
-                        stream_seq: replication_manager.get_stream_seq(game_id).await,
-                        user_id: Some(user_id),
-                        event: GameEvent::Snapshot { game_state: state },
-                    };
-                    let json =
-                        serde_json::to_string(&WSMessage::GameEvent(final_snapshot)).unwrap();
-                    let _ = ws_tx.send(Message::Text(json.into())).await;
-                    let _ = send_command_outcomes(
-                        &ws_tx,
-                        &game_bus,
-                        &cluster_namespace,
-                        game_id,
-                        user_id,
-                        terminal.then_some(TERMINAL_COMMAND_REJECTION_REASON),
-                    )
-                    .await;
-                } else {
-                    info!(
-                        "Event broadcaster closed for game {} (game evicted); ending subscription",
-                        game_id
-                    );
-                }
+                // The game's channel is gone. Terminal teardown always
+                // delivers the terminal snapshot first (handled below), so
+                // reaching this arm means the reader worker failed — which is
+                // task-fatal — or the terminal frame raced this receiver.
+                // Log loudly; the client's liveness watchdog and
+                // RequestResync path recover the session.
+                warn!(
+                    game_id,
+                    user_id, "Game event channel closed; ending subscription"
+                );
                 return;
             }
         };
@@ -2927,7 +2796,12 @@ async fn subscribe_to_game_events(
             break;
         }
 
-        if is_snapshot {
+        if is_snapshot || !live_proven {
+            // Every snapshot restarts the replay so its barrier pairs with
+            // the newest frontier. The first live event after a bridge anchor
+            // also starts it: live delivery is now proven, so the
+            // make-before-break promotion signal may flow.
+            live_proven = true;
             command_outcome_replay = Some(start_command_outcome_replay(
                 game_bus.clone(),
                 cluster_namespace.clone(),
@@ -3645,7 +3519,7 @@ async fn authenticate_ws_connection(
     ws_tx: &mpsc::Sender<Message>,
     game_bus: &Arc<GameBus>,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     websocket_id: &str,
     lifecycle: &TaskLifecycle,
     socket_generation: u64,
@@ -3721,7 +3595,7 @@ async fn authenticate_ws_connection(
                     metadata.matchmaking_pool,
                     ws_tx,
                     matchmaking_manager,
-                    replication_manager,
+                    event_router,
                     game_bus,
                     cluster_namespace,
                     db,
@@ -3752,7 +3626,7 @@ async fn process_ws_message(
     ws_tx: &mpsc::Sender<Message>,
     game_bus: &Arc<GameBus>,
     matchmaking_manager: &Arc<Mutex<MatchmakingManager>>,
-    replication_manager: &Arc<crate::replication::ReplicationManager>,
+    event_router: &Arc<crate::replication::GameEventRouter>,
     redis: &RedisConnection,
     _redis_url: &str,
     lobby_manager: &Arc<crate::lobby_manager::LobbyManager>,
@@ -3823,7 +3697,7 @@ async fn process_ws_message(
                         ws_tx,
                         game_bus,
                         matchmaking_manager,
-                        replication_manager,
+                        event_router,
                         websocket_id,
                         lifecycle,
                         socket_generation,
@@ -3843,7 +3717,7 @@ async fn process_ws_message(
                         ws_tx,
                         game_bus,
                         matchmaking_manager,
-                        replication_manager,
+                        event_router,
                         websocket_id,
                         lifecycle,
                         socket_generation,
@@ -4071,7 +3945,7 @@ async fn process_ws_message(
                         user_id,
                         metadata.matchmaking_pool,
                         matchmaking_manager,
-                        replication_manager,
+                        event_router,
                         game_bus,
                         cluster_namespace,
                         db,
@@ -5465,7 +5339,8 @@ mod lifecycle_protocol_tests {
     async fn pending_outcome_replay_does_not_block_live_game_events() {
         let (ws_tx, _ws_rx) = mpsc::channel(2);
         let (events_tx, events_rx) = broadcast::channel(2);
-        let mut events = crate::replication::FilteredEventReceiver::new(events_rx, 0, 42);
+        let mut events = crate::replication::GameEventSubscription::for_test(events_rx, 42);
+        events.anchor(4);
         let (release_tx, release_rx) = oneshot::channel();
         let mut replay: Option<CommandOutcomeReplay> = Some(Box::pin(async move {
             release_rx.await.expect("test replay release was dropped");
@@ -5484,7 +5359,7 @@ mod lifecycle_protocol_tests {
         };
         events_tx
             .send(live_event)
-            .expect("filtered receiver should remain subscribed");
+            .expect("subscription should remain attached");
 
         let input = timeout(
             Duration::from_secs(1),
@@ -5494,8 +5369,9 @@ mod lifecycle_protocol_tests {
         .expect("a pending Redis replay blocked a ready live event");
         assert!(matches!(
             input,
-            GameSubscriptionInput::Event(Ok(event))
-                if event.game_id == 42 && event.stream_seq == 5
+            GameSubscriptionInput::Update(Some(crate::replication::SubscriptionUpdate::Event(
+                event
+            ))) if event.game_id == 42 && event.stream_seq == 5
         ));
 
         release_tx.send(()).expect("replay future disappeared");

--- a/server/tests/game_load_failure_tests.rs
+++ b/server/tests/game_load_failure_tests.rs
@@ -61,24 +61,35 @@ async fn publish_snapshot_for_test(
     Ok(())
 }
 
-async fn wait_for_replica(env: &TestEnvironment, server_index: usize, game_id: u32) -> Result<()> {
-    timeout(Duration::from_secs(2), async {
-        loop {
-            if env
-                .server(server_index)
-                .expect("test gateway should be running")
-                .replication_manager()
-                .get_game_state_when_ready(game_id)
-                .await
-                .is_some()
-            {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(20)).await;
-        }
-    })
-    .await
-    .context("gateway did not consume the live snapshot")
+/// Write the fenced recovery envelope exactly as an executor checkpoint
+/// would. Stateless gateways authorize live joins from this envelope and use
+/// it as the join bridge snapshot, so a test that fabricates a live game must
+/// fabricate its envelope too.
+async fn write_recovery_envelope_for_test(
+    redis: &mut redis::aio::MultiplexedConnection,
+    game_id: u32,
+    state: &GameState,
+) -> Result<()> {
+    let namespace = ClusterNamespace::new("test-region")?;
+    let recovery = RecoveryEnvelopeV2::new(
+        game_id,
+        game_id % PARTITION_COUNT,
+        state.clone(),
+        "0-0".to_string(),
+        ResolvedCommandState::default(),
+        0,
+        0,
+        chrono::Utc::now().timestamp_millis(),
+        "gateway-routing-test".to_string(),
+    );
+    let _: () = redis
+        .set_ex(
+            namespace.recovery(game_id),
+            serde_json::to_vec(&recovery)?,
+            300,
+        )
+        .await?;
+    Ok(())
 }
 
 #[tokio::test]
@@ -385,27 +396,11 @@ async fn live_game_join_is_authorized_before_enabling_game_chat() -> Result<()> 
     let mut publisher = redis_client.get_multiplexed_async_connection().await?;
     let partition_id = game_id % PARTITION_COUNT;
 
-    // Replica reader startup is asynchronous (subscriptions anchor at the stream tail, so
-    // earlier entries are invisible). Republish until this server's replica proves the live
-    // state is available to the same authorization path used by JoinGame.
-    timeout(Duration::from_secs(10), async {
-        loop {
-            publish_snapshot_for_test(&mut publisher, partition_id, game_id, &live_state).await?;
-            if env
-                .server(0)
-                .expect("test server should be running")
-                .replication_manager()
-                .get_game_state_when_ready(game_id)
-                .await
-                .is_some()
-            {
-                return Ok::<_, anyhow::Error>(());
-            }
-            tokio::time::sleep(Duration::from_millis(50)).await;
-        }
-    })
-    .await
-    .context("live game did not reach the replication cache")??;
+    // Stateless gateways authorize live joins from the fenced recovery
+    // envelope, so this fabricated live game gets one exactly as an executor
+    // checkpoint would have written it.
+    write_recovery_envelope_for_test(&mut publisher, game_id, &live_state).await?;
+    publish_snapshot_for_test(&mut publisher, partition_id, game_id, &live_state).await?;
 
     let mut redis = redis_client.get_multiplexed_async_connection().await?;
     let chat_history_key = RedisKeys::game_chat_history_key(game_id);
@@ -473,10 +468,12 @@ async fn initial_join_waits_for_the_live_replica_after_executor_snapshot_storage
     client.authenticate(player_user_id).await?;
     client.join_game(game_id).await?;
 
-    // The server sees the executor-stored Redis snapshot first and enters its bounded
-    // readiness wait. Publishing shortly afterward models the replica consuming the initial
-    // snapshot a moment after the game was created.
+    // The server sees the executor-stored Redis snapshot first and enters its
+    // bounded authorization wait, polling for the fenced recovery envelope.
+    // Writing it shortly afterward models the executor checkpointing the game
+    // a moment after creation.
     tokio::time::sleep(Duration::from_millis(200)).await;
+    write_recovery_envelope_for_test(&mut redis, game_id, &live_state).await?;
     publish_snapshot_for_test(&mut redis, game_id % PARTITION_COUNT, game_id, &live_state).await?;
 
     let loaded_state = receive_snapshot(&mut client).await?;
@@ -523,22 +520,13 @@ async fn newly_ready_cold_gateway_waits_for_delayed_live_snapshot_within_authori
     let partition_id = game_id % PARTITION_COUNT;
 
     // Establish an active game before the replacement gateway starts. Its
-    // stream reader anchors at the tail, so this original snapshot must not
-    // warm the new gateway's local replica.
+    // stream reader anchors at the tail, so this original snapshot entry is
+    // invisible to the new gateway — and stateless gateways retain no state
+    // for it anyway. Withholding the recovery envelope makes the game
+    // unauthoritative until the delayed write below.
     publish_snapshot_for_test(&mut redis, partition_id, game_id, &live_state).await?;
-    wait_for_replica(&env, 0, game_id).await?;
 
     let (cold_gateway_index, _) = env.add_server().await?;
-    assert!(
-        env.server(cold_gateway_index)
-            .expect("cold gateway should be running")
-            .replication_manager()
-            .get_game_state_when_ready(game_id)
-            .await
-            .is_none(),
-        "newly ready gateway unexpectedly inherited another task's in-memory replica"
-    );
-
     let cold_gateway_addr = env
         .ws_addr(cold_gateway_index)
         .expect("cold gateway should be running");
@@ -548,14 +536,14 @@ async fn newly_ready_cold_gateway_waits_for_delayed_live_snapshot_within_authori
     let joined_at = Instant::now();
     client.join_game(game_id).await?;
     tokio::time::sleep(Duration::from_millis(350)).await;
-    publish_snapshot_for_test(&mut redis, partition_id, game_id, &live_state).await?;
+    write_recovery_envelope_for_test(&mut redis, game_id, &live_state).await?;
 
     let loaded_state = receive_snapshot_without_join_failure(&mut client, game_id).await?;
     let elapsed = joined_at.elapsed();
     assert_eq!(loaded_state.start_ms, live_state.start_ms);
     assert!(
         elapsed >= Duration::from_millis(350),
-        "join did not exercise delayed replica warming: {elapsed:?}"
+        "join did not exercise delayed authoritative-state warming: {elapsed:?}"
     );
     assert!(
         elapsed < Duration::from_secs(6),
@@ -586,19 +574,8 @@ async fn newly_ready_cold_gateway_returns_retryable_warming_when_replica_is_with
     let mut redis = redis_client.get_multiplexed_async_connection().await?;
     let partition_id = game_id % PARTITION_COUNT;
     publish_snapshot_for_test(&mut redis, partition_id, game_id, &live_state).await?;
-    wait_for_replica(&env, 0, game_id).await?;
 
     let (cold_gateway_index, _) = env.add_server().await?;
-    assert!(
-        env.server(cold_gateway_index)
-            .expect("cold gateway should be running")
-            .replication_manager()
-            .get_game_state_when_ready(game_id)
-            .await
-            .is_none(),
-        "newly ready gateway unexpectedly consumed the pre-start snapshot"
-    );
-
     let cold_gateway_addr = env
         .ws_addr(cold_gateway_index)
         .expect("cold gateway should be running");
@@ -702,14 +679,10 @@ async fn newly_ready_cold_gateway_returns_retryable_warming_when_replica_is_with
     // Receiving the retry snapshot and outcome barrier is not enough: the
     // retried JoinGame must have installed a live subscription on the same
     // socket. A subsequent state delta proves that the connection did not
-    // remain in a one-shot recovery path.
-    let delta_stream_seq = env
-        .server(cold_gateway_index)
-        .expect("cold gateway should be running")
-        .replication_manager()
-        .get_stream_seq(game_id)
-        .await
-        .saturating_add(1);
+    // remain in a one-shot recovery path. The retry anchored on the test
+    // envelope's zero watermark, so the next contiguous transport sequence
+    // is exactly one.
+    let delta_stream_seq = 1;
     let delta_score = 424_242;
     let delta = GameEventMessage {
         game_id,

--- a/server/tests/game_load_failure_tests.rs
+++ b/server/tests/game_load_failure_tests.rs
@@ -223,9 +223,12 @@ async fn joining_a_durably_saved_completed_game_returns_its_final_snapshot() -> 
     assert_eq!(loaded_state.scores, final_state.scores);
     assert_eq!(replayed_outcome_sessions, 0);
     assert_eq!(terminal_rejection_reason, None);
-    assert!(
-        nonterminal_bridge_snapshots >= 1,
-        "the stale recovery envelope should be observed before the durable terminal fallback"
+    // The durable terminal record is consulted BEFORE the stale non-terminal
+    // envelope may bridge, so the client goes straight to the final state and
+    // never sees a stale active frame flash first.
+    assert_eq!(
+        nonterminal_bridge_snapshots, 0,
+        "a stale recovery envelope must not be bridged over a durable terminal state"
     );
 
     client.disconnect().await?;
@@ -654,32 +657,13 @@ async fn newly_ready_cold_gateway_returns_retryable_warming_when_replica_is_with
         retried_state.status
     );
 
-    timeout(Duration::from_secs(3), async {
-        loop {
-            match client.receive_message().await? {
-                WSMessage::CommandOutcomesComplete {
-                    game_id: barrier_game_id,
-                    ..
-                } if barrier_game_id == game_id => return Ok::<_, anyhow::Error>(()),
-                WSMessage::GameLoadFailed {
-                    game_id: failed_game_id,
-                    reason,
-                } if failed_game_id == game_id => {
-                    return Err(anyhow::anyhow!(
-                        "same-socket retry failed before its outcome barrier: {reason}"
-                    ));
-                }
-                _ => continue,
-            }
-        }
-    })
-    .await
-    .context("same-socket retry did not receive its command-outcome barrier")??;
-
-    // Receiving the retry snapshot and outcome barrier is not enough: the
-    // retried JoinGame must have installed a live subscription on the same
-    // socket. A subsequent state delta proves that the connection did not
-    // remain in a one-shot recovery path. The retry anchored on the test
+    // Receiving the retry snapshot is not enough: the retried JoinGame must
+    // have installed a live subscription on the same socket, and the
+    // command-outcome barrier — a make-before-break promotion signal — is
+    // deliberately withheld until the first live event proves the stream
+    // flows behind the recovery bridge. Publish a delta to provide that
+    // proof (a real game's TickHash heartbeat does this within a second);
+    // the barrier must then follow it. The retry anchored on the test
     // envelope's zero watermark, so the next contiguous transport sequence
     // is exactly one.
     let delta_stream_seq = 1;
@@ -734,6 +718,28 @@ async fn newly_ready_cold_gateway_returns_retryable_warming_when_replica_is_with
     })
     .await
     .context("same-socket retry did not receive a subsequent live delta")??;
+
+    timeout(Duration::from_secs(3), async {
+        loop {
+            match client.receive_message().await? {
+                WSMessage::CommandOutcomesComplete {
+                    game_id: barrier_game_id,
+                    ..
+                } if barrier_game_id == game_id => return Ok::<_, anyhow::Error>(()),
+                WSMessage::GameLoadFailed {
+                    game_id: failed_game_id,
+                    reason,
+                } if failed_game_id == game_id => {
+                    return Err(anyhow::anyhow!(
+                        "same-socket retry failed before its outcome barrier: {reason}"
+                    ));
+                }
+                _ => continue,
+            }
+        }
+    })
+    .await
+    .context("same-socket retry did not receive its command-outcome barrier")??;
 
     client.disconnect().await?;
     env.shutdown().await?;

--- a/server/tests/lobby_matchmaking_tests.rs
+++ b/server/tests/lobby_matchmaking_tests.rs
@@ -1,5 +1,5 @@
 use ::common::{GameEvent, GameState, GameStatus, GameType, QueueMode, TeamId};
-use anyhow::Result;
+use anyhow::{Context, Result};
 use chrono::Utc;
 use futures_util::StreamExt;
 use redis::{AsyncCommands, Client, PushInfo};
@@ -1443,7 +1443,8 @@ async fn lobby_sockets_reconcile_durable_roster_and_ignore_stale_pubsub_payload(
             }
         }
     })
-    .await??;
+    .await
+    .context("host did not receive LobbyCreated")??;
 
     let mut follower = TestClient::connect(&server_addr).await?;
     follower.authenticate(follower_user_id).await?;
@@ -1464,7 +1465,8 @@ async fn lobby_sockets_reconcile_durable_roster_and_ignore_stale_pubsub_payload(
             }
         }
     })
-    .await??;
+    .await
+    .context("follower did not receive JoinedLobby")??;
 
     let mut baseline = [host_user_id as u32, follower_user_id as u32];
     baseline.sort_unstable();
@@ -1484,7 +1486,8 @@ async fn lobby_sockets_reconcile_durable_roster_and_ignore_stale_pubsub_payload(
             ),
         )
     })
-    .await??;
+    .await
+    .context("sockets did not converge on the baseline lobby roster")??;
 
     // Phase 1: mutate the authoritative roster without publishing anything.
     // Both sockets must converge from the periodic durable read alone.
@@ -1522,7 +1525,8 @@ async fn lobby_sockets_reconcile_durable_roster_and_ignore_stale_pubsub_payload(
             ),
         )
     })
-    .await??;
+    .await
+    .context("sockets did not converge on the durable roster after the stale hint")??;
 
     // Phase 2: inject a stale roster through the real Redis Pub/Sub path. Its
     // removed sentinel member must never reach either socket; the durable read
@@ -1919,7 +1923,8 @@ async fn create_lobby_and_queue_with_code(
             }
         }
     })
-    .await??;
+    .await
+    .context("host did not receive LobbyCreated")??;
 
     // Other clients join the lobby using the captured lobby_code
     if clients.len() > 1 {
@@ -1939,7 +1944,8 @@ async fn create_lobby_and_queue_with_code(
                     }
                 }
             })
-            .await??;
+            .await
+            .context("member did not receive JoinedLobby")??;
         }
     }
 
@@ -2003,7 +2009,8 @@ async fn wait_for_all_clients_to_join_game(clients: &mut [TestClient]) -> Result
                 }
             }
         })
-        .await??;
+        .await
+        .context("client did not receive its JoinGame push and game snapshot")??;
 
         if let Some(expected_game_id) = game_id {
             assert_eq!(

--- a/specs/autoscaling-resilience-prd.md
+++ b/specs/autoscaling-resilience-prd.md
@@ -5,7 +5,7 @@
 | Status | Direct-only implementation acceptance draft |
 | Product | Snaketron regional game service |
 | Owners | Engineering / Product |
-| Last updated | 2026-08-09 |
+| Last updated | 2026-08-14 |
 | Scope | Executor ownership, task lifecycle, WebSocket continuity, matchmaking safety, readiness, and autoscaling |
 
 ## 1. Executive summary
@@ -46,7 +46,7 @@ The superseded executor path exposed the following failure modes.
 | XP and MMR persistence use additive updates after completion. | `xp_persistence.rs`, `mmr_persistence.rs`, and `game_executor.rs`. | A replayed completion can apply durable rewards more than once. |
 | Traefik uses sticky cookies and a health endpoint that is always healthy. | `cdk/lib/fargate-stack.ts`. | A reconnect can be biased back to a draining task and route withdrawal is not truthful. |
 
-The existing gateway/executor decoupling is correct and must be preserved: WebSocket handlers already publish commands by partition to Valkey, and every task already maintains replicas for all partitions. Authoritative execution does not need to run on the task holding a player's WebSocket.
+The existing gateway/executor decoupling is correct and must be preserved: WebSocket handlers already publish commands by partition to Valkey, and every task already tails the event streams for all partitions. Authoritative execution does not need to run on the task holding a player's WebSocket. Gateways are stateless event routers: they forward per-game events to locally subscribed sockets and never retain a reconstructed `GameState`. The only authoritative game state in the region is the lease holder's actor state plus its fenced Redis recovery envelope.
 
 The legacy `specs/HighAvailability.md` describes a superseded Raft architecture. This PRD is the source of truth for the Redis/Valkey-based autoscaling design.
 
@@ -174,7 +174,7 @@ flowchart LR
     CS -->|"Consumer group / pending takeover"| E["Assigned partition executor"]
     L --> E
     E -->|"Fenced events and checkpoints"| V
-    V -->|"Partition event stream"| R["Replica readers on every ready task"]
+    V -->|"Partition event stream"| R["Stateless event routers on every ready task"]
     R --> G
     E -->|"Idempotent completion effects"| D["DynamoDB"]
 ~~~
@@ -194,8 +194,8 @@ The assignment coordinator is control plane only. Existing assignments and activ
 3. Membership heartbeat is one second and expiry is four seconds. Changes require staging evidence that the five-second crash-takeover objective still holds.
 4. Executor membership may enter `ACTIVE` after the listener, assignment
    watcher, and recent Valkey-operation predicates pass. It must not wait for
-   gateway replica hydration: a first or replacement task may need to own an
-   executor before it can answer the snapshot barrier that makes its gateway
+   gateway event-reader readiness: a first or replacement task may need to own
+   an executor before it can answer the reader barrier that makes its gateway
    routable.
 5. Only `ACTIVE` executor members are eligible for new desired assignments.
    Public `/health/ready` remains a stricter, independent gateway predicate.
@@ -249,7 +249,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 ### R4 — Durable executor command consumption
 
 1. Keep the existing Redis partition command stream, but add one stable executor consumer group per partition.
-2. Consumer groups apply only to the authoritative executor command path. Replica event readers and snapshot-request readers may keep ordinary `XREAD` fan-out.
+2. Consumer groups apply only to the authoritative executor command path. Gateway event readers and snapshot-request readers may keep ordinary `XREAD` fan-out.
 3. Each consumer name must identify one lease acquisition token, not merely a task.
 4. After acquiring authority, a successor must:
    1. load the partition's active-game checkpoints;
@@ -383,7 +383,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 3. Active games must initiate checkpoints on a one-second wall-clock cadence, independent of custom game tick duration. Persisted checkpoint age must remain below `SNAKETRON_MAX_CHECKPOINT_AGE_MS` (default ten seconds) or the actor fails closed.
 4. Checkpoints must also be written at game creation, successor activation after recovery, and completion. A planned handoff must not add a redundant incumbent checkpoint; it uses the same last-checkpoint plus PEL/decision-journal recovery source as an abrupt crash.
 5. Maintain a `partition -> active game IDs` index. Recovery must query this index and fetch checkpoints in a pipeline/batch rather than scan all `game:snapshot:*` keys.
-6. The authoritative recovery source is the versioned checkpoint. A local replica may accelerate recovery only if it carries the same cursor and dedupe metadata; an ordinary state-only replica must not override the checkpoint.
+6. The authoritative recovery source is the versioned checkpoint composed with the pending command-stream entries, decision journal, and planned-handoff watermark. No gateway-held state participates in recovery: gateways retain no reconstructed `GameState`, so nothing outside the fenced Redis records can override or accelerate the checkpoint path.
 7. A successor must batch-load the partition decision journal under its new
    fence, attach entries to reclaimed commands by exact stream ID, and preserve
    each game's complete source-stream projection while allowing independent
@@ -399,14 +399,19 @@ The assignment coordinator is control plane only. Existing assignments and activ
 9. Completed games must have explicit cleanup after their durable completion grace period.
 10. If replacement occurs after the documented recovery retention, the game must produce an explicit unrecoverable outcome. It must not silently fabricate or restart state.
 11. Checkpoint size and write volume must be measured under `1 -> 10 -> 1` load. Delta encoding is considered only if those measurements show a real capacity problem.
-12. A cold-join or ordinary on-demand repair request carries the exact game ID
-    and is only a best-effort hint to that actor. A gateway polls its local
-    replica every 100 milliseconds but publishes the targeted request at most
-    once per 500 milliseconds through the bounded warm-up window. The executor
-    uses a nonblocking actor mailbox send; a full mailbox, a request racing game
-    creation, or an ownership gap is benign because the gateway retries and a
-    successor publishes its recovery re-anchor. This path must not checkpoint
-    inline, wait for an actor reply, or fan out to unrelated games.
+12. A join or ordinary on-demand repair request carries the exact game ID and
+    is only a best-effort hint to that actor. The gateway registers its
+    per-game subscription before publishing the request, immediately sends the
+    validated recovery-envelope bridge snapshot when the envelope is
+    non-terminal and records the user, and then awaits the live authoritative
+    `Snapshot` on the partition event stream. Targeted requests are published
+    at most once per 500 milliseconds per game per gateway, coalesced across
+    every local socket waiting on that game, through the bounded warm-up
+    window. The executor uses a nonblocking actor mailbox send; a full
+    mailbox, a request racing game creation, or an ownership gap is benign
+    because the gateway retries and a successor publishes its recovery
+    re-anchor. This path must not checkpoint inline, wait for an actor reply,
+    or fan out to unrelated games.
 
     Partition startup/readiness and detected partition-gap repair remain
     explicitly partition-scoped requests. An initial readiness request retains
@@ -415,8 +420,12 @@ The assignment coordinator is control plane only. Existing assignments and activ
     same ordered partition event stream only after every active actor has
     published. The gateway retries a missed request and becomes ready only
     after consuming its exact marker, which also handles an empty partition
-    without a timer or synthetic game. Targeted cold-join hints never satisfy
-    this readiness proof.
+    without a timer or synthetic game. The gateway forwards, and does not
+    retain, the snapshots that precede its marker. Targeted cold-join hints
+    never satisfy this readiness proof. This request/marker wire contract is
+    version-stable: changing gateway-side consumption of the barrier must not
+    require an executor protocol version bump, because old executors answering
+    the same barrier request remain a correct, strictly stronger response.
 13. The authoritative executor partition reader must round-robin the complete
     projection for each addressable game, keep at most one unresolved delivery
     per game, and use a bounded fan-out. A later command, status, creation,
@@ -427,25 +436,49 @@ The assignment coordinator is control plane only. Existing assignments and activ
     completion. This removes cross-game head-of-line blocking without
     introducing a second scheduler or relaxing per-game ordering and recovery
     semantics.
-14. Gateway replicas must use a resumable event-only partition reader. They
-    must not read or drain the executor command stream or snapshot-request
+14. Gateway event routers must use a resumable event-only partition reader.
+    They must not read or drain the executor command stream or snapshot-request
     stream: pressure on either unrelated stream must not block authoritative
     game events from reaching connected sockets. The reader anchors before
     subscription returns, reconnects from its last event-stream ID, and
     verifies that a nonzero cursor has not crossed the bounded stream's trim
     horizon on initial connection, reconnect, full backlog batches, and local
     channel backpressure. A detected transport discontinuity fails the critical
-    replica worker and therefore the task; a surviving completion marker must
-    never certify snapshots that were trimmed before delivery. Existing
-    per-game sequence-gap and join-side snapshot repair remain responsible for
-    recoverable gaps beyond this bus.
-15. After broadcasting a full terminal snapshot, a gateway replica may evict
-    that game immediately. The fenced completion script stores the immutable
-    completion record, final recovery envelope, stored snapshot, pending-effect
-    index, and terminal publications in one atomic partition-slot operation
-    before the terminal snapshot can be observed. The existing command-stream
+    reader worker and therefore the task; a surviving completion marker must
+    never certify events that were trimmed before delivery.
+
+    The router holds no game state, so per-game continuity is a per-
+    subscription property with these mandatory rules:
+    - a subscription is cold until it forwards an authoritative `Snapshot`;
+      while cold it suppresses sequenced state deltas and re-requests the
+      targeted snapshot on the 500 ms per-game cadence;
+    - every `Snapshot` re-anchors the subscription's `stream_seq` watermark
+      unconditionally, because a restarted or failed-over executor begins a
+      new `stream_seq` sequence;
+    - `stream_seq == 0` events are out-of-band terminal `CommandRejected`
+      messages and must be forwarded by stable command identity even while the
+      subscription is cold;
+    - a detected per-game sequence gap or local broadcast lag returns the
+      subscription to cold rather than forwarding unverified continuations;
+    - `TickHash` heartbeats must be forwarded end-to-end to clients unchanged:
+      with no server-side reconstructed state, client-side `TickHash`
+      verification is the production desync detector, and dropping the
+      heartbeat would silently disable it.
+15. When a router forwards a full terminal snapshot, it may tear down that
+    game's local broadcaster immediately after the last local subscriber is
+    served. The fenced completion script stores the immutable completion
+    record, final recovery envelope, stored snapshot, pending-effect index,
+    and terminal publications in one atomic partition-slot operation before
+    the terminal snapshot can be observed. The existing command-stream
     terminal status remains available for executor cleanup, but gateways
-    neither consume it nor wait for it as an eviction/liveness dependency.
+    neither consume it nor wait for it as a teardown/liveness dependency.
+16. The active-play stored snapshot and recovery-envelope keys written by the
+    fenced checkpoint script are retained unchanged in this phase. Active and
+    terminal stored snapshots share one key by design, and the terminal-
+    pending TTL-refresh path requires that key to exist; consolidating or
+    dropping either write is a separate future decision that must rework the
+    checkpoint and completion Lua scripts together with a recovery schema
+    version change.
 
 ### R7 — Planned partition handoff and task shutdown
 
@@ -463,7 +496,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
 
 ### R8 — WebSocket recovery and planned make-before-break
 
-1. Preserve the single-process gateway/executor deployment. A gateway can serve any game through regional Valkey streams and its local replicas.
+1. Preserve the single-process gateway/executor deployment. A gateway can serve any game through regional Valkey streams, the fenced recovery envelope, and stateless per-game event forwarding; it holds no reconstructed game state of its own.
 2. Scale-up must not move existing WebSockets.
 3. Hard-crash reconnect behavior must be:
    - an immediate first retry;
@@ -481,7 +514,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
    3. after every executor partition has completed its marker-backed handoff, send one drain message containing task identity and deadline over every existing socket; if executor handoff failed, send no drain message and let socket closure use ordinary crash recovery;
    4. the client opens a second socket through the same regional URL, not a server-specific URL;
    5. the second socket authenticates and restores lobby/game context;
-   6. for a game, the second socket receives a current snapshot, resolved-command outcomes, and `CommandOutcomesComplete`, then buffers subsequent events;
+   6. for a game, the second socket receives a current snapshot — sourced from the recovery-envelope bridge (bounded staleness of one checkpoint interval) or the live targeted snapshot, whichever arrives first — plus resolved-command outcomes and `CommandOutcomesComplete`, then buffers subsequent events;
    7. after the candidate is ready, the client sends a uniquely tagged application Ping on the old socket and receives its matching Pong. WebSocket ordering freezes the old game-stream watermark observed through that Pong; the marker-backed successor guarantees a recovery snapshot beyond that fixed frontier;
    8. the old socket remains the visible event stream and sole command owner while the candidate catches the frozen frontier and receives `CommandOutcomesComplete` paired with its latest snapshot. At promotion, retain old state already applied beyond the frontier and suppress the candidate's prefix at or below that applied watermark, including covered frames that arrive after the atomic socket swap. Keep this suppression floor until the promoted stream advances beyond it; a terminal snapshot remains immediately authoritative;
    9. the client atomically switches command ownership to the new socket generation and only then closes the old socket. If the old transport closes or the shared deadline fires after the candidate is fully ready but before the Pong, retain and promote that candidate as crash recovery while recording a planned-handoff failure.
@@ -544,9 +577,10 @@ The assignment coordinator is control plane only. Existing assignments and activ
 3. Readiness requires:
    - the HTTP/WebSocket listener is bound;
    - a recent bounded Valkey operation succeeded;
-   - all partition replica stream readers are subscribed and alive, and each
-     has consumed its boot-unique initial snapshot-completion marker after all
-     preceding active-game snapshots;
+   - all partition event-stream readers are subscribed and alive, and each has
+     consumed its boot-unique initial completion marker on the ordered event
+     stream, proving an anchored reader that observed every preceding
+     requested snapshot in order;
    - membership and assignment watchers are alive;
    - other critical local workers are alive;
    - the task is not draining.
@@ -554,10 +588,15 @@ The assignment coordinator is control plane only. Existing assignments and activ
 5. A critical background worker exiting unexpectedly must fail the process so ECS restarts it. Do not add a general in-process supervisor.
 6. A transient regional Valkey failure makes tasks unready but must not make ECS liveness fail and create a replacement storm.
 7. Executor-placement eligibility and public gateway readiness are distinct.
-   A task may execute partitions while its gateway remains unready. After all
-   ten initial snapshot barriers pass, a later requested game that is still
-   cold uses the bounded on-demand snapshot request/load and returns a
-   retryable warming response rather than reporting a false missing game.
+   A task may execute partitions while its gateway remains unready. After the
+   initial reader barriers pass, every game join anchors on the bounded
+   on-demand path — recovery-envelope bridge plus targeted snapshot request —
+   and a join whose live snapshot has not yet arrived returns a retryable
+   warming response rather than reporting a false missing game. Readiness
+   certifies attached, anchored readers, not pre-warmed game state; the
+   warming path is therefore the ordinary join path, and its retry budget and
+   latency are certified under load rather than treated as a degraded
+   exception.
 8. Traefik backend health must use `/health/ready`; ECS container health must use `/health/live`.
 9. Keep `/api/health` as the lightweight client-side regional latency probe; it must not be the Traefik readiness signal.
 10. Remove the Traefik sticky-session cookie. Affinity is not required and can route reconnects back toward a draining backend.
@@ -600,8 +639,8 @@ The assignment coordinator is control plane only. Existing assignments and activ
     timeout or crash must repair a missing notification without publishing
     duplicates during the completion grace period. Because readers cannot
     observe the terminal snapshot before those durable writes commit, a gateway
-    replica broadcasts that snapshot and then evicts its local game without
-    waiting for a command-stream marker.
+    event router forwards that snapshot to its local subscribers and then tears
+    down the game's broadcaster without waiting for a command-stream marker.
 12. Durable effects must enforce their dependency order in the storage transaction: no XP, MMR, ranking, or high-score effect may commit before the completed-game record, and a ranking projection may not commit before its matching MMR effect.
 13. A successor executor must be able to finalize a game created or previously executed by another task. Completion identity must be the durable game ID and immutable completion revision; it must not require the finalizing task's server ID to match the original executor.
 
@@ -638,7 +677,7 @@ The assignment coordinator is control plane only. Existing assignments and activ
    identical Fargate placements; one vCPU did not preserve the one-second
    latency budget during the managed policy's observation lag.
 5. No custom game-specific autoscaling metric is added in this phase.
-6. Every task currently replicates every partition, so task-local replica memory may not fall on scale-out. Scaling tests must prove memory behavior is acceptable; otherwise the replication model or memory policy needs a separate decision.
+6. Gateways hold no reconstructed game state, so the total retained authoritative `GameState` count in the region equals the number of active games — never active games multiplied by task count. Per-task gateway memory follows locally subscribed games plus bounded in-flight snapshot payloads. Scaling tests must prove per-task memory follows this model during `1 -> 10 -> 1`, with no all-game snapshot retention burst when a new task starts.
 7. Existing WebSockets do not redistribute on scale-up, so service-average CPU can hide a hot gateway task. Record per-task CPU, memory, connections, and event-forwarding load during validation.
 8. Keep the partition count fixed at fifty; do not increase it again or add adaptive splitting without load evidence.
 9. Load tests must include Serverless Valkey read/write latency, ECPU, bytes, connections, network traffic, `ThrottledCmds`, and `Evictions`, plus the shared regional NAT/Traefik host's CPU, network, connection success, and admission latency/error evidence.
@@ -705,8 +744,9 @@ The stored source token is diagnostic only. On recovery, the successor's newly a
 3. The coordinator computes a minimally moved balanced desired map.
 4. Incumbents for moved partitions stop renewing, checkpoint, ACK covered commands, and compare-delete their leases.
 5. The new task acquires those leases, claims pending commands, restores checkpoints, catches up, and publishes fresh snapshots.
-6. Only after all gateway replicas consume their matching initial snapshot
-   barriers does `/health/ready` pass and Traefik route new connections to it.
+6. Only after all gateway event readers consume their matching initial
+   barrier markers does `/health/ready` pass and Traefik route new connections
+   to it.
 7. Existing WebSockets remain on their original tasks throughout.
 
 ### 11.2 Planned scale-down
@@ -812,7 +852,7 @@ Required metrics:
 - partition unowned duration and fenced-write rejection count;
 - pending command count/oldest age, claims, ACKs, resends, deduplications, rejections, pending completions, and quarantines;
 - checkpoint age/size/failures and active-game index parity;
-- recovered games, replay count, and deterministic fingerprint divergence;
+- recovered games, replay count, and client-reported desync signals: resync request/accept/reject counters and client trace uploads (server-side replica fingerprint verification no longer exists; client `TickHash` verification is the production divergence detector);
 - active WebSockets and planned-drain failures;
 - load-test reconnect, authentication, rejoin, snapshot, per-command terminal-outcome latency, command-outcome barrier, usable-session-gap, and socket-generation evidence, combined with real-browser Playwright stale-overlay evidence;
 - match claim conflicts and prevented duplicate completion effects;
@@ -828,7 +868,7 @@ Critical alerts:
 - assignment stuck with eligible tasks or imbalance;
 - oldest pending command or checkpoint age approaching the recovery budget;
 - active-game index/checkpoint mismatch;
-- fingerprint divergence after recovery;
+- elevated client resync-request rate (the desync tripwire replacing replica fingerprint divergence);
 - any planned-drain failure;
 - any Serverless Valkey eviction or throttled command, or sustained service-side latency inconsistent with the command budget.
 
@@ -887,8 +927,10 @@ Command-outcome certification accepts report schema 11 or newer only when
 | Fail checkpoint writes for nine seconds, then for eleven seconds, with the ten-second age budget | In the nine-second case commands remain pending and checkpointing recovers; in the eleven-second case the actor fails closed at the budget without falsely retiring work. |
 | Block one game actor while a later command targets another game in the same partition batch | The unrelated game receives its command before the blocked actor is released; each game retains one unresolved delivery at most, cursors never regress, and a handoff drains only the accepted prefix while leaving the untouched suffix recoverable in the PEL. |
 | Flood the executor command stream beyond the legacy gateway channel capacity while publishing a later authoritative event | The event-only gateway reader continues delivering the event promptly because it reads neither commands nor snapshot requests. |
-| Start a gateway while a partition is empty, active, or temporarily has no subscribed executor | Executor placement can converge before gateway routing; the gateway retries one boot-unique request, consumes every preceding requested snapshot and then its exact same-stream completion marker, and remains unready until that proof arrives. Snapshot publication waits on the existing actor checkpoint without blocking partition command dispatch. |
-| Remove a gateway event reader's nonzero cursor from the bounded stream before initial readiness or after routing | The reader emits a transport discontinuity, the critical replica worker exits, readiness is false, and no surviving old completion marker can make the task routable. |
+| Start a gateway while a partition is empty, active, or temporarily has no subscribed executor | Executor placement can converge before gateway routing; the gateway retries one boot-unique request, observes (forwarding, not retaining) every preceding requested snapshot and then consumes its exact same-stream completion marker, and remains unready until that proof arrives. Snapshot publication waits on the existing actor checkpoint without blocking partition command dispatch. |
+| Remove a gateway event reader's nonzero cursor from the bounded stream before initial readiness or after routing | The reader emits a transport discontinuity, the critical reader worker exits, readiness is false, and no surviving old completion marker can make the task routable. |
+| Own a game's executor on task A while its only WebSocket lives on task B | B forwards the join snapshot, deltas, `TickHash` heartbeats, and the terminal snapshot to its socket while retaining zero reconstructed game states; total retained authoritative states in the region equal the number of active games. |
+| Mark one subscription cold via injected broadcast lag while other games on the partition stay live | Only the lagged game's sockets re-anchor through a targeted snapshot; requests coalesce to at most one per 500 ms per game per gateway across all its waiting sockets, unrelated games see no request traffic, and a `stream_seq == 0` terminal rejection arriving during the cold window is still forwarded by command identity. |
 | Fail an owned partition executor closed, remove its final local handle, then begin task drain | The process-boot failure latch makes executor drain fail and no WebSocket `Drain` is announced; lease expiry plus ordinary reconnect remains authoritative. An empty handle map alone never passes. |
 | Inject failure at each WebSocket drain phase | Old socket remains usable until replacement auth, rejoin, snapshot, and switch complete; only one sends commands. |
 | Let the old socket advance beyond the frozen Pong frontier, promote the caught-up candidate, then deliver covered candidate snapshots both before and after the socket swap | Visible game state never rolls backward. Covered nonterminal stream-zero and sequenced frames remain suppressed until the promoted stream exceeds the old applied watermark; a terminal snapshot remains authoritative. |
@@ -906,10 +948,10 @@ Command-outcome certification accepts report schema 11 or newer only when
 | Commit immediately before a connected lobby listener subscribes, then drop or duplicate the Pub/Sub hint | Subscribe-then-read or the five-second reconciliation forwards the durable game ID once; duplicate hint/read overlap does not send a second `JoinGame`, and a later play-again game ID is still delivered. |
 | Kill after the fenced Valkey completion commit and before each DynamoDB effect or its confirmation marker | A successor reloads the same immutable completion revision; completed game, XP, MMR, rankings, and high scores converge to one application per effect key, and pending completion state is retained until all effects are confirmed. |
 | Time out the fenced completion commit after it may have executed, then retry it repeatedly | The exact same completion record is accepted; one terminal snapshot and one terminal status are observable, matchmaking cleanup converges, and no completion effect is duplicated. |
-| Deliver the full terminal snapshot to a gateway replica | The snapshot is broadcast before local eviction; the immutable completion record, final recovery envelope, stored snapshot, and pending-effect index are already durable from the same fenced transaction, so no command-stream completion marker is consumed or awaited. |
+| Deliver the full terminal snapshot to a gateway event router | The snapshot is forwarded to every local subscriber before the game's broadcaster is torn down; the immutable completion record, final recovery envelope, stored snapshot, and pending-effect index are already durable from the same fenced transaction, so no command-stream completion marker is consumed or awaited. |
 | Delay completion cleanup until a player or lobby is mapped to a newer game | The old active-match record is removed, but every newer user/lobby mapping remains unchanged. |
 | Complete a game on a takeover executor with a different task/server identity | Final state and every durable effect commit once under the original game ID and one completion revision; original executor identity is not required. |
-| Join an active game through a newly ready cold task | Snapshot warming succeeds inside the six-second authorization deadline or returns `GameWarming` with a 500 ms retry hint, never a false missing-game result. A playing-phase certification client pauses command emission, retries `JoinGame` on the same authenticated socket within its existing game deadline, and resumes only after a fresh snapshot and `CommandOutcomesComplete`; it must not manufacture a reconnect or continue sending against a cold replica. |
+| Join an active game through a newly ready task | The join first-frame arrives from the recovery-envelope bridge or the live targeted snapshot inside the six-second authorization deadline, or returns `GameWarming` with a 500 ms retry hint, never a false missing-game result. A playing-phase certification client pauses command emission, retries `JoinGame` on the same authenticated socket within its existing game deadline, and resumes only after a fresh snapshot and `CommandOutcomesComplete`; it must not manufacture a reconnect or continue sending against a cold subscription. |
 | Make Valkey unavailable through the deterministic local fault proxy | Readiness drops within seven seconds, liveness remains healthy, and restoration creates no conflicting authority. A remote ElastiCache outage is not a separate release test because availability during that accepted dependency outage is out of scope. |
 | With recovery retention set to 60 seconds, crash the sole task and delay replacement 30 seconds | The documented availability gap occurs, then games recover automatically. |
 | With recovery retention set to 60 seconds, delay sole-task replacement 61 seconds | The game returns the explicit unrecoverable outcome and no fabricated state. |
@@ -989,7 +1031,7 @@ criteria pass before the production ramp.
 | `server/src/game_bus.rs` | Executor consumer-group reader, safe command retention, deterministic routing through fifty prewarmed partition-hot lanes and fifty independently prewarmed partition-scoped recovery-read lanes, event-only gateway subscriptions, lease-aware single-slot scripts, versioned checkpoint APIs, idempotent outbox delivery, and separately retryable completion cleanup. |
 | `server/src/game_executor_v2.rs` | Recovery envelope, dedupe, active-game index, backlog-first resume, cooperative checkpoint/release, idempotent finalization. |
 | `server/src/game_server.rs` and `main.rs` | SIGTERM, lifecycle state, readiness state, critical-worker failure policy, one bounded drain deadline. |
-| `server/src/replication.rs` | Event-only resumable partition readers and broadcast-before-eviction handling for atomically durable terminal snapshots. |
+| `server/src/replication.rs` | Stateless `GameEventRouter`: event-only resumable partition readers, per-game broadcast channels created only for locally subscribed games, per-subscription cold/re-anchor continuity rules, per-game targeted-request coalescing, and terminal-snapshot forwarding before broadcaster teardown. No `ReplicaStore` or reconstructed `GameState`. |
 | `server/src/matchmaking.rs` and manager | Atomic queue admission/cancellation/commit scripts, durable user-to-game mappings, and a bounded `GameCreated` outbox routed through one nonblocking delivery worker per fixed partition. |
 | `server/src/ws_server.rs` | Explicit auth response, drain protocol, generation-safe cleanup, active-game resolution, retryable warming. |
 | `client/web/contexts/WebSocketContext.tsx` | Immediate/backoff reconnect, socket generations, dual-socket drain, explicit auth, one command owner. |
@@ -1010,8 +1052,20 @@ criteria pass before the production ramp.
 - Active authority is an exact, unique lease token.
 - Consumer groups are executor-only.
 - The fenced consumer-group executor is the only executor implementation.
-- Gateway replicas tail only authoritative partition events; they do not consume
-  executor commands or snapshot requests.
+- Gateway event routers tail only authoritative partition events; they do not
+  consume executor commands or snapshot requests.
+- Gateways hold no reconstructed `GameState`. The only live authoritative game
+  state is the exact lease holder's; a gateway may hold a bounded snapshot
+  payload only while delivering it to a local socket. Join authorization uses
+  the durable `ActiveMatch` roster with the validated recovery envelope as the
+  fallback for games without one.
+- Removing gateway state replication required no executor protocol version
+  bump: the readiness probe reuses the existing snapshot-barrier wire shape,
+  and old executors answering it with the full fan-out remain correct.
+- Client-side `TickHash` verification (with resync-request metrics and client
+  trace upload) is the production desync detector; forwarding `TickHash`
+  heartbeats end-to-end is therefore a routing correctness requirement, and
+  the retired server-side replica fingerprint check is not reintroduced.
 - `CommandScheduledV2` is the positive semantic acknowledgement; `XACK` is still required internally.
 - Checkpoints remain full and per game.
 - Recovery reads use fifty fixed partition lanes, resilience metrics use a
@@ -1024,7 +1078,7 @@ criteria pass before the production ramp.
 - Readiness and liveness are separate.
 - Executor-placement eligibility is also separate from gateway readiness so an
   unready first/replacement gateway can own the executor that completes its
-  ordered initial-snapshot barrier.
+  ordered initial reader barrier.
 - CPU/memory autoscaling and `minTasks=1` remain.
 - Regional Serverless Valkey and single-ingress availability risks are accepted for this phase.
 - Serverless Valkey uses its fixed `volatile-lru` policy. CDK sets no data/ECPU usage maximum; any eviction or throttling fails certification and alarms in production.


### PR DESCRIPTION
## Summary

Gateways no longer replicate game state. Every task used to run replica workers for all 50 partitions and retain a full `GameState` for **every active game in the region**, applying each event to it — so regional memory scaled with `tasks × games`, and every task paid a full-`GameState` clone per delta per game. This replaces that with stateless event routing: partition readers forward per-game events to locally subscribed sockets and retain nothing.

The invariant is now: **the only live authoritative `GameState` is the exact lease holder's**; a gateway may hold a bounded snapshot payload only while delivering it to a socket. Total retained states equals the number of active games, not active games × task count.

This was safe to do because the authoritative recovery path never used replicas: executor takeover already restores from the fenced Redis recovery envelope plus the pending command PEL, decision journal, and handoff watermark.

## What changed

**`replication.rs` — `ReplicationManager` → `GameEventRouter`.** `ReplicaStore`, `ReplicatedGame`, `GameStateReader`, delta application, tick simulation, and fingerprint reconstruction are gone. Partition readers keep the boot-unique barrier readiness proof on the same wire format. Per-game broadcast channels are created only when a local socket subscribes and torn down when the last one leaves.

**Continuity moved from shared replica state to the per-socket subscription.** These rules are load-bearing:
- a subscription is cold until it forwards a `Snapshot`; sequenced deltas are suppressed while cold
- every `Snapshot` re-anchors the watermark **unconditionally** — a failed-over executor restarts `stream_seq` near 1, so comparing against the old epoch would wedge the socket forever
- `stream_seq == 0` events are out-of-band terminal `CommandRejected` messages and are forwarded by command identity **even while cold**, so a player never loses a command outcome during warm-up
- a gap or broadcast lag returns the subscription to cold rather than forwarding unverified continuations, with targeted snapshot requests coalesced to one per game per gateway per 500 ms

**Joins authorize from durable sources.** The `ActiveMatch` roster first, then the validated recovery envelope (which covers legacy/custom games that predate roster attestation), then the stored/DynamoDB terminal record. The envelope doubles as the join bridge snapshot, so the first frame arrives in one Redis GET and contiguous live deltas forward without waiting for a fresh snapshot.

**Desync detection.** Server-side replica fingerprint verification was the only producer of `RecoveryFingerprintDivergences`; it is retired with its metric. Client-side `TickHash` verification is now the production detector, which makes forwarding `TickHash` heartbeats end-to-end a **routing correctness requirement** — recorded in both the PRD and DEBUGGING.md.

## Deliberately not done

Two changes that looked reasonable but are wrong against this codebase:

- **No `EXECUTOR_PROTOCOL_VERSION` bump.** That constant is an exact-equality mutual-exclusion fence enforced at assignment eligibility, urgent-owner-loss, and on *every* recovery-envelope read — not a negotiation scheme. Bumping it would deadlock a rolling deploy: a new task's `/health/ready` needs its barrier acked by the partition's current owner, which is an old-version executor for the whole window. The readiness probe reuses the existing `SnapshotRequest.completion_id` barrier shape instead, and old executors answering it with the full fan-out remain correct.
- **The `game_snapshot` key layout is untouched.** Active and terminal stored snapshots share one key by design, and the terminal-pending TTL-refresh script fails closed if it is absent — so "stop writing the active copy, keep the terminal one" would turn a DynamoDB blip into partition-level actor death via the fail-closed checkpoint-age watchdog. Consolidating it is a separate decision requiring a Lua rework plus a recovery schema version.

## Two bugs this surfaced

**Readiness could outrun game creation.** With roster-based authorization, a hint-driven client confirms readiness milliseconds after the matchmaking commit — before the outbox scanner delivers `GameCreated`. The confirmation then entered the partition command stream ahead of `GameCreated` and was quarantined as targeting an inactive game, holding the match until its readiness deadline. Replica-based authorization had been serializing this by accident. Readiness publication now waits (bounded, fail-open, detached from the socket loop, bound to task cancellation) for the fenced envelope that proves the actor exists.

**A stale envelope could shadow a completed game.** The completion race can leave a non-terminal envelope in Redis while DynamoDB already holds the final state. The durable terminal record is now consulted before any bridge, so the client gets the final snapshot instead of a stale active frame with no live stream behind it.

## PRD

`specs/autoscaling-resilience-prd.md` is amended, not reinterpreted — DoD item 1 requires dropped requirements to be explicitly removed by an approved change, and R12.6 already framed the replication model as "a separate decision". The local-replica model appeared in ~20 normative locations (R6.12/R6.14/R6.15, R8.1, R10.3, R10.7, workflow 11.1.6, acceptance rows, locked decisions, component impact); all now describe stateless routing, plus new acceptance rows for owner-on-A/socket-on-B delivery and for cold-subscription re-anchoring.

## Testing

- **473/473 pass** (`cargo nextest run -p server --profile ci`), three consecutive clean full-suite runs; clippy and `fmt --check` clean.
- New coverage: cold-subscription delta suppression, snapshot re-anchoring across `stream_seq` epochs, bridge-anchored contiguous delivery, gap→cold→recover, `stream_seq == 0` rejection passthrough while cold, lagged-subscription recovery, terminal-snapshot forwarding before channel teardown, abandoned-channel pruning, per-game request coalescing, and readiness-barrier ordering with subscriber delivery.
- Integration tests that fabricated live games via the event stream now also write the fenced envelope, matching what an executor checkpoint actually produces.
- An earlier run showed two `lobby_matchmaking_tests` failures. They were **environmental** — that run predates a LocalStack restart, both tests pass in every run since, and neither reaches changed code (one is lobby-only; the other never sends `PlayerReady`). A targeted run of that binary confirmed **zero** warm-up fallthroughs across all 34 tests, closing the only branch-specific mechanism. Those tests' bare timeouts now carry context so a future failure names the await that expired.

## Follow-up (not in this PR)

The loadtest bot (`bot/src/main.rs`) ignores `GameWarming` and never retries a join. Warming is a normal first response under the new model, so the bot needs preserve-and-retry (as the web client already does) before it can produce valid scale evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
