### PR TITLE
Refresh the PotG fixture and calibration clips past two version bumps

### DIFF
--- a/client/web/fixtures/potg-goal-run.json
+++ b/client/web/fixtures/potg-goal-run.json
@@ -10,9 +10,9 @@
       "points": 15
     }
   },
-  "score": 125,
+  "score": 140,
   "breakdown": {
-    "total": 125,
+    "total": 140,
     "focus_tick": 144,
     "kills": 0,
     "boosted_cutoff_kills": 0,
@@ -21,7 +21,7 @@
     "max_chain": 0,
     "pickups": 0,
     "demolition_points": 0,
-    "banking_points": 125,
+    "banking_points": 140,
     "combo_points": 0
   },
   "window": {
@@ -331,12 +331,13 @@
       "2": "DEFENDER",
       "1": "BANKER"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},
     "team_scores": {
-      "1": 0,
-      "0": 0
+      "0": 0,
+      "1": 0
     },
     "player_xp": {},
     "player_action_counts": {},
@@ -635,7 +636,7 @@
     ]
   },
   "config": {
-    "rules_version": 1,
+    "rules_version": 2,
     "minimum_score": 120,
     "elimination": 90,
     "mutual_trade": 60,
@@ -646,9 +647,9 @@
     "laden_per_point": 4,
     "laden_cap": 50,
     "teammate_kill": -80,
-    "banked_per_point": 5,
+    "banked_per_point": 6,
     "big_carry": 50,
-    "combo_step": 15,
+    "combo_step": 21,
     "nick_of_time": 10,
     "boosted_pickup": 5,
     "feeding_frenzy": 20,

--- a/common/examples/export_potg_fixture.rs
+++ b/common/examples/export_potg_fixture.rs
@@ -1,7 +1,15 @@
 //! Regenerates the browser QA's production-shaped Play-of-the-Game fixture.
 //!
-//! Run from the repository root:
-//! `cargo run -q -p common --example export_potg_fixture`
+//! The clip is written to stdout, so the redirect is not optional — without it
+//! the fixture on disk keeps whatever scoring rules and gameplay version it was
+//! last written under, and the QA lab silently exercises a stale clip. Run from
+//! the repository root:
+//!
+//! `cargo run -q -p common --example export_potg_fixture > client/web/fixtures/potg-goal-run.json`
+//!
+//! Regenerate after any change to `HighlightConfig`'s defaults (including its
+//! `rules_version`), to `GAMEPLAY_REPLAY_VERSION`, or to the serialized shape
+//! of `GameState`: the fixture embeds all three and nothing else validates it.
 
 use anyhow::{Context, Result};
 use common::{

--- a/docs/qa/play-of-the-game-calibration/README.md
+++ b/docs/qa/play-of-the-game-calibration/README.md
@@ -33,6 +33,33 @@ selected clip, writes `corpus-summary.json`, and exits unsuccessfully unless:
   two active players produce a highlight;
 - no Demolition, Banking, Combo, or Frenzy category exceeds 60% of winners.
 
+> **Point it at a scratch directory unless you mean to redo the human gate.**
+> Writing straight into this directory also rewrites `corpus-summary.json`,
+> `top-20-review.json` and `review-template.csv` with blank human-review
+> fields, discarding hand-entered verdicts that are not tool output. Nothing
+> regenerates those, and `client/web/tests/unit/potgCalibrationArtifacts.test.ts`
+> fails once they are gone.
+>
+> To refresh only the clip data — which is what a `GAMEPLAY_REPLAY_VERSION`
+> bump or a change to the serialized shape of `GameState` requires, since
+> the browser rejects any clip whose `gameplay_version` differs from the
+> protocol it speaks — generate into a scratch directory and copy `clips/`
+> back:
+>
+> ```sh
+> cargo run -p server --release --bin highlight_tune -- \
+>   --bot-corpus-dir /tmp/potg-regen \
+>   --games 200 --seed 0x534e414b4554524f --review-count 20
+> cp /tmp/potg-regen/clips/*.json docs/qa/play-of-the-game-calibration/clips/
+> ```
+>
+> Diff the scratch `corpus-summary.json` and `top-20-review.json` against the
+> checked-in ones first: apart from the blanked human-review fields they should
+> be identical, and any other difference means the corpus itself moved and the
+> human gate genuinely has to be redone. Clip regeneration is deterministic in
+> content but not byte-stable — `HashMap` fields such as `last_death_causes`
+> serialize in arbitrary key order, so expect reordering noise in the diff.
+
 `tuning-rounds.json` records the fixed-seed baseline and the only tuning round.
 Round 1 changed only `banked_per_point` (`5 -> 6`) and `combo_step` (`15 ->
 21`), promoting the calibrated defaults to rules version 2. The 120-point

--- a/docs/qa/play-of-the-game-calibration/clips/01-game-8000148.json
+++ b/docs/qa/play-of-the-game-calibration/clips/01-game-8000148.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000148,
   "star_user_id": 10002,
   "star_snake_id": 2,
@@ -385,10 +385,10 @@
       }
     ],
     "last_death_causes": {
-      "1": "Banked",
       "2": "Banked",
-      "0": "Banked",
-      "3": "Banked"
+      "1": "Banked",
+      "3": "Banked",
+      "0": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -425,21 +425,21 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
       },
       "10001": {
         "user_id": 10001,
         "snake_id": 1
       },
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
-      },
       "10002": {
         "user_id": 10002,
         "snake_id": 2
+      },
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       }
     },
     "rng": null,
