### PR TITLE
Stop the nickname field, the roster, and the results card misfiring

### DIFF
--- a/client/web/components/GameHudShell.tsx
+++ b/client/web/components/GameHudShell.tsx
@@ -93,7 +93,6 @@ const GameHudShell: React.FC<GameHudShellProps> = ({
       <MatchRosterBand
         presentation={presentation}
         isVisible={isVisible}
-        shareGameId={shareGameId}
         onMenu={onMenu}
         onScoreCard={() => setScoreCardOpen((open) => !open)}
         scoreCardOpen={scoreCardOpen}

--- a/client/web/components/GameOverCard.tsx
+++ b/client/web/components/GameOverCard.tsx
@@ -249,6 +249,16 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
     ? `${presentation.sides[0]?.score ?? 0}–${presentation.sides[1]?.score ?? 0}`
     : current?.score.toString() ?? presentation.soloScore.toString();
 
+  // Rematch is a group decision — it converges everyone who ticks the box onto
+  // one lobby. A solo run has nobody to converge with, so the box can only ever
+  // report back the one opt-in it just took, which is why it reads as an
+  // orphaned control there. The server does offer it (rematch.rs:92 treats a
+  // lone Solo player as a valid rematch), so this is suppressed here rather
+  // than expected to arrive empty.
+  //
+  // Keyed on the match's shape rather than on roster size, so a duel that
+  // merely emptied out still gets the real control and its waiting copy.
+  const rematchOffer = presentation.isSoloGame ? null : rematch;
 
   return (
     <div
@@ -371,7 +381,7 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
                   {player.name}
                   {player.isWinner && <span className="game-over-winner">Winner</span>}
                   {player.isIdleKicked && <span className="game-over-idle">Idle</span>}
-                  {rematchBadgeFor(rematch, player.userId) === 'rematch' && (
+                  {rematchBadgeFor(rematchOffer, player.userId) === 'rematch' && (
                     <span
                       className="game-over-rematch-pill"
                       data-testid={`rematch-pill-${player.snakeId}`}
@@ -379,7 +389,7 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
                       Rematch
                     </span>
                   )}
-                  {rematchBadgeFor(rematch, player.userId) === 'left' && (
+                  {rematchBadgeFor(rematchOffer, player.userId) === 'left' && (
                     <span className="game-over-left-pill">Left</span>
                   )}
                 </span>
@@ -397,7 +407,7 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
           ))}
         </div>
 
-        {rematch && onRematchToggle && canRematch(rematch, currentUserId) && (
+        {rematchOffer && onRematchToggle && canRematch(rematchOffer, currentUserId) && (
           <div className="game-over-rematch" data-testid="rematch-toggle">
             {/* Same control as the Competitive checkbox on the home form: a
                 bare label, the native input hidden for semantics, and a drawn
@@ -408,19 +418,19 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
               <div className="relative">
                 <input
                   type="checkbox"
-                  checked={hasOptedIntoRematch(rematch, currentUserId)}
+                  checked={hasOptedIntoRematch(rematchOffer, currentUserId)}
                   onChange={(event) => onRematchToggle(event.target.checked)}
                   className="sr-only"
                   data-testid="rematch-checkbox"
                 />
                 <div
                   className={`w-4 h-4 border-2 rounded transition-all group-hover:border-gray-400 ${
-                    hasOptedIntoRematch(rematch, currentUserId)
+                    hasOptedIntoRematch(rematchOffer, currentUserId)
                       ? 'bg-blue-500 border-blue-500'
                       : 'bg-white border-gray-300'
                   }`}
                 >
-                  {hasOptedIntoRematch(rematch, currentUserId) && (
+                  {hasOptedIntoRematch(rematchOffer, currentUserId) && (
                     <svg
                       className="w-full h-full text-white"
                       fill="none"
@@ -437,9 +447,9 @@ const GameOverCard: React.FC<GameOverCardProps> = ({
             </label>
             {/* Only ever shown when ticking the box cannot actually produce a
                 game; silence there would read as the feature being broken. */}
-            {rematchBlockReason(rematch) && (
+            {rematchBlockReason(rematchOffer) && (
               <span className="game-over-rematch-blocked" role="status">
-                {rematchBlockReason(rematch)}
+                {rematchBlockReason(rematchOffer)}
               </span>
             )}
           </div>

--- a/client/web/components/GameStartForm.tsx
+++ b/client/web/components/GameStartForm.tsx
@@ -299,7 +299,29 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-md mx-auto">
+    <form
+      onSubmit={handleSubmit}
+      className="w-full max-w-md mx-auto"
+      onKeyDown={(event) => {
+        // The nickname field is not the only implicit-submit path: Chromium
+        // also submits on Enter from the sr-only Competitive checkbox. A match
+        // starts from the Start Game button, so every keyboard route into
+        // submission is closed here.
+        //
+        // Controls that handle Enter themselves are exempt, because for them
+        // it is activation rather than an implicit submit: the Start Game
+        // button, the mode chips, the sign-in button, and — the reason this
+        // tests for anchors too — the ticker's Leaderboards link, which is a
+        // react-router <Link> and so renders an <a href> inside this form.
+        if (
+          event.key === 'Enter'
+          && event.target instanceof HTMLElement
+          && !event.target.closest('a[href], button')
+        ) {
+          event.preventDefault();
+        }
+      }}
+    >
       {/* Logo */}
       <div className="home-brand-lockup">
         <img src="SnaketronLogo.png" alt="Snaketron" className="h-8 w-auto opacity-80" />
@@ -322,6 +344,27 @@ export const GameStartForm: React.FC<GameStartFormProps> = ({
             type="text"
             value={nickname}
             onChange={(e) => setNickname(e.target.value)}
+            onKeyDown={(e) => {
+              // Return in a text field is an implicit form submission, which
+              // the browser performs by clicking the default button — here,
+              // Start Game. A phone keyboard's "go" key takes that same path,
+              // so a player finishing their nickname was queueing a match by
+              // accident. Starting a match is a deliberate act; return only
+              // puts the keyboard away. The isComposing guard leaves IME
+              // confirmation alone for anyone typing a nickname in CJK.
+              if (e.key === 'Enter' && !e.nativeEvent.isComposing) {
+                e.preventDefault();
+                // Only on touch, where the point of return is to put the
+                // keyboard away. On desktop there is no keyboard to dismiss,
+                // and blurring would drop focus to <body>, so the next Tab
+                // would restart from the top of the page instead of moving on
+                // to the mode chips.
+                if (inputSurface === 'touch') {
+                  e.currentTarget.blur();
+                }
+              }
+            }}
+            enterKeyHint="done"
             placeholder="Nickname"
             className={`w-full bg-white px-4 py-3 text-base border-2 rounded-lg transition-colors ${
               locksNickname

--- a/client/web/components/Leaderboard.tsx
+++ b/client/web/components/Leaderboard.tsx
@@ -1,12 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import type { AccountModalView } from './AccountModal';
-import { HomeHeader } from './HomeHeader';
+import { SocialHeader } from './SocialHeader';
 import { SocialFooter } from './SocialFooter';
 import { LobbyChat } from './LobbyChat';
 import { RegionSelector } from './RegionSelector';
-import { InviteFriendsModal } from './InviteFriendsModal';
-import JoinGameModal from './JoinGameModal';
 import { ConnectionStatusRack } from './ConnectionStatusRack';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
@@ -18,8 +16,6 @@ import RankIcon from './RankIcon';
 import SoloTrophyIcon from './SoloTrophyIcon';
 import { api } from '../services/api';
 import { useGameWebSocket } from '../hooks/useGameWebSocket';
-
-const generateGuestNickname = () => `Guest${Math.floor(1000 + Math.random() * 9000)}`;
 
 const DEFAULT_LEADERBOARD_REGION = 'global';
 const DEFAULT_LEADERBOARD_MODE: LobbyGameMode = 'duel';
@@ -622,7 +618,7 @@ interface LeaderboardProps {
 export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAccount }) => {
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const {
     connectToRegion,
     isConnected,
@@ -630,15 +626,9 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
     onMessage,
     currentRegionUrl,
     currentLobby,
-    lobbyMembers,
-    createLobby,
-    leaveLobby,
     lobbyChatMessages,
     sendChatMessage,
   } = useWebSocket();
-  const [showInviteModal, setShowInviteModal] = useState(false);
-  const [showJoinModal, setShowJoinModal] = useState(false);
-  const [isCreatingInvite, setIsCreatingInvite] = useState(false);
   const [seasons, setSeasons] = useState<number[]>([]);
   // Latched on the first answer from /api/seasons, success or failure. A
   // failure still resolves the selection: `null` means "current season", which
@@ -840,35 +830,6 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
     sendChatMessage('lobby', message);
   };
 
-  const handleInvite = async () => {
-    if (isCreatingInvite) {
-      return;
-    }
-
-    setIsCreatingInvite(true);
-    try {
-      if (!currentLobby) {
-        await createLobby();
-        console.log('Lobby created successfully');
-      }
-
-      setShowInviteModal(true);
-    } catch (error) {
-      console.error('Failed to create lobby:', error);
-    } finally {
-      setIsCreatingInvite(false);
-    }
-  };
-
-  const handleLeaveLobby = async () => {
-    try {
-      await leaveLobby();
-      console.log('Left lobby successfully');
-    } catch (error) {
-      console.error('Failed to leave lobby:', error);
-    }
-  };
-
   const isReady = isConnectionReady({
     isConnected,
     isSessionAuthenticated,
@@ -878,18 +839,10 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
   return (
     <>
       <div className="home-page leaderboard-page">
-        <HomeHeader
+        <SocialHeader
           activePage="leaderboards"
-          currentUser={user}
-          lobbyMembers={lobbyMembers}
-          hasLobby={Boolean(currentLobby)}
-          isInviteDisabled={isCreatingInvite}
-          onInvite={handleInvite}
-          onJoinGame={() => setShowJoinModal(true)}
-          onLeaveLobby={handleLeaveLobby}
-          onAuthClick={onOpenAuth}
+          onOpenAuth={onOpenAuth}
           onOpenAccount={onOpenAccount}
-          onLogout={logout}
         />
 
         <ConnectionStatusRack
@@ -936,19 +889,6 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({ onOpenAuth, onOpenAcco
           initialExpanded={true}
         />
       </div>
-
-      {/* Invite Friends Modal */}
-      <InviteFriendsModal
-        isOpen={showInviteModal}
-        onClose={() => setShowInviteModal(false)}
-        lobbyCode={currentLobby?.code || null}
-      />
-
-      {/* Join Game Modal */}
-      <JoinGameModal
-        isOpen={showJoinModal}
-        onClose={() => setShowJoinModal(false)}
-      />
     </>
   );
 };

--- a/client/web/components/MatchRosterBand.tsx
+++ b/client/web/components/MatchRosterBand.tsx
@@ -1,13 +1,10 @@
 import React from 'react';
 import type { MatchPlayerPresentation, MatchPresentation } from '../utils/gamePresentation';
 import RosterSnakeCanvas from './RosterSnakeCanvas';
-import ShareGame from './ShareGame';
 
 export interface MatchRosterBandProps {
   presentation: MatchPresentation;
   isVisible: boolean;
-  /** Wire game id; a null id simply hides the share control. */
-  shareGameId?: number | null;
   onMenu?: () => void;
   onScoreCard?: () => void;
   scoreCardOpen?: boolean;
@@ -61,7 +58,6 @@ const PlayerLegend: React.FC<{
 const MatchRosterBand: React.FC<MatchRosterBandProps> = ({
   presentation,
   isVisible,
-  shareGameId = null,
   onMenu,
   onScoreCard,
   scoreCardOpen = false,
@@ -69,18 +65,11 @@ const MatchRosterBand: React.FC<MatchRosterBandProps> = ({
   const leftSide = presentation.sides[0];
   const rightSide = presentation.sides[1];
   const showActions = presentation.isComplete && Boolean(onMenu || onScoreCard);
-  // Share stays available for the whole match, not just at the end: the link
-  // is permanent and resolves to the result page once the match finishes, so
-  // posting it mid-game is a real thing to do.
-  const share = shareGameId !== null && (
-    <ShareGame
-      gameId={shareGameId}
-      headline={presentation.isComplete ? presentation.resultSummary : null}
-      variant="compact"
-      className="game-roster-share"
-      triggerClassName="game-shell-button is-share-icon"
-    />
-  );
+  // The band carries no share control. It is a 44px row with `overflow: hidden`
+  // and a transform of its own (index.css:613-628, :421-428), so a popover
+  // anchored inside it cannot paint in either direction — and mid-match the
+  // slot also drove the roster onto a second grid row. Sharing lives where the
+  // result does: the score card's footer, and the permanent /g/:id page.
 
   return (
     <section
@@ -89,10 +78,6 @@ const MatchRosterBand: React.FC<MatchRosterBandProps> = ({
       aria-hidden={!isVisible}
       data-testid="game-roster-band"
     >
-      {!showActions && share && (
-        <div className="game-roster-action-slot is-right game-roster-share-slot">{share}</div>
-      )}
-
       {showActions && (
         <div className="game-roster-action-slot is-left">
           {onMenu && (
@@ -156,7 +141,6 @@ const MatchRosterBand: React.FC<MatchRosterBandProps> = ({
       {showActions && (
         <div className="game-roster-action-slot is-right">
           <div className="game-roster-actions is-right">
-            {share}
             {onScoreCard && (
               <button
                 type="button"

--- a/client/web/components/NewHome.tsx
+++ b/client/web/components/NewHome.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import type { AccountModalView } from './AccountModal';
-import { HomeHeader } from './HomeHeader';
+import { SocialHeader } from './SocialHeader';
 import { GameStartForm } from './GameStartForm';
 import { SocialFooter } from './SocialFooter';
 import { LobbyChat } from './LobbyChat';
 import { RegionSelector } from './RegionSelector';
-import { InviteFriendsModal } from './InviteFriendsModal';
-import JoinGameModal from './JoinGameModal';
 import { ConnectionStatusRack } from './ConnectionStatusRack';
 import { useAuth } from '../contexts/AuthContext';
 import { useWebSocket } from '../contexts/WebSocketContext';
@@ -17,8 +15,6 @@ import { isConnectionReady } from '../utils/connectionBanner';
 import { readHomeNotice, type HomeNotice } from '../utils/homeNotice';
 import { LobbyGameMode } from '../types';
 
-const generateGuestNickname = () => `Guest${Math.floor(1000 + Math.random() * 9000)}`;
-
 interface NewHomeProps {
   onOpenAuth: () => void;
   onOpenAccount: (view: AccountModalView) => void;
@@ -27,7 +23,7 @@ interface NewHomeProps {
 export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) => {
   const navigate = useNavigate();
   const location = useLocation();
-  const { user, ensurePlayableSession, logout } = useAuth();
+  const { user, ensurePlayableSession } = useAuth();
   const {
     connectToRegion,
     isConnected,
@@ -37,9 +33,7 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
     currentRegionUrl,
     currentLobby,
     isLobbyLeader,
-    lobbyMembers,
     createLobby,
-    leaveLobby,
     lobbyChatMessages,
     sendChatMessage,
     lobbyPreferences,
@@ -47,9 +41,6 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
   } = useWebSocket();
   const { currentGameId, isQueued, queueForMatch, queueForMatchMulti } = useGameWebSocket();
   const [isLoading, setIsLoading] = useState(false);
-  const [showInviteModal, setShowInviteModal] = useState(false);
-  const [showJoinModal, setShowJoinModal] = useState(false);
-  const [isCreatingInvite, setIsCreatingInvite] = useState(false);
   const [startError, setStartError] = useState<string | null>(null);
   const [homeNotice, setHomeNotice] = useState<HomeNotice | null>(null);
 
@@ -185,44 +176,6 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
     sendChatMessage('lobby', message);
   };
 
-  const handleInvite = async () => {
-    if (isCreatingInvite) {
-      return;
-    }
-
-    setIsCreatingInvite(true);
-    try {
-      try {
-        await ensurePlayableSession(generateGuestNickname());
-      } catch (error) {
-        console.error('Player session creation failed for lobby invite:', error);
-        return;
-      }
-
-      await waitForSessionReady();
-
-      if (!currentLobby) {
-        await createLobby();
-        console.log('Lobby created successfully');
-      }
-
-      setShowInviteModal(true);
-    } catch (error) {
-      console.error('Failed to create lobby:', error);
-    } finally {
-      setIsCreatingInvite(false);
-    }
-  };
-
-  const handleLeaveLobby = async () => {
-    try {
-      await leaveLobby();
-      console.log('Left lobby successfully');
-    } catch (error) {
-      console.error('Failed to leave lobby:', error);
-    }
-  };
-
   const isReady = isConnectionReady({
     isConnected,
     isSessionAuthenticated,
@@ -232,18 +185,10 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
   return (
     <>
       <div className="home-page">
-        <HomeHeader
+        <SocialHeader
           activePage="play"
-          currentUser={user}
-          lobbyMembers={lobbyMembers}
-          hasLobby={Boolean(currentLobby)}
-          isInviteDisabled={isCreatingInvite}
-          onInvite={handleInvite}
-          onJoinGame={() => setShowJoinModal(true)}
-          onLeaveLobby={handleLeaveLobby}
-          onAuthClick={onOpenAuth}
+          onOpenAuth={onOpenAuth}
           onOpenAccount={onOpenAccount}
-          onLogout={logout}
         />
 
         <ConnectionStatusRack
@@ -293,20 +238,6 @@ export const NewHome: React.FC<NewHomeProps> = ({ onOpenAuth, onOpenAccount }) =
           initialExpanded={true}
         />
       </div>
-
-      {/* Invite Friends Modal */}
-      <InviteFriendsModal
-        isOpen={showInviteModal}
-        onClose={() => setShowInviteModal(false)}
-        lobbyCode={currentLobby?.code || null}
-        region={currentLobby?.region || null}
-      />
-
-      {/* Join Game Modal */}
-      <JoinGameModal
-        isOpen={showJoinModal}
-        onClose={() => setShowJoinModal(false)}
-      />
     </>
   );
 };

--- a/client/web/components/SkinBuilder.tsx
+++ b/client/web/components/SkinBuilder.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import type { AccountModalView } from './AccountModal';
-import { HomeHeader } from './HomeHeader';
+import { SocialHeader } from './SocialHeader';
 import { useAuth } from '../contexts/AuthContext';
 import { api, isApiError } from '../services/api';
 import { getWasm, initWasm } from '../wasm';
@@ -745,7 +745,7 @@ const ExpressionField: React.FC<ExpressionFieldProps> = ({ field, kind, value, o
 };
 
 const SkinBuilder: React.FC<SkinBuilderProps> = ({ onOpenAuth, onOpenAccount }) => {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   const navigate = useNavigate();
   const { skinId } = useParams<{ skinId: string }>();
 
@@ -1099,24 +1099,27 @@ const SkinBuilder: React.FC<SkinBuilderProps> = ({ onOpenAuth, onOpenAccount }) 
   }, [skin]);
 
   const chrome = (
-    <HomeHeader
+    <SocialHeader
       activePage="skins"
-      currentUser={user}
-      lobbyMembers={[]}
-      hasLobby={false}
-      onInvite={() => {}}
-      onJoinGame={() => {}}
-      onLeaveLobby={() => {}}
-      onAuthClick={onOpenAuth}
+      onOpenAuth={onOpenAuth}
       onOpenAccount={onOpenAccount}
-      onLogout={logout}
     />
   );
+
+  // Both return paths below are rooted in this same provider on purpose. A
+  // differing root element type makes React tear down the whole page when
+  // `document` flips, and the header in that subtree owns UI state now: pick a
+  // template while an invite is being minted and the dialog never opens. The
+  // lobby itself is safe either way — it lives in WebSocketProvider, above the
+  // router — so this costs at most a repeated click, but the remount buys
+  // nothing to be worth even that.
+  const textureContext = { catalogue: schema?.builtinTextures ?? [], choose: chooseTexture };
 
   // A new skin picks a starting point first. An empty stack is not a skin, and
   // the first thing an author should see is something that already paints.
   if (!document) {
     return (
+      <TextureContext.Provider value={textureContext}>
       <div className="home-page builder-page">
         {chrome}
         <main className="builder-main">
@@ -1152,6 +1155,7 @@ const SkinBuilder: React.FC<SkinBuilderProps> = ({ onOpenAuth, onOpenAccount }) 
           ) : null}
         </main>
       </div>
+      </TextureContext.Provider>
     );
   }
 
@@ -1159,9 +1163,7 @@ const SkinBuilder: React.FC<SkinBuilderProps> = ({ onOpenAuth, onOpenAccount }) 
   const overBudget = cost ? cost.ops > cost.maxOps : false;
 
   return (
-    <TextureContext.Provider
-      value={{ catalogue: schema?.builtinTextures ?? [], choose: chooseTexture }}
-    >
+    <TextureContext.Provider value={textureContext}>
     <div className="home-page builder-page">
       {chrome}
 

--- a/client/web/components/SkinsPage.tsx
+++ b/client/web/components/SkinsPage.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { AccountModalView } from './AccountModal';
-import { HomeHeader } from './HomeHeader';
+import { SocialHeader } from './SocialHeader';
 import { SocialFooter } from './SocialFooter';
 import { useAuth } from '../contexts/AuthContext';
 import { api, isApiError } from '../services/api';
@@ -440,7 +440,7 @@ const SkinRow: React.FC<SkinRowProps> = ({
 };
 
 const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
-  const { user, logout } = useAuth();
+  const { user } = useAuth();
   // Skin editing is an operator surface for now: every CTA into the builder
   // is admin-only, and an admin may edit anyone's skin, not just their own.
   const isAdmin = Boolean(user?.isAdmin);
@@ -817,17 +817,10 @@ const SkinsPage: React.FC<SkinsPageProps> = ({ onOpenAuth, onOpenAccount }) => {
 
   return (
     <div className="home-page skins-page">
-      <HomeHeader
+      <SocialHeader
         activePage="skins"
-        currentUser={user}
-        lobbyMembers={[]}
-        hasLobby={false}
-        onInvite={() => {}}
-        onJoinGame={() => {}}
-        onLeaveLobby={() => {}}
-        onAuthClick={onOpenAuth}
+        onOpenAuth={onOpenAuth}
         onOpenAccount={onOpenAccount}
-        onLogout={logout}
       />
 
       <main className="skins-main">

--- a/client/web/components/SocialHeader.tsx
+++ b/client/web/components/SocialHeader.tsx
@@ -1,0 +1,117 @@
+import React, { useCallback, useState } from 'react';
+import type { AccountModalView } from './AccountModal';
+import { HomeHeader } from './HomeHeader';
+import { InviteFriendsModal } from './InviteFriendsModal';
+import JoinGameModal from './JoinGameModal';
+import { useAuth } from '../contexts/AuthContext';
+import { useWebSocket } from '../contexts/WebSocketContext';
+
+const generateGuestNickname = () => `Guest${Math.floor(1000 + Math.random() * 9000)}`;
+
+interface SocialHeaderProps {
+  activePage: 'play' | 'leaderboards' | 'skins';
+  onOpenAuth: () => void;
+  onOpenAccount: (view: AccountModalView) => void;
+}
+
+/**
+ * The site header together with the lobby state its social menu acts on.
+ *
+ * The menu is only as good as the handlers behind it: Invite has to be able to
+ * mint a player session and a lobby before it has a code to show. Owning that
+ * here rather than in each page is what stopped /skins and the skin builder
+ * from shipping the menu with no-ops wired to it, and what keeps the home and
+ * leaderboard copies from drifting apart again — they already had.
+ *
+ * A component rather than a hook on purpose: the WebSocket context value is a
+ * fresh object on every ping, so every consumer re-renders that often.
+ * Confining the subscription to this subtree keeps the skins grid out of it.
+ */
+export const SocialHeader: React.FC<SocialHeaderProps> = ({
+  activePage,
+  onOpenAuth,
+  onOpenAccount,
+}) => {
+  const { user, ensurePlayableSession, logout } = useAuth();
+  const {
+    currentLobby,
+    lobbyMembers,
+    createLobby,
+    leaveLobby,
+    waitForSessionReady,
+  } = useWebSocket();
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  const [showJoinModal, setShowJoinModal] = useState(false);
+  const [isCreatingInvite, setIsCreatingInvite] = useState(false);
+
+  const handleInvite = useCallback(async () => {
+    if (isCreatingInvite) {
+      return;
+    }
+
+    setIsCreatingInvite(true);
+    try {
+      // Someone who has never pressed Play has no session, and the socket will
+      // not accept CreateLobby without one. Minting a guest here is what lets
+      // "Invite friends" be the first thing a visitor ever clicks.
+      try {
+        await ensurePlayableSession(generateGuestNickname());
+      } catch (error) {
+        console.error('Player session creation failed for lobby invite:', error);
+        return;
+      }
+
+      await waitForSessionReady();
+
+      if (!currentLobby) {
+        await createLobby();
+      }
+
+      setShowInviteModal(true);
+    } catch (error) {
+      console.error('Failed to create lobby:', error);
+    } finally {
+      setIsCreatingInvite(false);
+    }
+  }, [createLobby, currentLobby, ensurePlayableSession, isCreatingInvite, waitForSessionReady]);
+
+  const handleLeaveLobby = useCallback(async () => {
+    try {
+      await leaveLobby();
+    } catch (error) {
+      console.error('Failed to leave lobby:', error);
+    }
+  }, [leaveLobby]);
+
+  return (
+    <>
+      <HomeHeader
+        activePage={activePage}
+        currentUser={user}
+        lobbyMembers={lobbyMembers}
+        hasLobby={Boolean(currentLobby)}
+        isInviteDisabled={isCreatingInvite}
+        onInvite={() => { void handleInvite(); }}
+        onJoinGame={() => setShowJoinModal(true)}
+        onLeaveLobby={() => { void handleLeaveLobby(); }}
+        onAuthClick={onOpenAuth}
+        onOpenAccount={onOpenAccount}
+        onLogout={logout}
+      />
+
+      <InviteFriendsModal
+        isOpen={showInviteModal}
+        onClose={() => setShowInviteModal(false)}
+        lobbyCode={currentLobby?.code || null}
+        region={currentLobby?.region || null}
+      />
+
+      <JoinGameModal
+        isOpen={showJoinModal}
+        onClose={() => setShowJoinModal(false)}
+      />
+    </>
+  );
+};
+
+export default SocialHeader;

--- a/client/web/index.css
+++ b/client/web/index.css
@@ -811,7 +811,14 @@ button.game-scoreboard-brand {
   height: 100%;
 }
 
+/* Row 1, always. `is-right` below asks for column 3, and the live band is a
+   single column — so a slot emitted before the roster drives grid
+   auto-placement's cursor past a column the roster then asks to go back to,
+   which opens a second implicit row and pushes the snakes down out of a band
+   whose height is fixed. Pinning the row makes the band's single-row layout
+   independent of child order. */
 .game-roster-action-slot {
+  grid-row: 1;
   display: flex;
   min-width: 0;
   align-items: center;
@@ -3080,6 +3087,9 @@ button.game-scoreboard-brand {
 }
 
 .game-over-actions {
+  /* Positioned so the share popover can hang off the whole row rather than off
+     the button — see the rule below for why that is what keeps it on screen. */
+  position: relative;
   display: flex;
   min-height: 70px;
   align-items: center;
@@ -3087,6 +3097,28 @@ button.game-scoreboard-brand {
   padding: 14px 22px;
   border-top: 1px solid #d8dbe0;
   background: #fafafa;
+}
+
+/* The card is a scroll container — `max-height` plus `overflow: auto`, so its
+   buttons stay reachable on a short viewport — and that clips anything
+   absolutely positioned inside it. Anchored to the Share button, the 320px
+   popover starts about 95px left of the card's edge, and left overflow in a
+   scroll container cannot be scrolled back to: that strip is simply gone.
+   Anchoring to the footer instead resolves the panel's offsets and its
+   percentage width against the full card width, so it cannot outgrow the box
+   that clips it. */
+.game-over-actions .share-game {
+  position: static;
+}
+
+.game-over-actions .share-game-popover {
+  right: auto;
+  bottom: calc(100% + 8px);
+  left: 22px;
+  /* Keeps the base rule's 320px where the card has room — preflight makes that
+     an outer width — and otherwise shrinks to hold the same 22px inset on the
+     right as `left` gives on the left. */
+  width: min(320px, calc(100% - 44px));
 }
 
 .game-over-actions .game-shell-button {
@@ -7380,14 +7412,6 @@ a.home-social-icon:hover {
   outline-offset: 2px;
 }
 
-/* The in-match share sits in the roster rail; when the match is still live
-   there are no other actions there, so the slot only holds this. */
-.game-roster-share-slot {
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-}
-
 /* Public match page ---------------------------------------------------------
    The landing surface for a shared link. Most people arriving here have never
    played, so it is a single centered card and one call to action. */
@@ -7619,8 +7643,7 @@ a.home-social-icon:hover {
 
 
 /* Share adopting the shell button: the icon has to come down to the 9px type
-   it now sits beside, and the icon-only form in the HUD rail needs a square
-   footprint rather than the label padding. */
+   it now sits beside. */
 .game-shell-button .share-game-icon {
   width: 12px;
   height: 12px;
@@ -7630,11 +7653,6 @@ a.home-social-icon:hover {
    icon straight into the word. */
 .game-shell-button:has(.share-game-icon) {
   gap: 7px;
-}
-
-.game-shell-button.is-share-icon {
-  width: 32px;
-  padding: 0;
 }
 
 .skins-row {


### PR DESCRIPTION
Five reported UI defects in the web client. Four trace to a control placed somewhere it could not work.

## What was wrong

**Mobile return started the game.** A text input inside a `<form>` submits implicitly, and the browser performs that as a click on the default button — Start Game. A phone keyboard's "go" key takes the same path, so finishing a nickname queued a match. Not a key handler, so nothing in the component was intercepting it.

**The roster share button pushed the snake preview down.** The live band is a one-column grid, but the share slot asked for `grid-column: 3` as the band's *first* child. Grid auto-placement moved the cursor to column 3; the roster then asked to go back to column 1, which per spec increments the row — so the snakes landed on an implicit second row and were clipped out of the fixed-height band. Measured in Chromium against the compiled stylesheet: `grid-template-rows` was `32px 27px` instead of `44px`.

**Solo showed a Rematch checkbox.** The gate was only `rematch && canRematch(...)`. The server genuinely offers solo rematch (`rematch.rs:92` treats a lone Solo player as valid), arriving a few seconds late via a 15s reconcile loop.

**The share popover was cut off by the results modal.** Anchored `right: 0` to a mid-footer button, its 320px panel started ~95px past the card's left edge. The card is `overflow: auto`, and left overflow in a scroll container cannot be scrolled back to. Measured: 86–124px lost, at every card width.

**Social menu buttons did nothing off the home page.** Skins and the skin builder passed `() => {}` and `lobbyMembers={[]}`.

## What changed

- Enter cancelled in the nickname field and form-wide for the sr-only Competitive checkbox; buttons and anchors exempt so Start Game, the mode chips and the ticker's Leaderboards `<Link>` keep keyboard activation. Blurs on touch only.
- `ShareGame` removed from `MatchRosterBand` entirely — the band is 44px with `overflow: hidden` and a transform, so its popover could never paint in *any* state. Sharing stays on the score card footer and `/g/:id`. `.game-roster-action-slot` pinned to `grid-row: 1` so no future slot can displace the roster.
- `rematchOffer = presentation.isSoloGame ? null : rematch`, with every rematch read routed through it.
- Score-card popover anchored to the footer and capped against the card.
- New `SocialHeader` owns the lobby state and both modals for all four pages.

## Incidental fixes

The leaderboard's copy of the invite handler had drifted from the home page's: it skipped `ensurePlayableSession`, so **Invite hung for ten seconds for signed-out visitors**, and it dropped the `region` param from CrazyGames invite links. Both now match. `SkinBuilder`'s two return branches also had different root element types, remounting the page when a template is picked; they now share a root.

## Verification

- `npm run type-check` clean; `npm run test:unit` 368/369 (the one failure is a pre-existing missing-WASM import, which CI builds first).
- Both CSS fixes measured in Chromium against the **Tailwind-compiled** stylesheet, before vs after — not raw source, where the unresolved `@import "tailwindcss"` hides preflight's `box-sizing: border-box` and gives wrong numbers.
- Reviewed by 4 independent adversarial passes; every finding fixed, 0 surviving.

Removing the roster share also brings ~6 assertions in `planned-websocket-drain.spec.js` back into line — they expect zero buttons in the live band and exactly two when complete, and had gone stale unnoticed because that suite runs in no workflow.

## Judgment calls worth a look

1. The roster share is removed in **all** states, not just mid-game — its popover is unrenderable there either way and the score card already carries a working one.
2. Hiding Solo rematch removes the only control that guaranteed *another Solo run*: `handlePlayAgain` re-queues the lobby's selected modes, so a player with SOLO+DUEL ticked can get a Duel from Play again.

No protocol, generated-type, or service files touched — wire compatibility unchanged, so shipped itch.io builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)