### PR TITLE
Hide empty Play of the Game slots

### DIFF
--- a/client/web/components/PlayOfTheGame.css
+++ b/client/web/components/PlayOfTheGame.css
@@ -1,6 +1,6 @@
 /* The replay band keeps exactly two pieces of broadcast styling — the title
    plate and the lower third — because they read as a sports replay caption.
-   Everything else (controls, sponsor slot, poster) uses the same quiet
+   Everything else (controls and poster) uses the same quiet
    black-on-white chrome as the rest of the results card. */
 .potg-band {
   --potg-ink: #20232a;
@@ -69,9 +69,8 @@
    from a 21:9 canvas, so there is no pixel value to animate to. The resting
    state is the open one, which is what lets reduced motion simply switch the
    animation off.
-   Whichever fills the slot — the replay or the sponsor — opens the same way;
-   appearing without the growth reads as the card mis-laying itself out rather
-   than as something being presented. */
+   The verified replay opens inside this slot; unavailable highlights do not
+   mount a row at all. */
 .potg-slot {
   display: grid;
   grid-template-rows: 1fr;
@@ -81,11 +80,7 @@
   animation: potg-slot-open 560ms cubic-bezier(0.34, 0.68, 0.3, 1) both;
 }
 
-/* Both fills are named rather than using `> *`: the sponsor slot sets its own
-   min-height, and at equal specificity that would win and stop the row
-   collapsing — it would open from 94px instead of from nothing. */
-.potg-slot > .potg-band,
-.potg-slot > .potg-sponsor {
+.potg-slot > .potg-band {
   min-height: 0;
 }
 
@@ -409,68 +404,6 @@
   font-size: 7px;
 }
 
-.potg-sponsor {
-  --potg-ink: #20232a;
-  position: relative;
-  display: grid;
-  min-height: 94px;
-  place-items: center;
-  overflow: hidden;
-  border-bottom: 1px solid #d8dbe0;
-  background: #f7f8fa;
-}
-
-.potg-sponsor__label {
-  position: absolute;
-  top: 8px;
-  left: 10px;
-  z-index: 2;
-  padding: 2px 5px;
-  border: 1px solid rgb(63 63 65 / 24%);
-  background: #fff;
-  color: rgb(63 63 65 / 58%);
-  font-size: 6px;
-  font-weight: 900;
-  letter-spacing: 0.11em;
-  text-transform: uppercase;
-}
-
-.potg-sponsor__sdk {
-  position: relative;
-  z-index: 1;
-  width: 100%;
-  min-height: 90px;
-}
-
-.potg-sponsor__fallback {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  color: var(--potg-ink);
-}
-
-.potg-sponsor__fallback strong {
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.01em;
-}
-
-.potg-sponsor__fallback small {
-  color: rgb(63 63 65 / 55%);
-  font-size: 7px;
-  font-weight: 900;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.potg-sponsor.has-live-banner .potg-sponsor__fallback {
-  display: none;
-}
-
 @media (max-width: 420px) {
   .potg-kicker {
     min-height: 18px;
@@ -500,10 +433,6 @@
   .potg-replay {
     width: 24px;
     height: 24px;
-  }
-
-  .potg-sponsor {
-    min-height: 82px;
   }
 }
 
@@ -543,8 +472,7 @@
 }
 
 @media (forced-colors: active) {
-  .potg-band,
-  .potg-sponsor {
+  .potg-band {
     border-color: CanvasText;
     background: Canvas;
     color: CanvasText;

--- a/client/web/components/PlayOfTheGame.tsx
+++ b/client/web/components/PlayOfTheGame.tsx
@@ -1,14 +1,11 @@
 import React, {
   useCallback,
   useEffect,
-  useId,
   useLayoutEffect,
   useRef,
   useState,
 } from 'react';
 import { useCrazyGames } from '../contexts/CrazyGamesContext';
-import { useAdsOptional } from '../contexts/AdsContext';
-import { crazyGames } from '../services/crazyGames';
 import type { HighlightClip, Rank } from '../types';
 import {
   canAutoplayHighlight,
@@ -42,65 +39,6 @@ const INTRO_TRAVEL_MS = 560;
 const INTRO_STAR_SCALE = 1.85;
 
 type IntroPhase = 'idle' | 'title' | 'star' | 'travelling' | 'done';
-
-interface SponsorSlotProps {
-  reason: 'absent' | 'incompatible' | 'network';
-}
-
-const SponsorSlot: React.FC<SponsorSlotProps> = ({ reason }) => {
-  const { available, adState } = useCrazyGames();
-  // Ad enablement is server-owned policy, not a build flag: it arrives through
-  // AdsProvider. Outside that provider (the QA harness) policy is unknown, and
-  // a slot that cannot confirm policy must not request inventory.
-  const ads = useAdsOptional();
-  const bannerAllowed = Boolean(ads?.config.enabled && ads.capabilities.banners);
-  const reactId = useId();
-  const containerIdRef = useRef(`potg-sponsor-${reactId.replace(/[^a-zA-Z0-9_-]/g, '')}`);
-  const attemptedRef = useRef(false);
-  const [bannerLive, setBannerLive] = useState(false);
-  const containerId = containerIdRef.current;
-
-  useEffect(() => {
-    if (!bannerAllowed || !available || adState !== 'idle' || attemptedRef.current) {
-      return undefined;
-    }
-    let active = true;
-    // Completion may request an interstitial in a parent effect from the same
-    // commit. Yield once, then consult the adapter's live snapshot so a stale
-    // context render cannot start a banner underneath that commercial break.
-    const timer = window.setTimeout(() => {
-      if (!active || crazyGames.getSnapshot().adState !== 'idle') return;
-      attemptedRef.current = true;
-      void crazyGames.requestResponsiveBanner(containerId).then((result) => {
-        if (active) setBannerLive(result.status === 'filled');
-      });
-    }, 0);
-    return () => {
-      active = false;
-      window.clearTimeout(timer);
-    };
-  }, [adState, available, bannerAllowed, containerId]);
-
-  useEffect(() => () => crazyGames.clearBanner(containerId), [containerId]);
-
-  return (
-    <aside
-      className={`potg-sponsor${bannerLive ? ' has-live-banner' : ' is-house-slot'}`}
-      aria-label="Advertisement"
-      data-testid="potg-sponsor"
-      data-unavailable-reason={reason}
-    >
-      <span className="potg-sponsor__label">Sponsored</span>
-      <div id={containerId} className="potg-sponsor__sdk" />
-      {!bannerLive && (
-        <div className="potg-sponsor__fallback">
-          <strong>Replay booth</strong>
-          <small>Advertisement placement</small>
-        </div>
-      )}
-    </aside>
-  );
-};
 
 interface HighlightReplayProps {
   clip: HighlightClip;
@@ -413,31 +351,24 @@ const PlayOfTheGame: React.FC<PlayOfTheGameProps> = ({
   autoplayAllowed,
   onAutoplayStarted,
 }) => {
-  // Nothing at all while the server is still cutting. A placeholder panel
-  // sitting open under the rating asks the viewer to watch an empty box, and
-  // it spends the slide-in that makes the replay's arrival read as deliberate
-  // — the panel has to be closed for there to be an opening.
-  if (highlight.phase === 'idle' || highlight.phase === 'pending') {
+  // The slot exists only when there is a verified replay to present. Pending,
+  // absent, incompatible, and network-failed highlights leave the results
+  // card at its natural height; ad inventory has its own provider-owned
+  // surfaces and must never be represented by placeholder chrome here.
+  if (highlight.phase !== 'ready') {
     return null;
   }
 
-  // Whichever fill this space gets, it opens inside the same slot, so the
-  // card grows with it instead of jumping to its final height and then
-  // fading something into the gap.
   return (
     <div className="potg-slot" data-testid="potg-slot">
-      {highlight.phase === 'unavailable' ? (
-        <SponsorSlot reason={highlight.reason} />
-      ) : (
-        <HighlightReplay
-          key={`${highlight.clip.game_id}:${highlight.clip.window.start_tick}`}
-          clip={highlight.clip}
-          starRank={starRank}
-          ratingSettled={ratingSettled}
-          autoplayAllowed={autoplayAllowed}
-          onAutoplayStarted={onAutoplayStarted}
-        />
-      )}
+      <HighlightReplay
+        key={`${highlight.clip.game_id}:${highlight.clip.window.start_tick}`}
+        clip={highlight.clip}
+        starRank={starRank}
+        ratingSettled={ratingSettled}
+        autoplayAllowed={autoplayAllowed}
+        onAutoplayStarted={onAutoplayStarted}
+      />
     </div>
   );
 };

--- a/client/web/components/PlayOfTheGameQA.tsx
+++ b/client/web/components/PlayOfTheGameQA.tsx
@@ -20,6 +20,7 @@ type QaState =
   | 'pending'
   | 'unavailable'
   | 'incompatible'
+  | 'network'
   | 'malformed-anchor'
   | 'bad-end-hash';
 
@@ -27,8 +28,9 @@ const STATES: readonly { id: QaState; label: string }[] = [
   { id: 'ready', label: 'Ready replay' },
   { id: 'ranked', label: 'Ranked star' },
   { id: 'pending', label: 'Pending cut' },
-  { id: 'unavailable', label: 'Unavailable / ad' },
+  { id: 'unavailable', label: 'Unavailable' },
   { id: 'incompatible', label: 'Version mismatch' },
+  { id: 'network', label: 'Network failure' },
   { id: 'malformed-anchor', label: 'Malformed anchor' },
   { id: 'bad-end-hash', label: 'Bad end hash' },
 ] as const;
@@ -47,6 +49,8 @@ const highlightForState = (state: QaState): MatchHighlightState => {
       return { phase: 'unavailable', reason: 'absent' };
     case 'incompatible':
       return { phase: 'unavailable', reason: 'incompatible' };
+    case 'network':
+      return { phase: 'unavailable', reason: 'network' };
     case 'malformed-anchor': {
       const clip = cloneClip();
       clip.anchor.tick = clip.window.start_tick + 1;

--- a/client/web/tests/play-of-the-game.spec.js
+++ b/client/web/tests/play-of-the-game.spec.js
@@ -211,7 +211,7 @@ test('modal playback sustains at least 30fps under Chrome 4x CPU throttle', asyn
   expect(fps).toBeGreaterThanOrEqual(30);
 });
 
-test('the panel stays closed while pending, and both fills arrive by animating', async ({ page }) => {
+test('the panel stays closed while a highlight is pending', async ({ page }) => {
   // Nothing is reserved while the server is still cutting: the panel has to
   // be closed for its arrival to be an opening rather than a content swap.
   await page.goto('/qa/play-of-the-game?state=pending&chrome=0');
@@ -220,69 +220,54 @@ test('the panel stays closed while pending, and both fills arrive by animating',
   await expect(page.getByTestId('play-of-the-game')).toHaveCount(0);
   await expect(page.getByTestId('potg-sponsor')).toHaveCount(0);
   await expect(page.locator('.potg-band, .potg-sponsor')).toHaveCount(0);
-
-  await page.goto('/qa/play-of-the-game?state=unavailable&chrome=0');
-  await expect(page.getByTestId('potg-sponsor')).toHaveAttribute(
-    'data-unavailable-reason',
-    'absent',
-  );
-  await expect(page.getByTestId('potg-sponsor')).toContainText('Sponsored');
-
-  // The sponsor slot fills the same space, so it opens the same way — inside
-  // the slot, which is what pushes the rest of the card down as it grows.
-  await expect(page.getByTestId('potg-slot')).toHaveCount(1);
-  await expect(page.getByTestId('potg-slot').locator('.potg-sponsor')).toHaveCount(1);
-
-  // ...but it keeps its own quiet border rather than the replay's recess.
-  const inset = await page.getByTestId('potg-sponsor').evaluate((el) => (
-    getComputedStyle(el, '::after').boxShadow
-  ));
-  expect(inset === 'none' || inset === '').toBe(true);
-
-  await page.goto('/qa/play-of-the-game?state=incompatible&chrome=0');
-  await expect(page.getByTestId('potg-sponsor')).toHaveAttribute(
-    'data-unavailable-reason',
-    'incompatible',
-  );
 });
 
-for (const [label, state] of [['replay', 'ready'], ['sponsor slot', 'unavailable']]) {
-  test(`the ${label} opens by pushing the card, not by appearing at full height`, async ({ page }) => {
+for (const state of ['unavailable', 'incompatible', 'network']) {
+  test(`${state} highlights do not mount an ad or placeholder row`, async ({ page }) => {
     await page.goto(`/qa/play-of-the-game?state=${state}&chrome=0`);
-    await page.getByTestId('game-over-card').waitFor();
-
-    const frames = await page.evaluate(() => new Promise((resolve) => {
-      const samples = [];
-      const startedAt = performance.now();
-      const tick = () => {
-        const slot = document.querySelector('.potg-slot');
-        const statline = document.querySelector('.game-over-statline');
-        if (slot && statline) {
-          samples.push({
-            slot: slot.getBoundingClientRect().height,
-            statTop: statline.getBoundingClientRect().top,
-          });
-        }
-        if (performance.now() - startedAt < 900) requestAnimationFrame(tick);
-        else resolve(samples);
-      };
-      requestAnimationFrame(tick);
-    }));
-
-    expect(frames.length).toBeGreaterThan(10);
-    const heights = frames.map((frame) => frame.slot);
-    const settled = heights[heights.length - 1];
-
-    // It opens from nothing, and every frame is at least as tall as the last:
-    // the card is displaced continuously rather than in one step.
-    expect(heights[0]).toBeLessThan(settled * 0.9);
-    expect(heights.every((h, i) => i === 0 || h >= heights[i - 1] - 0.5)).toBe(true);
-
-    // What sits below it moves with it, which is the whole point.
-    const statTops = frames.map((frame) => frame.statTop);
-    expect(statTops[statTops.length - 1]).toBeGreaterThan(statTops[0] + 20);
+    await expect(page.getByTestId('game-over-card')).toBeVisible();
+    await expect(page.getByTestId('potg-slot')).toHaveCount(0);
+    await expect(page.getByTestId('potg-sponsor')).toHaveCount(0);
+    await expect(page.getByText('Replay booth')).toHaveCount(0);
+    await expect(page.getByText('Advertisement placement')).toHaveCount(0);
   });
 }
+
+test('the replay opens by pushing the card, not by appearing at full height', async ({ page }) => {
+  await page.goto('/qa/play-of-the-game?state=ready&chrome=0');
+  await page.getByTestId('game-over-card').waitFor();
+
+  const frames = await page.evaluate(() => new Promise((resolve) => {
+    const samples = [];
+    const startedAt = performance.now();
+    const tick = () => {
+      const slot = document.querySelector('.potg-slot');
+      const statline = document.querySelector('.game-over-statline');
+      if (slot && statline) {
+        samples.push({
+          slot: slot.getBoundingClientRect().height,
+          statTop: statline.getBoundingClientRect().top,
+        });
+      }
+      if (performance.now() - startedAt < 900) requestAnimationFrame(tick);
+      else resolve(samples);
+    };
+    requestAnimationFrame(tick);
+  }));
+
+  expect(frames.length).toBeGreaterThan(10);
+  const heights = frames.map((frame) => frame.slot);
+  const settled = heights[heights.length - 1];
+
+  // It opens from nothing, and every frame is at least as tall as the last:
+  // the card is displaced continuously rather than in one step.
+  expect(heights[0]).toBeLessThan(settled * 0.9);
+  expect(heights.every((h, i) => i === 0 || h >= heights[i - 1] - 0.5)).toBe(true);
+
+  // What sits below it moves with it, which is the whole point.
+  const statTops = frames.map((frame) => frame.statTop);
+  expect(statTops[statTops.length - 1]).toBeGreaterThan(statTops[0] + 20);
+});
 
 for (const malformedState of ['malformed-anchor', 'bad-end-hash']) {
   test(`${malformedState} collapses to the branded poster with replay hidden`, async ({ page }) => {

--- a/client/web/tests/unit/highlightPresentation.test.ts
+++ b/client/web/tests/unit/highlightPresentation.test.ts
@@ -4,6 +4,8 @@ import type { HighlightClip } from '../../types/generated/HighlightClip.ts';
 import {
   canAutoplayHighlight,
   formatHighlightReason,
+  HIGHLIGHT_POLL_INTERVAL_MS,
+  HIGHLIGHT_POLL_MAX_ATTEMPTS,
   highlightFocusViewerMs,
   isCompatibleHighlightClip,
 } from '../../utils/highlightPresentation.ts';
@@ -66,6 +68,14 @@ test('highlight compatibility rejects deploy skew and malformed windows', () => 
     ...clip,
     window: { ...clip.window, focus_tick: 191 },
   }), false);
+});
+
+test('highlight polling leaves time for durable replay persistence', () => {
+  const pollWindowMs =
+    (HIGHLIGHT_POLL_MAX_ATTEMPTS - 1) * HIGHLIGHT_POLL_INTERVAL_MS;
+
+  assert.ok(pollWindowMs >= 25_000);
+  assert.ok(pollWindowMs <= 35_000);
 });
 
 test('highlight captions are human and plural-aware', () => {

--- a/client/web/utils/highlightPresentation.ts
+++ b/client/web/utils/highlightPresentation.ts
@@ -4,7 +4,10 @@ import type { HighlightClip, HighlightReason } from '../types/generated';
 
 export const HIGHLIGHT_CLIP_FORMAT_VERSION = 1;
 export const HIGHLIGHT_POLL_INTERVAL_MS = 900;
-export const HIGHLIGHT_POLL_MAX_ATTEMPTS = 7;
+// Replay persistence includes an object-store write before the highlight is
+// queryable. Allow roughly 30 seconds so a healthy write is not mistaken for
+// an unavailable highlight after only a few seconds.
+export const HIGHLIGHT_POLL_MAX_ATTEMPTS = 34;
 
 export type MatchHighlightState =
   | { phase: 'idle' }


### PR DESCRIPTION
## Summary

- render the results replay row only when a verified Play of the Game is ready
- remove the sponsor/ad placeholder and its slide-in styling for unavailable highlights
- keep polling for roughly 30 seconds so replay persistence is not abandoned after 5.4 seconds
- cover absent, incompatible, and network-failed highlights with browser regressions

## Validation

- `npm run type-check`
- `node --test tests/unit/highlightPresentation.test.ts tests/unit/potgCalibrationArtifacts.test.ts tests/unit/ads.test.ts`
- `npx playwright test tests/play-of-the-game.spec.js --project=chromium` (16 passed)
- `npm run build:prod`
- targeted common/server Play of the Game tests