### PR TITLE
Give a newly-created account the skin picked before it existed

### DIFF
--- a/client/web/contexts/AuthContext.tsx
+++ b/client/web/contexts/AuthContext.tsx
@@ -17,7 +17,7 @@ import {
   readCrazyGamesPreferences,
 } from '../services/crazyGamesPreferences';
 import { gameStorage, subscribeGameStorage } from '../services/gameStorage';
-import { adoptServerEquipment } from '../utils/skinPreference';
+import { adoptServerEquipment, equipmentToAdopt } from '../utils/skinPreference';
 import { CrazyGamesAccountException } from '../services/crazyGames';
 import { useCrazyGames } from './CrazyGamesContext';
 import {
@@ -511,6 +511,37 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     };
     void fetchCurrentUser();
   }, [isCrazyGamesPrivacyPage, resolveCrazyGamesAccount, setUser]);
+
+  /**
+   * Hand a newly-arrived account whatever this browser was already wearing.
+   *
+   * Equipping needs somewhere to write, and for much of a player's first
+   * session there is nowhere: accounts are created lazily, so a visitor
+   * browsing skins has none, and a guest account only exists once they try to
+   * play. The choice waits in local storage until this runs.
+   *
+   * Every route to an account passes through `user` becoming set — signing in,
+   * registering, the guest account a first match creates, and a reload — so
+   * this sits on that transition rather than in any one of them. It also
+   * repairs an account that missed the write before this existed.
+   */
+  const equipmentAdoptedForRef = useRef<number | null>(null);
+  useEffect(() => {
+    if (!user || equipmentAdoptedForRef.current === user.id) {
+      return;
+    }
+    equipmentAdoptedForRef.current = user.id;
+    const pending = equipmentToAdopt(user);
+    if (!pending) {
+      return;
+    }
+    void api
+      .setEquipment(pending)
+      .then(adoptServerEquipment)
+      // Cosmetics are never worth surfacing an error over; the next account
+      // that resolves tries again.
+      .catch((error) => console.debug('Could not adopt local equipment:', error));
+  }, [user]);
 
   // Renew the internal session while the platform can still mint a fresh
   // CrazyGames token. Token changes for the same user preserve lobby state.

--- a/client/web/tests/unit/skinPreference.test.ts
+++ b/client/web/tests/unit/skinPreference.test.ts
@@ -84,3 +84,81 @@ test('a spectator sees team 0 as the friendly side', () => {
   assert.equal(getScoreEffectTeamColor(0, null, EMBER), EMBER.friendly_accent);
   assert.equal(getScoreEffectTeamColor(1, null, EMBER), EMBER.enemy_accent);
 });
