### PR TITLE
Make skin editing admin-only and give every skin its own URL

### DIFF
--- a/client/web/App.tsx
+++ b/client/web/App.tsx
@@ -201,8 +201,12 @@ function AppContent() {
             />
           }
         />
+        {/* One route for the catalogue and for a skin's own page: the page is
+            the same either way — the reference only opens a modal over it —
+            and a single route keeps the catalogue mounted across the toggle.
+            The static /skins/builder segments outrank the parameter. */}
         <Route
-          path="/skins"
+          path="/skins/:reference?"
           element={
             <SkinsPage
               onOpenAuth={handleOpenAuth}
@@ -210,16 +214,22 @@ function AppContent() {
             />
           }
         />
+        {/* Skin editing is an operator surface: the catalogue only shows its
+            CTAs to admins, and the builder itself turns everyone else away. */}
         <Route
           path="/skins/builder"
           element={
-            <SkinBuilder onOpenAuth={handleOpenAuth} onOpenAccount={setAccountModalView} />
+            <AdminRoute>
+              <SkinBuilder onOpenAuth={handleOpenAuth} onOpenAccount={setAccountModalView} />
+            </AdminRoute>
           }
         />
         <Route
           path="/skins/builder/:skinId"
           element={
-            <SkinBuilder onOpenAuth={handleOpenAuth} onOpenAccount={setAccountModalView} />
+            <AdminRoute>
+              <SkinBuilder onOpenAuth={handleOpenAuth} onOpenAccount={setAccountModalView} />
+            </AdminRoute>
           }
         />
         <Route path="/profile" element={<Navigate to="/" replace />} />

--- a/client/web/components/SkinsPage.tsx
+++ b/client/web/components/SkinsPage.tsx
@@ -16,7 +16,7 @@ import GetSkinModal from './GetSkinModal';
 import WalletModal from './WalletModal';
 import SkinToast from './SkinToast';
 import type { CatalogEntry, SkinSummary } from '../types/generated';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   DEFAULT_SKIN_REF,
   readBasePreference,
@@ -441,6 +441,9 @@ const SkinRow: React.FC<SkinRowProps> = ({
 
 const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
   const { user, logout } = useAuth();
+  // Skin editing is an operator surface for now: every CTA into the builder
+  // is admin-only, and an admin may edit anyone's skin, not just their own.
+  const isAdmin = Boolean(user?.isAdmin);
   const { applyBalance, balanceBux } = useWallet();
   const [ready, setReady] = useState(false);
   const [snakeSkins, setSnakeSkins] = useState<CatalogEntry[]>([]);
@@ -455,8 +458,14 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
   const [registryRevision, setRegistryRevision] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const navigate = useNavigate();
-  /** The skin whose page is open, if any. */
-  const [viewing, setViewing] = useState<SkinView | null>(null);
+  /**
+   * The reference of the skin whose page is open, straight from the URL.
+   *
+   * The URL rather than component state, so an open skin page is a place: it
+   * survives a reload, the back button closes it, and copying the address bar
+   * hands someone else the same skin.
+   */
+  const { reference: viewingReference } = useParams<{ reference: string }>();
   /** The skin awaiting a spend confirmation. */
   const [getting, setGetting] = useState<SkinSummary | null>(null);
   /** Whether the wallet is open, and what it is being opened *for*. */
@@ -769,11 +778,42 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
             : (match.creatorUsername ?? undefined),
         owned: match.owned,
         stats: { ownerCount: match.ownerCount, wearerCount: match.wearerCount },
-        editableSkinId: match.creatorUserId === user?.id ? match.skinId : undefined,
+        editableSkinId: isAdmin ? match.skinId : undefined,
       };
     },
-    [summaryFor, user?.id],
+    [isAdmin, summaryFor, user?.id],
   );