@@ -448,34 +448,35 @@
     "start_ms": 0,
     "event_sequence": 368,
     "usernames": {
-      "10000": "Corpus Bot 1",
-      "10002": "Corpus Bot 3",
       "10003": "Corpus Bot 4",
-      "10001": "Corpus Bot 2"
+      "10001": "Corpus Bot 2",
+      "10002": "Corpus Bot 3",
+      "10000": "Corpus Bot 1"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "3": 16,
-      "2": 19,
       "0": 16,
+      "2": 19,
       "1": 19
     },
     "food_pickups": {
+      "1": 13,
       "0": 12,
       "3": 12,
-      "2": 13,
-      "1": 13
+      "2": 13
     },
     "team_scores": {
-      "1": 31,
-      "0": 31
+      "0": 31,
+      "1": 31
     },
     "player_xp": {},
     "player_action_counts": {
-      "10002": 45,
       "10000": 44,
-      "10003": 41,
-      "10001": 41
+      "10002": 45,
+      "10001": 41,
+      "10003": 41
     },
     "player_last_activity_ticks": {
       "10000": 498,

--- a/docs/qa/play-of-the-game-calibration/clips/02-game-8000001.json
+++ b/docs/qa/play-of-the-game-calibration/clips/02-game-8000001.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000001,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -403,6 +403,7 @@
       }
     ],
     "last_death_causes": {
+      "0": "Banked",
       "1": {
         "HeadToHead": {
           "other_snake_id": 3
@@ -412,8 +413,7 @@
         "HeadToHead": {
           "other_snake_id": 1
         }
-      },
-      "0": "Banked"
+      }
     },
     "game_type": {
       "TeamMatch": {
@@ -450,21 +450,21 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
-      },
-      "10002": {
-        "user_id": 10002,
-        "snake_id": 2
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
       },
       "10001": {
         "user_id": 10001,
         "snake_id": 1
       },
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
+      "10002": {
+        "user_id": 10002,
+        "snake_id": 2
+      },
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       }
     },
     "rng": null,
@@ -474,18 +474,19 @@
     "event_sequence": 62,
     "usernames": {
       "10000": "Corpus Bot 1",
-      "10003": "Corpus Bot 4",
+      "10001": "Corpus Bot 2",
       "10002": "Corpus Bot 3",
-      "10001": "Corpus Bot 2"
+      "10003": "Corpus Bot 4"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "0": 4,
-      "2": 7
+      "2": 7,
+      "0": 4
     },
     "food_pickups": {
-      "2": 4,
-      "0": 3
+      "0": 3,
+      "2": 4
     },
     "team_scores": {
       "0": 4,
@@ -493,16 +494,16 @@
     },
     "player_xp": {},
     "player_action_counts": {
-      "10002": 8,
-      "10001": 4,
       "10003": 4,
-      "10000": 5
+      "10000": 5,
+      "10002": 8,
+      "10001": 4
     },
     "player_last_activity_ticks": {
-      "10002": 98,
-      "10001": 98,
+      "10003": 98,
       "10000": 98,
-      "10003": 98
+      "10001": 98,
+      "10002": 98
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,
@@ -11855,10 +11856,10 @@
       "event": {
         "XPAwarded": {
           "player_xp": {
-            "10002": 110,
+            "10003": 10,
             "10001": 10,
-            "10000": 150,
-            "10003": 10
+            "10002": 110,
+            "10000": 150
           }
         }
       }

--- a/docs/qa/play-of-the-game-calibration/clips/03-game-8000118.json
+++ b/docs/qa/play-of-the-game-calibration/clips/03-game-8000118.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000118,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -381,8 +381,8 @@
       }
     ],
     "last_death_causes": {
-      "3": "Banked",
       "1": "OutOfBounds",
+      "3": "Banked",
       "0": "Banked"
     },
     "game_type": {
@@ -424,17 +424,17 @@
         "user_id": 10001,
         "snake_id": 1
       },
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       },
       "10002": {
         "user_id": 10002,
         "snake_id": 2
       },
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
       }
     },
     "rng": null,