+
+/**
+ * Equipping has to survive getting an account, because for much of a first
+ * session there is not one: accounts are created lazily, so a choice made
+ * while browsing lives only in local storage until something can write it.
+ */
+const withStoredPreferences = async (
+  stored: Record<string, string>,
+  body: (module: typeof import('../../utils/skinPreference.ts')) => Promise<void> | void,
+) => {
+  const hadWindow = 'window' in globalThis;
+  const previousWindow = (globalThis as any).window;
+  const values = new Map<string, string>(Object.entries(stored));
+  (globalThis as any).window = {
+    localStorage: {
+      get length() { return values.size; },
+      clear: () => values.clear(),
+      getItem: (key: string) => values.get(key) ?? null,
+      key: (index: number) => [...values.keys()][index] ?? null,
+      removeItem: (key: string) => { values.delete(key); },
+      setItem: (key: string, value: string) => { values.set(key, String(value)); },
+    },
+  };
+  try {
+    // Cache-busted so each case reads its own storage stub.
+    await body(await import(`../../utils/skinPreference.ts?adopt=${values.size}-${Math.random()}`));
+  } finally {
+    if (hadWindow) {
+      (globalThis as any).window = previousWindow;
+    } else {
+      delete (globalThis as any).window;
+    }
+  }
+};
+
+test('an empty account inherits the skin chosen before it existed', async () => {
+  await withStoredPreferences(
+    { 'snaketron:skin:v1': 'voltage@1' },
+    ({ equipmentToAdopt }) => {
+      // The exact shape a fresh guest arrives in.
+      assert.deepEqual(equipmentToAdopt({}), { selectedSkin: 'voltage@1' });
+      assert.deepEqual(
+        equipmentToAdopt({ selectedSkin: null, selectedBase: null }),
+        { selectedSkin: 'voltage@1' },
+      );
+    },
+  );
+});
+
+test('an account that already dressed itself is never overwritten', async () => {
+  await withStoredPreferences(
+    { 'snaketron:skin:v1': 'voltage@1', 'snaketron:base:v1': 'base:ember@1' },
+    ({ equipmentToAdopt }) => {
+      // The account is the authority: this fills a blank, it never argues.
+      assert.equal(
+        equipmentToAdopt({ selectedSkin: 'aurora@1', selectedBase: 'base:aurora@1' }),
+        null,
+      );
+      // Each slot is judged on its own.
+      assert.deepEqual(equipmentToAdopt({ selectedSkin: 'aurora@1' }), {
+        selectedBase: 'base:ember@1',
+      });
+    },
+  );
+});
+
+test('an untouched browser has nothing worth saying', async () => {
+  await withStoredPreferences({}, ({ equipmentToAdopt }) => {
+    assert.equal(equipmentToAdopt({}), null);
+  });
+  // The default carries no intent, so it is not worth a write either.
+  await withStoredPreferences(
+    { 'snaketron:skin:v1': DEFAULT_SKIN_REF },
+    ({ equipmentToAdopt }) => {
+      assert.equal(equipmentToAdopt({}), null);
+    },
+  );
+});

--- a/client/web/types/index.ts
+++ b/client/web/types/index.ts
@@ -102,6 +102,18 @@ export interface User {
   isAdmin?: boolean;
   authSource?: 'crazygames' | string;
   avatarUrl?: string | null;
+  /**
+   * What this player is wearing, as the account has it. Mirrors the server's
+   * `UserInfo` (see `types/generated/UserInfo.ts`), which sends both fields
+   * with every authenticated user. Optional here because the guest-creation
+   * response omits them — a brand-new guest is wearing nothing yet.
+   *
+   * This is the authority on the snake skin: it is what match preparation
+   * reads and hands to every other player. Local storage only holds a choice
+   * made before there was an account to write it to.
+   */
+  selectedSkin?: string | null;
+  selectedBase?: string | null;
 }
 
 export type CrazyGamesSessionStatus =