+
+  /**
+   * The skin the URL says is open, resolved against the loaded catalogue.
+   *
+   * Resolved rather than stored: the catalogue is the authority on what the
+   * reference means, and a pasted link arrives before any click has built a
+   * view. A reference the catalogue does not know — a typo, or a skin that
+   * has since vanished — opens nothing rather than an empty dialog.
+   */
+  const viewing = useMemo((): SkinView | null => {
+    if (!viewingReference) {
+      return null;
+    }
+    const entry = snakeSkins.find(
+      (candidate) => candidate.reference === viewingReference,
+    );
+    return entry ? viewOf(entry) : null;
+  }, [snakeSkins, viewOf, viewingReference]);
+
+  const openSkin = useCallback(
+    (reference: string) => {
+      navigate(`/skins/${encodeURIComponent(reference)}`);
+    },
+    [navigate],
+  );
+
+  // Plain navigation rather than history.back(): someone who arrived on a
+  // shared link has no /skins entry behind them to go back to.
+  const closeSkin = useCallback(() => {
+    navigate('/skins');
+  }, [navigate]);
 
   return (
     <div className="home-page skins-page">
@@ -793,17 +833,19 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
       <main className="skins-main">
         <div className="skins-intro">
           <h1 className="skins-title">SKINS</h1>
-          <div className="skins-intro-actions">
-            <Link
-              className="game-shell-button is-primary skins-make-own"
-              to="/skins/builder"
-            >
-              <span className="skins-make-own-icon" aria-hidden="true">
-                +
-              </span>
-              Make your own
-            </Link>
-          </div>
+          {isAdmin ? (
+            <div className="skins-intro-actions">
+              <Link
+                className="game-shell-button is-primary skins-make-own"
+                to="/skins/builder"
+              >
+                <span className="skins-make-own-icon" aria-hidden="true">
+                  +
+                </span>
+                Make your own
+              </Link>
+            </div>
+          ) : null}
         </div>
 
         {error ? (
@@ -846,7 +888,7 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
                         const match = summaryFor(entry.reference);
                         return match ? () => startGet(match) : undefined;
                       })()}
-                      onOpen={() => setViewing(viewOf(entry))}
+                      onOpen={() => openSkin(entry.reference)}
                     />
                   ))
                 : null}
@@ -883,17 +925,17 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
           balanceBux={balanceBux ?? 0}
           isEquipped={viewing.reference === equippedSkin}
           busy={busySkin === viewing.editableSkinId}
-          onClose={() => setViewing(null)}
+          onClose={closeSkin}
           onGet={() => {
             const match = summaryFor(viewing.reference);
-            setViewing(null);
+            closeSkin();
             if (match) {
               startGet(match);
             }
           }}
           onEquip={() => {
             void equip('snake', viewing.reference);
-            setViewing(null);
+            closeSkin();
           }}
           onEdit={() => {
             if (viewing.editableSkinId !== undefined) {
@@ -901,7 +943,7 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
             }
           }}
           onTopUp={() => {
-            setViewing(null);
+            closeSkin();
             setWallet({ name: viewing.name, priceBux: viewing.priceBux });
           }}
         />

--- a/client/web/tests/capture-skins-tour.mjs
+++ b/client/web/tests/capture-skins-tour.mjs
@@ -133,8 +133,10 @@ await page.waitForTimeout(600);
 await shot('08-after-buying');
 
 // ---------------------------------------------------------------------------
-// 6. The Builder, on a new skin.
+// 6. The Builder, on a new skin. The builder is an admin surface now, so the
+//    session is promoted before entering it.
 // ---------------------------------------------------------------------------
+await setState({ signedIn: true, isAdmin: true });
 await page.goto(`${baseUrl}/skins/builder`, { waitUntil: 'networkidle' });
 await page.waitForSelector('.builder-preview canvas');
 await shot('09-builder-new');

--- a/client/web/tests/unit/routeTransitions.test.ts
+++ b/client/web/tests/unit/routeTransitions.test.ts
@@ -3,6 +3,7 @@ import test from 'node:test';
 
 import {
   isGameRoutePath,
+  isSkinsCataloguePath,
   shouldSwapRouteImmediately,
 } from '../../utils/routeTransitions.ts';
 