@@ -443,23 +443,24 @@
     "start_ms": 0,
     "event_sequence": 75,
     "usernames": {
-      "10003": "Corpus Bot 4",
-      "10002": "Corpus Bot 3",
       "10001": "Corpus Bot 2",
-      "10000": "Corpus Bot 1"
+      "10000": "Corpus Bot 1",
+      "10002": "Corpus Bot 3",
+      "10003": "Corpus Bot 4"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "1": 2,
-      "0": 4,
+      "2": 4,
       "3": 4,
-      "2": 4
+      "0": 4,
+      "1": 2
     },
     "food_pickups": {
-      "0": 3,
-      "2": 3,
       "3": 3,
-      "1": 2
+      "1": 2,
+      "2": 3,
+      "0": 3
     },
     "team_scores": {
       "0": 4,
@@ -467,10 +468,10 @@
     },
     "player_xp": {},
     "player_action_counts": {
-      "10000": 8,
+      "10003": 10,
       "10001": 5,
       "10002": 10,
-      "10003": 10
+      "10000": 8
     },
     "player_last_activity_ticks": {
       "10003": 98,

--- a/docs/qa/play-of-the-game-calibration/clips/04-game-8000103.json
+++ b/docs/qa/play-of-the-game-calibration/clips/04-game-8000103.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000103,
   "star_user_id": 10002,
   "star_snake_id": 2,
@@ -385,8 +385,8 @@
     "last_death_causes": {
       "3": "Banked",
       "2": "Banked",
-      "0": "Banked",
-      "1": "Banked"
+      "1": "Banked",
+      "0": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -423,14 +423,6 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
-      },
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10002": {
         "user_id": 10002,
         "snake_id": 2
@@ -438,6 +430,14 @@
       "10003": {
         "user_id": 10003,
         "snake_id": 3
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
+      },
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       }
     },
     "rng": null,
