### PR TITLE
Remove the word NOS from Boost copy

### DIFF
--- a/client/web/components/GameControlsHint.tsx
+++ b/client/web/components/GameControlsHint.tsx
@@ -60,7 +60,7 @@ export function GameControlsHint({
             className="boost-input-mode"
             data-testid="boost-input-mode"
             title={isTouch
-              ? 'Checked: boost while the NOS button is held. Unchecked: tap the NOS button to start or stop Boost.'
+              ? 'Checked: boost while the Boost button is held. Unchecked: tap the Boost button to start or stop Boost.'
               : 'Checked: boost while Space is held. Unchecked: press Space to start or stop Boost.'}
           >
             <input
@@ -76,8 +76,8 @@ export function GameControlsHint({
           <span className="sr-only">
             {isTouch
               ? (boostInputMode === 'hold'
-                  ? 'Hold the NOS button to boost'
-                  : 'Tap the NOS button to start or stop boost')
+                  ? 'Hold the Boost button to boost'
+                  : 'Tap the Boost button to start or stop boost')
               : (boostInputMode === 'hold'
                   ? 'Hold the Space key to boost'
                   : 'Press the Space key to start or stop boost')}

--- a/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
+++ b/client/web/tests/e2e/specs/planned-websocket-drain.spec.js
@@ -1023,7 +1023,7 @@ test('the pre-match guide reveals one animated real-arena step at a time', async
   await readyButton.focus();
   await expect.poll(() => modal.getAttribute('data-step'), { timeout: 6_500 }).toBe('2');
   await expect(readyButton).toBeFocused();
-  await expect(modal).toContainText('Collect NOS, then hold Space to boost.');
+  await expect(modal).toContainText('Collect fuel, then hold Space to boost.');
   await expect(canvas).toHaveAttribute('data-scene', 'team-boost');
 
   await page.keyboard.press('Escape');

--- a/client/web/tests/unit/tutorial.test.ts
+++ b/client/web/tests/unit/tutorial.test.ts
@@ -69,7 +69,7 @@ test('custom games get no tutorial rather than a wrong one', () => {
   );
 });
 
-test('every mode names the boost key, and only collectible modes mention NOS', () => {
+test('every mode names the boost key, and only collectible modes mention fuel', () => {
   for (const queueMode of ['Quickmatch', 'Competitive'] as const) {
     // Every matchmade mode has Boost on the same key.
     for (const mode of ['duel', '2v2', 'ffa', 'solo'] as const) {
@@ -79,13 +79,13 @@ test('every mode names the boost key, and only collectible modes mention NOS', (
     // The three contested modes fuel from pickups on the map...
     for (const mode of ['duel', '2v2', 'ffa'] as const) {
       const text = tutorialContent(mode, queueMode).steps.map((step) => step.body).join(' ');
-      assert.match(text, /NOS/, `${mode} must explain NOS`);
+      assert.match(text, /fuel/i, `${mode} must explain fuel`);
     }
     // ...but a solo tank never empties and has nothing to collect, so telling
     // a solo player to look for canisters would send them hunting for
     // objectives the map does not contain.
     const solo = tutorialContent('solo', queueMode).steps.map((step) => step.body).join(' ');
-    assert.doesNotMatch(solo, /NOS|canister/i, 'solo has no boost pickups');
+    assert.doesNotMatch(solo, /fuel|canister/i, 'solo has no boost pickups');
     assert.match(solo, /unlimited/i, 'solo must say the boost is unlimited');
   }
 });
@@ -263,7 +263,7 @@ test('the persistence key distinguishes ranked from casual for the same mode', (
   assert.equal(tutorialKey('duel', 'Quickmatch'), 'duel:casual');
 });
 
-test('touch surfaces teach the d-pad and NOS button instead of keyboard keys', () => {
+test('touch surfaces teach the d-pad and Boost button instead of keyboard keys', () => {
   for (const mode of MODES) {
     for (const inputMode of ['hold', 'toggle'] as const) {
       const touchCopy = tutorialContent(
@@ -276,11 +276,11 @@ test('touch surfaces teach the d-pad and NOS button instead of keyboard keys', (
 
       assert.doesNotMatch(touchCopy, /Space/, `${mode}:${inputMode} mentions Space on touch`);
       assert.doesNotMatch(touchCopy, /arrow keys/i, `${mode}:${inputMode} mentions arrow keys on touch`);
-      assert.match(touchCopy, /NOS button/, `${mode}:${inputMode} must name the NOS button`);
+      assert.match(touchCopy, /Boost button/, `${mode}:${inputMode} must name the Boost button`);
       if (inputMode === 'hold') {
-        assert.match(touchCopy, /hold the NOS button/i);
+        assert.match(touchCopy, /hold the Boost button/i);
       } else {
-        assert.match(touchCopy, /tap the NOS button/i);
+        assert.match(touchCopy, /tap the Boost button/i);
       }
     }
   }

--- a/client/web/utils/tutorial.ts
+++ b/client/web/utils/tutorial.ts
@@ -103,12 +103,12 @@ const collectibleBoostStep = (
   body:
     inputSurface === 'touch'
       ? (inputMode === 'toggle'
-          ? 'Collect NOS, then tap the NOS button to toggle boost.'
-          : 'Collect NOS, then hold the NOS button to boost.')
+          ? 'Collect fuel, then tap the Boost button to toggle boost.'
+          : 'Collect fuel, then hold the Boost button to boost.')
       : (inputMode === 'toggle'
-          ? 'Collect NOS, then press Space to toggle boost.'
-          : 'Collect NOS, then hold Space to boost.'),
-  visualLabel: 'A snake collects NOS; its fuel fills and it accelerates.',
+          ? 'Collect fuel, then press Space to toggle boost.'
+          : 'Collect fuel, then hold Space to boost.'),
+  visualLabel: 'A snake collects fuel; its tank fills and it accelerates.',
 });
 
 const teamSteps = (
@@ -179,8 +179,8 @@ const soloSteps = (
     body:
       inputSurface === 'touch'
         ? (inputMode === 'toggle'
-            ? 'Tap the NOS button to toggle unlimited boost.'
-            : 'Hold the NOS button for unlimited boost.')
+            ? 'Tap the Boost button to toggle unlimited boost.'
+            : 'Hold the Boost button for unlimited boost.')
         : (inputMode === 'toggle'
             ? 'Press Space to toggle unlimited boost.'
             : 'Hold Space for unlimited boost.'),


### PR DESCRIPTION
## Summary
- Tutorial briefings and the in-arena controls hint referred to the boost pickup and button as "NOS", which reads as unexplained jargon to a new player. Copy now says "fuel" and "Boost button" instead.
- The NOS wordmark on the canister icon itself (the SVG glyph in `BoostCanisterMark.tsx` and the canvas-drawn version in `render.rs`) is untouched — the icon should still visually say NOS.
- Updated the unit and e2e test assertions that pinned the old copy strings.

## Test plan
- [x] `npx tsc --noEmit` in `client/web` — clean
- [x] `npx tsx --test tests/unit/*.test.ts` — 259/260 pass (the one pre-existing failure, `bodyScrollLock.test.ts`, fails identically on `master` and is unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)