@@ -17,4 +18,18 @@ test('ordinary page transitions keep their existing fade timing', () => {
   assert.equal(shouldSwapRouteImmediately('/lobby/ROOM', '/play/42'), false);
   assert.equal(isGameRoutePath('/play/42'), true);
   assert.equal(isGameRoutePath('/leaderboards'), false);
+});
+
+test('opening or closing a skin page toggles a modal, not a page, so it swaps directly', () => {
+  assert.equal(shouldSwapRouteImmediately('/skins', '/skins/classic'), true);
+  assert.equal(shouldSwapRouteImmediately('/skins/classic', '/skins'), true);
+  assert.equal(shouldSwapRouteImmediately('/skins/skin%3A12', '/skins'), true);
+  assert.equal(shouldSwapRouteImmediately('/skins', '/skins'), false);
+});
+
+test('the builder is a different screen and keeps the fade', () => {
+  assert.equal(isSkinsCataloguePath('/skins/builder'), false);
+  assert.equal(isSkinsCataloguePath('/skins/builder/12'), false);
+  assert.equal(shouldSwapRouteImmediately('/skins', '/skins/builder'), false);
+  assert.equal(shouldSwapRouteImmediately('/', '/skins'), false);
 });

--- a/client/web/utils/routeTransitions.ts
+++ b/client/web/utils/routeTransitions.ts
@@ -2,14 +2,27 @@ export const isGameRoutePath = (pathname: string): boolean =>
   pathname.startsWith('/play/');
 
 /**
+ * The skins catalogue and a skin's own page within it — but not the builder,
+ * which is a genuinely different screen. Opening a skin page is a modal
+ * appearing over a catalogue that stays put, so fading the whole route would
+ * misdescribe what is happening.
+ */
+export const isSkinsCataloguePath = (pathname: string): boolean =>
+  pathname === '/skins' ||
+  (pathname.startsWith('/skins/') && !pathname.startsWith('/skins/builder'));
+
+/**
  * A retained party moving between matches must render the assigned game
  * immediately. Deferring this route swap to an animation timer can strand a
  * background/throttled browser on the previous match's score card.
+ *
+ * Moves within the skins catalogue also swap immediately: they toggle a
+ * modal over an unchanging page rather than replacing the page.
  */
 export const shouldSwapRouteImmediately = (
   displayedPathname: string,
   nextPathname: string,
 ): boolean =>
   displayedPathname !== nextPathname &&
-  isGameRoutePath(displayedPathname) &&
-  isGameRoutePath(nextPathname);
+  ((isGameRoutePath(displayedPathname) && isGameRoutePath(nextPathname)) ||
+    (isSkinsCataloguePath(displayedPathname) && isSkinsCataloguePath(nextPathname)));


### PR DESCRIPTION
## Why

The skins page showed "Make your own" to every visitor, and `/skins/builder` was open to anyone who typed the URL. Skin editing is an operator surface for now. Separately, a skin's detail modal was pure component state, so there was no way to share a link to a skin.

## What changed

**Admin-only editing**
- The "Make your own" button on the skins page renders only for admins (`user.isAdmin`).
- The Edit button in the skin modal is now admin-only — and admins can edit *any* authored skin, not just their own (previously it was creator-only).
- `/skins/builder` and `/skins/builder/:skinId` are wrapped in `AdminRoute`, so non-admins are redirected even with a direct link. Embedded (itch/CrazyGames) builds lose builder access entirely, which follows from admin-only.

**Shareable skin URLs**
- The catalogue route is now `/skins/:reference?` — one route for the list and for an open skin, so opening/closing the modal never remounts the page (wallet, toast, and catalogue state survive).
- Clicking a skin navigates to `/skins/<reference>` (e.g. `/skins/aurora@1`, `/skins/skin%3A12`); reload keeps the modal open, back closes it, and the address bar is the share link.
- An unknown reference just shows the catalogue with no modal.
- `shouldSwapRouteImmediately` treats moves within the catalogue as modal toggles, skipping the route fade (with unit tests).

**Harness**
- `capture-skins-tour.mjs` promotes its session to admin before entering the builder.

## Verified

- `tsc --noEmit` clean (after `wasm-pack build`)
- `npm run test:unit`: 374 pass, including new routeTransitions cases

## Notes

- This is client-side gating only. The server's skin create/update endpoints still accept requests from any authenticated user — worth a server-side admin check as a follow-up if that isn't already enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)