@@ -446,34 +446,35 @@
     "start_ms": 0,
     "event_sequence": 307,
     "usernames": {
-      "10001": "Corpus Bot 2",
       "10000": "Corpus Bot 1",
+      "10001": "Corpus Bot 2",
       "10003": "Corpus Bot 4",
       "10002": "Corpus Bot 3"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
+      "2": 10,
       "1": 16,
       "0": 12,
-      "3": 16,
-      "2": 10
+      "3": 16
     },
     "food_pickups": {
-      "1": 12,
       "2": 7,
       "3": 12,
-      "0": 8
+      "0": 8,
+      "1": 12
     },
     "team_scores": {
-      "1": 28,
-      "0": 14
+      "0": 14,
+      "1": 28
     },
     "player_xp": {},
     "player_action_counts": {
-      "10002": 36,
       "10001": 25,
       "10000": 32,
-      "10003": 35
+      "10003": 35,
+      "10002": 36
     },
     "player_last_activity_ticks": {
       "10002": 398,

--- a/docs/qa/play-of-the-game-calibration/clips/05-game-8000123.json
+++ b/docs/qa/play-of-the-game-calibration/clips/05-game-8000123.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000123,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -387,10 +387,10 @@
       }
     ],
     "last_death_causes": {
-      "2": "Banked",
-      "1": "Banked",
+      "3": "Banked",
       "0": "Banked",
-      "3": "Banked"
+      "1": "Banked",
+      "2": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -427,17 +427,17 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
+      "10002": {
+        "user_id": 10002,
+        "snake_id": 2
       },
       "10001": {
         "user_id": 10001,
         "snake_id": 1
       },
-      "10002": {
-        "user_id": 10002,
-        "snake_id": 2
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       },
       "10003": {
         "user_id": 10003,
@@ -450,11 +450,12 @@
     "start_ms": 0,
     "event_sequence": 365,
     "usernames": {
-      "10002": "Corpus Bot 3",
-      "10001": "Corpus Bot 2",
       "10000": "Corpus Bot 1",
-      "10003": "Corpus Bot 4"
+      "10001": "Corpus Bot 2",
+      "10003": "Corpus Bot 4",
+      "10002": "Corpus Bot 3"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "0": 15,
@@ -463,27 +464,27 @@
       "2": 20
     },
     "food_pickups": {
-      "2": 14,
       "1": 15,
+      "2": 14,
       "0": 12,
       "3": 12
     },
     "team_scores": {
-      "0": 29,
-      "1": 32
+      "1": 32,
+      "0": 29
     },
     "player_xp": {},
     "player_action_counts": {
-      "10003": 46,
-      "10002": 40,
       "10000": 35,
-      "10001": 35
+      "10003": 46,
+      "10001": 35,
+      "10002": 40
     },
     "player_last_activity_ticks": {
       "10000": 498,
-      "10003": 498,
+      "10001": 498,
       "10002": 498,
-      "10001": 498
+      "10003": 498
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/06-game-8000064.json
+++ b/docs/qa/play-of-the-game-calibration/clips/06-game-8000064.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000064,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -293,14 +293,14 @@
       }
     ],
     "last_death_causes": {
-      "1": {
-        "HeadToHead": {
-          "other_snake_id": 0
-        }
-      },
       "0": {
         "HeadToHead": {
           "other_snake_id": 1
+        }
+      },
+      "1": {
+        "HeadToHead": {
+          "other_snake_id": 0
         }
       }
     },
@@ -339,13 +339,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
-      },
       "10001": {
         "user_id": 10001,
         "snake_id": 1
+      },
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       }
     },
     "rng": null,
@@ -354,15 +354,16 @@
     "start_ms": 0,
     "event_sequence": 109,
     "usernames": {
-      "10000": "Corpus Bot 1",
-      "10001": "Corpus Bot 2"
+      "10001": "Corpus Bot 2",
+      "10000": "Corpus Bot 1"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},
     "team_scores": {
-      "1": 0,
-      "0": 0
+      "0": 0,
+      "1": 0
     },
     "player_xp": {},
     "player_action_counts": {},

--- a/docs/qa/play-of-the-game-calibration/clips/07-game-8000150.json
+++ b/docs/qa/play-of-the-game-calibration/clips/07-game-8000150.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000150,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -333,14 +333,15 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "1": 16,
-      "0": 12
+      "0": 12,
+      "1": 16
     },
     "food_pickups": {
-      "0": 9,
-      "1": 12
+      "1": 12,
+      "0": 9
     },
     "team_scores": {
       "0": 12,

--- a/docs/qa/play-of-the-game-calibration/clips/08-game-8000151.json
+++ b/docs/qa/play-of-the-game-calibration/clips/08-game-8000151.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000151,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -397,6 +397,10 @@
         "user_id": 10000,
         "snake_id": 0
       },
+      "10002": {
+        "user_id": 10002,
+        "snake_id": 2
+      },
       "10003": {
         "user_id": 10003,
         "snake_id": 3
@@ -404,10 +408,6 @@
       "10001": {
         "user_id": 10001,
         "snake_id": 1
-      },
-      "10002": {
-        "user_id": 10002,
-        "snake_id": 2
       }
     },
     "rng": null,
@@ -416,23 +416,24 @@
     "start_ms": 0,
     "event_sequence": 0,
     "usernames": {
-      "10000": "Corpus Bot 1",
       "10002": "Corpus Bot 3",
+      "10001": "Corpus Bot 2",
       "10003": "Corpus Bot 4",
-      "10001": "Corpus Bot 2"
+      "10000": "Corpus Bot 1"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},
     "team_scores": {
-      "1": 0,
-      "0": 0
+      "0": 0,
+      "1": 0
     },
     "player_xp": {},
     "player_action_counts": {},
     "player_last_activity_ticks": {
-      "10003": 0,
       "10001": 0,
+      "10003": 0,
       "10002": 0,
       "10000": 0
     },