--- a/client/web/utils/skinPreference.ts
+++ b/client/web/utils/skinPreference.ts
@@ -113,6 +113,43 @@ export const adoptServerEquipment = (equipment: {
 };
 
 /**
+ * What this browser has stored that an empty account should inherit.
+ *
+ * The other half of {@link adoptServerEquipment}, and the reason equipping is
+ * not lost across getting an account. Anyone may pick a skin before they have
+ * one — accounts are created lazily, guests included — and that choice lives
+ * only here until there is somewhere to put it. Without this direction, a
+ * choice made before signing in (or before the guest account that a first
+ * match creates) stays local forever: the picker keeps showing it, while
+ * matchmaking reads an account that never heard about it and dresses the
+ * player in the default.
+ *
+ * Returns what should be sent, or null when the account already has its own
+ * answer. The account always wins where it has one — this fills a blank, it
+ * never overwrites.
+ */
+export const equipmentToAdopt = (equipment: {
+  selectedSkin?: string | null;
+  selectedBase?: string | null;
+}): { selectedSkin?: string; selectedBase?: string } | null => {
+  const request: { selectedSkin?: string; selectedBase?: string } = {};
+
+  const localSkin = readSkinPreference();
+  // The default is what an untouched browser reads, so it carries no intent
+  // and is not worth a write.
+  if (!isPlausibleSkinRef(equipment.selectedSkin) && localSkin !== DEFAULT_SKIN_REF) {
+    request.selectedSkin = localSkin;
+  }
+
+  const localBase = readBasePreference();
+  if (typeof equipment.selectedBase !== 'string' && localBase !== null) {
+    request.selectedBase = `${BASE_REF_PREFIX}${localBase}`;
+  }
+
+  return request.selectedSkin || request.selectedBase ? request : null;
+};
+
+/**
  * The skins this build can render, straight from the Rust catalogue so the
  * list can never drift from what the renderer actually knows.
  * Empty until the WASM module has loaded.


### PR DESCRIPTION
## The bug

Equipping a skin held on the Skins page but never reached a real match. The row kept its **EQUIPPED** badge while every game drew the default snake.

Reported with the Voltage skin: equipped and badged on `/skins`, classic in game.

## Why

The two ends read different stores.

Matchmaking asks the **account** — [`apply_player_skin`](https://github.com/lopatin/Snaketron/blob/master/server/src/matchmaking.rs#L1262) reads `user.selected_skin` and puts it in the match snapshot. That is the right authority: the choice has to travel to every other player, so it cannot be client state.

The picker's badge reads **local storage**, which is also reasonable as far as it goes. Accounts are created lazily — `ensurePlayableSession` only mints a guest account when you first try to *play* — so a visitor browsing `/skins` has no account at all, and a choice made then has nowhere else to live.

What was missing is the direction between them. `adoptServerEquipment` carried the account down to local storage on load; nothing ever carried local storage up. A skin equipped before signing in, or before the guest account a first match creates, stayed local forever: the picker went on showing it while the account it should have been written to never heard about it, and matchmaking read that empty account and fell back to `classic@1`.

This stayed invisible for a while because the local value never had any say over your snake. `local_skin_ref` reaches only `viewer_skin.base_theme()` in `render.rs` — the snake always comes from the server snapshot — so the two stores could disagree indefinitely without the picker ever looking wrong.

## The change

- **`utils/skinPreference.ts`** — `equipmentToAdopt` reports what an empty account should inherit, judged per slot. The account wins wherever it has an answer of its own; this only ever fills a blank.
- **`contexts/AuthContext.tsx`** — offers it on the transition every route to an account passes through: signing in, registering, the guest account matchmaking creates, and a reload. Failures are logged at debug and never surfaced; cosmetics are not worth an error toast, and the next account that resolves retries.
- **`types/index.ts`** — `User` now declares `selectedSkin`/`selectedBase`. The server has always sent both and `adoptServerEquipment` already read them; only the type was silent about it.

Because it also runs on reload, **accounts already in this state self-heal** — no one has to re-equip by hand.

## Reviewer notes

- **Scope of the write.** It fills a blank, never overwrites. An account with `selectedSkin` set is left alone, and the two slots are judged independently, so an account with a skin but no base still gets the base. `classic@1` is treated as "no intent" and never written, since that is what an untouched browser reads.
- **Guarded per user id**, so it fires once per account rather than on every render.
- **Not `SkinsPage`.** My first attempt put this in the page's equip handler. That only covers signing in from the auth modal and misses the guest path entirely — equip signed out, click Play, guest account created — because the page unmounts on navigation. `AuthContext` is the one chokepoint that catches all of them.
- **No screenshots.** The visible difference is "your snake is Voltage rather than default in a live match", which needs a full cluster and two accounts to stage; the diff itself changes no layout or styling.

## Testing

- `npm run test:unit` — 377/377 pass, including 3 new cases: empty account inherits, an account that dressed itself is never overwritten, and an untouched browser has nothing to say.
- `npx tsc --noEmit` — no new errors. The 17 it reports are pre-existing in this worktree and all trace to a stale `client/pkg` WASM build (`registerDraftSkin`, `skinSchemaV2`, etc.), unrelated to this change.

## Follow-up found along the way

The equipped **base** skin has no effect in game: `GameArena.tsx:270` passes `readSkinPreference()` (the snake slot) as the viewer's base theme, and `readBasePreference()` is never used by the arena. Tracked separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)