--- a/docs/qa/play-of-the-game-calibration/clips/09-game-8000022.json
+++ b/docs/qa/play-of-the-game-calibration/clips/09-game-8000022.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000022,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -265,8 +265,8 @@
       }
     },
     "last_death_causes": {
-      "1": "Banked",
-      "0": "Banked"
+      "0": "Banked",
+      "1": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -303,13 +303,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -321,6 +321,7 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "0": 8,
@@ -336,8 +337,8 @@
     },
     "player_xp": {},
     "player_action_counts": {
-      "10001": 17,
-      "10000": 14
+      "10000": 14,
+      "10001": 17
     },
     "player_last_activity_ticks": {
       "10001": 198,

--- a/docs/qa/play-of-the-game-calibration/clips/10-game-8000065.json
+++ b/docs/qa/play-of-the-game-calibration/clips/10-game-8000065.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000065,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -322,9 +322,10 @@
     "start_ms": 0,
     "event_sequence": 104,
     "usernames": {
-      "10001": "Corpus Bot 2",
-      "10000": "Corpus Bot 1"
+      "10000": "Corpus Bot 1",
+      "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "1": 10,

--- a/docs/qa/play-of-the-game-calibration/clips/11-game-8000072.json
+++ b/docs/qa/play-of-the-game-calibration/clips/11-game-8000072.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000072,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -265,8 +265,8 @@
       }
     },
     "last_death_causes": {
-      "1": "Banked",
-      "0": "Banked"
+      "0": "Banked",
+      "1": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -303,13 +303,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -318,17 +318,18 @@
     "start_ms": 0,
     "event_sequence": 408,
     "usernames": {
-      "10001": "Corpus Bot 2",
-      "10000": "Corpus Bot 1"
+      "10000": "Corpus Bot 1",
+      "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "1": 46,
       "0": 36
     },
     "food_pickups": {
-      "1": 33,
-      "0": 28
+      "0": 28,
+      "1": 33
     },
     "team_scores": {
       "0": 36,
@@ -340,8 +341,8 @@
       "10000": 82
     },
     "player_last_activity_ticks": {
-      "10000": 1198,
-      "10001": 1198
+      "10001": 1198,
+      "10000": 1198
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,
@@ -5650,8 +5651,8 @@
       "event": {
         "XPAwarded": {
           "player_xp": {
-            "10000": 340,
-            "10001": 430
+            "10001": 430,
+            "10000": 340
           }
         }
       }

--- a/docs/qa/play-of-the-game-calibration/clips/12-game-8000099.json
+++ b/docs/qa/play-of-the-game-calibration/clips/12-game-8000099.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000099,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -277,8 +277,8 @@
       }
     ],
     "last_death_causes": {
-      "0": "Banked",
-      "1": "Banked"
+      "1": "Banked",
+      "0": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -333,10 +333,11 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "0": 20,
-      "1": 22
+      "1": 22,
+      "0": 20
     },
     "food_pickups": {
       "0": 15,
@@ -348,12 +349,12 @@
     },
     "player_xp": {},
     "player_action_counts": {
-      "10001": 42,
-      "10000": 33
+      "10000": 33,
+      "10001": 42
     },
     "player_last_activity_ticks": {
-      "10001": 1698,
-      "10000": 1698
+      "10000": 1698,
+      "10001": 1698
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/13-game-8000003.json
+++ b/docs/qa/play-of-the-game-calibration/clips/13-game-8000003.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000003,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -401,9 +401,9 @@
       }
     ],
     "last_death_causes": {
-      "2": "Banked",
-      "3": "Banked",
       "1": "Banked",
+      "3": "Banked",
+      "2": "Banked",
       "0": "Banked"
     },
     "game_type": {
@@ -441,21 +441,21 @@
       "tombstone_ids": []
     },
     "players": {
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
+      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
-      },
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
       },
       "10002": {
         "user_id": 10002,
         "snake_id": 2
       },
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -464,40 +464,41 @@
     "start_ms": 0,
     "event_sequence": 236,
     "usernames": {
-      "10001": "Corpus Bot 2",
       "10002": "Corpus Bot 3",
+      "10001": "Corpus Bot 2",
       "10000": "Corpus Bot 1",
       "10003": "Corpus Bot 4"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "0": 10,
+      "3": 12,
       "1": 15,
       "2": 11,
-      "3": 12
+      "0": 10
     },
     "food_pickups": {
-      "2": 7,
       "1": 10,
-      "3": 9,
-      "0": 8
+      "2": 7,
+      "0": 8,
+      "3": 9
     },
     "team_scores": {
-      "0": 21,
-      "1": 27
+      "1": 27,
+      "0": 21
     },
     "player_xp": {},
     "player_action_counts": {
-      "10003": 27,
+      "10000": 29,
       "10002": 25,
-      "10001": 20,
-      "10000": 29
+      "10003": 27,
+      "10001": 20
     },
     "player_last_activity_ticks": {
-      "10001": 298,
+      "10003": 298,
       "10002": 298,
-      "10000": 298,
-      "10003": 298
+      "10001": 298,
+      "10000": 298
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/14-game-8000052.json
+++ b/docs/qa/play-of-the-game-calibration/clips/14-game-8000052.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000052,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -269,8 +269,8 @@
       }
     },
     "last_death_causes": {
-      "1": "Banked",
-      "0": "Banked"
+      "0": "Banked",
+      "1": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -307,13 +307,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -325,27 +325,28 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "0": 37,
-      "1": 42
+      "1": 42,
+      "0": 37
     },
     "food_pickups": {
       "1": 32,
       "0": 29
     },
     "team_scores": {
-      "1": 36,
-      "0": 32
+      "0": 32,
+      "1": 36
     },
     "player_xp": {},
     "player_action_counts": {
-      "10000": 71,
-      "10001": 77
+      "10001": 77,
+      "10000": 71
     },
     "player_last_activity_ticks": {
-      "10000": 1198,
-      "10001": 1198
+      "10001": 1198,
+      "10000": 1198
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/15-game-8000152.json
+++ b/docs/qa/play-of-the-game-calibration/clips/15-game-8000152.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000152,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -299,13 +299,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
-      },
       "10001": {
         "user_id": 10001,
         "snake_id": 1
+      },
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       }
     },
     "rng": null,
@@ -317,6 +317,7 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},
@@ -327,8 +328,8 @@
     "player_xp": {},
     "player_action_counts": {},
     "player_last_activity_ticks": {
-      "10001": 0,
-      "10000": 0
+      "10000": 0,
+      "10001": 0
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/16-game-8000082.json
+++ b/docs/qa/play-of-the-game-calibration/clips/16-game-8000082.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000082,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -325,14 +325,15 @@
       "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "0": 39,
       "1": 36
     },
     "food_pickups": {
-      "1": 27,
-      "0": 27
+      "0": 27,
+      "1": 27
     },
     "team_scores": {
       "1": 32,
@@ -344,8 +345,8 @@
       "10000": 67
     },
     "player_last_activity_ticks": {
-      "10000": 1098,
-      "10001": 1098
+      "10001": 1098,
+      "10000": 1098
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/17-game-8000121.json
+++ b/docs/qa/play-of-the-game-calibration/clips/17-game-8000121.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000121,
   "star_user_id": 10002,
   "star_snake_id": 2,
@@ -393,9 +393,9 @@
       "tombstone_ids": []
     },
     "players": {
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       },
       "10001": {
         "user_id": 10001,
@@ -405,9 +405,9 @@
         "user_id": 10002,
         "snake_id": 2
       },
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
       }
     },
     "rng": null,
@@ -416,25 +416,26 @@
     "start_ms": 0,
     "event_sequence": 0,
     "usernames": {
+      "10000": "Corpus Bot 1",
       "10001": "Corpus Bot 2",
       "10002": "Corpus Bot 3",
-      "10003": "Corpus Bot 4",
-      "10000": "Corpus Bot 1"
+      "10003": "Corpus Bot 4"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},
     "team_scores": {
-      "1": 0,
-      "0": 0
+      "0": 0,
+      "1": 0
     },
     "player_xp": {},
     "player_action_counts": {},
     "player_last_activity_ticks": {
-      "10000": 0,
       "10003": 0,
-      "10001": 0,
-      "10002": 0
+      "10002": 0,
+      "10000": 0,
+      "10001": 0
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/18-game-8000191.json
+++ b/docs/qa/play-of-the-game-calibration/clips/18-game-8000191.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000191,
   "star_user_id": 10003,
   "star_snake_id": 3,
@@ -393,9 +393,9 @@
       "tombstone_ids": []
     },
     "players": {
-      "10003": {
-        "user_id": 10003,
-        "snake_id": 3
+      "10000": {
+        "user_id": 10000,
+        "snake_id": 0
       },
       "10001": {
         "user_id": 10001,
@@ -405,9 +405,9 @@
         "user_id": 10002,
         "snake_id": 2
       },
-      "10000": {
-        "user_id": 10000,
-        "snake_id": 0
+      "10003": {
+        "user_id": 10003,
+        "snake_id": 3
       }
     },
     "rng": null,
@@ -416,11 +416,12 @@
     "start_ms": 0,
     "event_sequence": 0,
     "usernames": {
+      "10001": "Corpus Bot 2",
       "10000": "Corpus Bot 1",
       "10003": "Corpus Bot 4",
-      "10002": "Corpus Bot 3",
-      "10001": "Corpus Bot 2"
+      "10002": "Corpus Bot 3"
     },
+    "skins": {},
     "spectators": [],
     "scores": {},
     "food_pickups": {},

--- a/docs/qa/play-of-the-game-calibration/clips/19-game-8000199.json
+++ b/docs/qa/play-of-the-game-calibration/clips/19-game-8000199.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000199,
   "star_user_id": 10001,
   "star_snake_id": 1,
@@ -325,13 +325,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -340,17 +340,18 @@
     "start_ms": 0,
     "event_sequence": 381,
     "usernames": {
-      "10000": "Corpus Bot 1",
-      "10001": "Corpus Bot 2"
+      "10001": "Corpus Bot 2",
+      "10000": "Corpus Bot 1"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
-      "1": 25,
-      "0": 28
+      "0": 28,
+      "1": 25
     },
     "food_pickups": {
-      "0": 21,
-      "1": 19
+      "1": 19,
+      "0": 21
     },
     "team_scores": {
       "1": 25,
@@ -362,8 +363,8 @@
       "10000": 58
     },
     "player_last_activity_ticks": {
-      "10000": 1998,
-      "10001": 1998
+      "10001": 1998,
+      "10000": 1998
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,

--- a/docs/qa/play-of-the-game-calibration/clips/20-game-8000047.json
+++ b/docs/qa/play-of-the-game-calibration/clips/20-game-8000047.json
@@ -1,6 +1,6 @@
 {
   "clip_format_version": 1,
-  "gameplay_version": 9,
+  "gameplay_version": 10,
   "game_id": 8000047,
   "star_user_id": 10000,
   "star_snake_id": 0,
@@ -287,8 +287,8 @@
       }
     ],
     "last_death_causes": {
-      "1": "Banked",
-      "0": "Banked"
+      "0": "Banked",
+      "1": "Banked"
     },
     "game_type": {
       "TeamMatch": {
@@ -325,13 +325,13 @@
       "tombstone_ids": []
     },
     "players": {
-      "10001": {
-        "user_id": 10001,
-        "snake_id": 1
-      },
       "10000": {
         "user_id": 10000,
         "snake_id": 0
+      },
+      "10001": {
+        "user_id": 10001,
+        "snake_id": 1
       }
     },
     "rng": null,
@@ -340,9 +340,10 @@
     "start_ms": 0,
     "event_sequence": 301,
     "usernames": {
-      "10001": "Corpus Bot 2",
-      "10000": "Corpus Bot 1"
+      "10000": "Corpus Bot 1",
+      "10001": "Corpus Bot 2"
     },
+    "skins": {},
     "spectators": [],
     "scores": {
       "1": 32,
@@ -353,8 +354,8 @@
       "1": 24
     },
     "team_scores": {
-      "1": 32,
-      "0": 34
+      "0": 34,
+      "1": 32
     },
     "player_xp": {},
     "player_action_counts": {
@@ -362,8 +363,8 @@
       "10001": 59
     },
     "player_last_activity_ticks": {
-      "10000": 898,
-      "10001": 898
+      "10001": 898,
+      "10000": 898
     },
     "idle_kicked_user_ids": [],
     "completed_by_inactivity": false,


### PR DESCRIPTION
Two checked-in Play-of-the-Game data files had fallen behind version bumps that nothing regenerates automatically. Neither is a code defect — both are data that predates a bump, and in both cases the thing that should have caught it couldn't.

## The QA fixture was a scoring-rules version behind

`client/web/fixtures/potg-goal-run.json` carried `rules_version: 1`; the current scorer is on 2.

| field | was | now |
|---|---|---|
| `config.rules_version` | 1 | 2 |
| `config.banked_per_point` | 5 | 6 |
| `config.combo_step` | 15 | 21 |
| `score` / `breakdown.banking_points` | 125 | 140 |
| `anchor.skins` | *absent* | `{}` |

`window`, `reason`, `presentation`, `messages` and `end_sync_hash` are byte-identical under both rule sets — which is precisely why the Playwright assertions kept passing. They check the reason text and the speed segments, and neither moved.

The `anchor.skins` row is a second axis of staleness that wasn't in the original report: the fixture also predates a serialized `GameState` field. `common/tests/potg_browser_fixture.rs` replays the fixture and checks its end hash, but asserts nothing about the score or the rule set, so it never saw either problem.

## The calibration clips were a gameplay protocol version behind

All 20 clips in `docs/qa/play-of-the-game-calibration/clips/` carried `gameplay_version: 9` against the current protocol 10. `HighlightClip::replay_and_verify` rejects any clip whose version differs from the protocol it speaks (`common/src/highlight.rs:383`), so **every one of them was unplayable in the browser** — `client/web/tests/scenario-player.spec.js:98` was just the only test that loads one, and it failed with `Error: highlight gameplay version mismatch`. That failure reproduces on unmodified `master`.

I regenerated the corpus into a scratch directory and diffed before copying anything back. The regenerated clips differ from the checked-in ones **only** by the version stamp and `anchor.skins` — same game ids, same ranking, same filenames, same scores, same windows. The simulation is unchanged across the bump, so this is purely a stamp-and-schema refresh, and it's safe to take all 20 rather than only the one the test loads.

## What was deliberately not regenerated

Running the README's corpus command in place would also have rewritten `corpus-summary.json`, `top-20-review.json` and `review-template.csv` with blank human-review fields — `status: pending_human_review`, `0` completed reviews, `null` verdicts. Those hold hand-entered verdicts from three reviewers across 20 clips and are not tool output; nothing regenerates them, and `client/web/tests/unit/potgCalibrationArtifacts.test.ts` fails once they're gone.

I confirmed this rather than assuming it: apart from the human-review fields, the scratch `corpus-summary.json` and `top-20-review.json` are identical to the checked-in ones, and `top-20-review.html` is byte-identical. Only `clips/` was copied back. `git status` on the five review artifacts is clean.

## Docs

Both traps are now documented where they bite:

- `common/examples/export_potg_fixture.rs` — the exporter prints to stdout, so the `>` redirect isn't optional; without it the fixture on disk silently keeps whatever rules and version it was last written under. Also lists the three inputs that should trigger a regeneration, since the fixture embeds all three.
- `docs/qa/play-of-the-game-calibration/README.md` — a warning block on the corpus command explaining that it blanks the human gate, with the scratch-dir + `cp clips/` recipe and the instruction to diff the summary artifacts first. Any difference beyond the blanked review fields means the corpus genuinely moved and the human gate has to be redone.

## Verification

- `npx playwright test tests/scenario-player.spec.js tests/play-of-the-game.spec.js --project=chromium` — **21 passed**, including the previously failing `scenario-player.spec.js:98`.
- `node --test tests/unit/potgCalibrationArtifacts.test.ts` — passes; 16 deserved reviews and `status: 'passed'` intact.
- `cargo test -p common --test potg_browser_fixture` — passes against the regenerated fixture.
- `cargo fmt --all -- --check` — clean.

## Notes for review

**The clip diff is noisier than the change.** Clip regeneration is deterministic in content but not byte-stable — `last_death_causes` is a `HashMap` and serializes in arbitrary key order. I kept the generator's real output rather than hand-patching a minimal diff, so the reordering doesn't get mistaken for drift later; the README says so too. The only semantic changes in those 20 files are `gameplay_version` and `anchor.skins`.

**No screenshots.** Nothing user-visible changes — the highlight score isn't rendered anywhere in the band, and the reason line (`Goal run — 15 points`) comes from `reason.GoalRun.points`, which didn't move. The QA lab renders identically before and after; what changed is data correctness behind it.

**Local test setup, not part of this change.** Port 3000 on this machine is held by a different worktree's `webpack-dev-server`, so I ran the suite against this worktree's server on another port with a config that mirrors `playwright.config.js` and overrides only `baseURL`. I also had to rebuild `client/pkg` first: it held a build predating the protocol bump, and since `replay_and_verify` is Rust compiled into the WASM, a stale bundle would have *rejected* the corrected version-10 clips and inverted the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
