### PR TITLE
Fail the build rather than ship analytics that report nothing

### DIFF
--- a/.github/workflows/github-action-test-simple-game.yml
+++ b/.github/workflows/github-action-test-simple-game.yml
@@ -364,13 +364,29 @@ jobs:
       # is worth catching here rather than in a silently dead release.
       #
       # This bundle is never deployed and never runs, so it reports nothing.
+      #
+      # The assertion below is the one that matters most: a build succeeding
+      # proves only that webpack ran. The production client shipped for a full
+      # release cycle with both keys compiled to the empty string, and every
+      # build was green throughout. Only checking that the key reached the
+      # artifact distinguishes "built" from "would actually report".
       - name: Build the production web bundle
-        run: npm run build:prod
         working-directory: client/web
         env:
           GAME_ANALYTICS_GAME_KEY: ${{ vars.GAME_ANALYTICS_GAME_KEY }}
           GAME_ANALYTICS_SECRET_KEY: ${{ secrets.GAME_ANALYTICS_SECRET_KEY }}
-          GAME_ANALYTICS_BUILD: ci-${{ github.sha }}
+          # GameAnalytics caps the build label at 32 characters and silently
+          # keeps its default past that, so a full 40-character SHA cannot be
+          # used here.
+          GAME_ANALYTICS_REQUIRED: 'true'
+        run: |
+          set -euo pipefail
+          GAME_ANALYTICS_BUILD="ci-${GITHUB_SHA::12}" npm run build:prod
+          if ! grep -rlq "$GAME_ANALYTICS_GAME_KEY" dist/; then
+            echo "::error::The game key never reached the bundle - this build would report nothing"
+            exit 1
+          fi
+          echo "✅ Game key is compiled into the production bundle"
 
       # The switch that takes analytics back out of a reviewed release package
       # has no other test: it only shows up in the shape of a built artifact.

--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -21,12 +21,24 @@ further setup.
 
 ## Continuous integration and deployment
 
-The keys are stored on the GitHub repository as:
+The keys must be stored on **both** repositories, because two different
+repositories build a bundle from this checkout:
 
 | Name | Kind | Why |
 | --- | --- | --- |
 | `GAME_ANALYTICS_GAME_KEY` | Repository **variable** | It ships inside the client bundle, so it is a public identifier, not a credential |
 | `GAME_ANALYTICS_SECRET_KEY` | Repository **secret** | Also reaches the bundle, but keeping it out of a public repository's files and out of build logs costs nothing |
+
+| Repository | Builds | Needs the keys because |
+| --- | --- | --- |
+| `lopatin/SnakeTron` | CI only, never deployed | The guard build below has to exercise a real key |
+| `lopatin/snaketron-io` | **The bundle players actually load** | `release-production.yml` → `deploy-client.yml` is the only path to snaketron.io |
+
+Storing them on the game repository alone is the failure this section exists to
+prevent, and it is not hypothetical: the production client shipped for a full
+release cycle with both keys compiled to the empty string, because CI had them
+and the deploying repository did not. Nothing failed — that is the whole
+problem, and it is what `GAME_ANALYTICS_REQUIRED` below now catches.
 
 Neither is a credential in the usual sense: GameAnalytics' HTML5 SDK signs
 payloads in the browser, so anyone can read both out of the served JavaScript.
@@ -50,8 +62,14 @@ client build:**
 env:
   GAME_ANALYTICS_GAME_KEY: ${{ vars.GAME_ANALYTICS_GAME_KEY }}
   GAME_ANALYTICS_SECRET_KEY: ${{ secrets.GAME_ANALYTICS_SECRET_KEY }}
-  GAME_ANALYTICS_BUILD: web-${{ github.ref_name }}
+  GAME_ANALYTICS_BUILD: web-<short sha>   # 32 characters maximum
+  GAME_ANALYTICS_REQUIRED: 'true'         # fail rather than ship inert
 ```
+
+A **reusable** workflow needs one thing more: a repository secret is invisible
+across a `workflow_call` boundary unless it is declared under
+`on.workflow_call.secrets` *and* passed by the caller. Repository variables
+need neither. Missing that declaration looks exactly like a missing key.
 
 **No AWS or ECS configuration is required for the keys.** They are compile-time
 client configuration baked into the bundle, and the server never talks to
@@ -69,6 +87,12 @@ Unset excludes nobody, so production works without it; setting it is what keeps
 the release owner's own play out of the numbers on every device at home,
 including signed-out ones.
 
+**`GAME_ANALYTICS_REQUIRED=true` makes a keyless build fail.** A checkout with
+no keys is a supported state everywhere else — that is what keeps developer
+machines and forks out of the numbers — but for a build that is going to be
+distributed it is indistinguishable at runtime from a working release that
+reports nothing. Both `deploy-client.yml` and `scripts/build-itch.sh` set it.
+
 The game key is exactly 32 alphanumeric characters and the secret exactly 40.
 The SDK refuses to initialize on any other shape — it logs and returns, with no
 failed request to notice — so the build validates both shapes and fails loudly
@@ -81,7 +105,10 @@ rotate it in the dashboard if it is ever abused.
 
 `GAME_ANALYTICS_BUILD` is the version label attached to every event, so a
 regression can be traced to the release that introduced it. It defaults to
-`0.0.0`.
+`0.0.0`, and is capped at **32 characters** by the SDK — which logs and keeps
+its default beyond that rather than failing, so a full 40-character commit SHA
+cannot be used as a label. The build validates the length. Deployments tag
+releases `web-<short sha>`; the itch package uses `itch-<short sha>`.
 
 **A checkout with no keys never loads the SDK.** That is deliberate and is what
 keeps developer machines, CI, and forks out of the live game's numbers with no
@@ -360,7 +387,7 @@ one, and expect to synthesize session annotations for every event.
 
 | File | Role |
 | --- | --- |
-| `server/src/api/analytics.rs` | `GET /api/analytics/consent`; address matching |
+| `server/src/api/analytics_consent.rs` | `GET /api/analytics/consent`; address matching (routed in `server/src/http_server.rs`) |
 | `client/web/components/PrivacyPolicy.tsx` | The player-facing notice, incl. the analytics disclosure |
 | `client/web/services/sessionIdentity.ts` | Reads the user id from the session token, before init |
 | `client/web/services/analytics/config.ts` | Build-time keys and distribution scope |

--- a/client/web/webpack.config.js
+++ b/client/web/webpack.config.js
@@ -67,6 +67,38 @@ for (const [name, value, shape, length] of gameAnalyticsKeyShapes) {
   }
 }
 
+// Absent keys are a supported state — that is exactly what keeps developer
+// machines, CI, and forks out of the live game's numbers with no switch to
+// remember. But at runtime it is indistinguishable from a working release that
+// reports nothing, which is how the production client shipped for a full
+// release cycle with analytics silently dead: the deploy workflow never passed
+// the keys and nothing failed. A build that is going to be distributed sets
+// GAME_ANALYTICS_REQUIRED=true and fails here instead of shipping inert.
+if (
+  process.env.GAME_ANALYTICS_REQUIRED === 'true'
+  && !analyticsExcludedFromBuild
+  && !gameAnalyticsGameKey
+) {
+  throw new Error(
+    'GAME_ANALYTICS_REQUIRED=true but GAME_ANALYTICS_GAME_KEY and '
+    + 'GAME_ANALYTICS_SECRET_KEY are unset, so this bundle would never load the '
+    + 'SDK and would report nothing. Set both, or unset GAME_ANALYTICS_REQUIRED '
+    + 'for a build that is not being distributed. See ANALYTICS.md.',
+  );
+}
+
+// The build label is capped at 32 characters by the SDK, which logs and keeps
+// its default beyond that rather than failing — the same silent shape the key
+// checks above exist to prevent. A full commit SHA overruns it.
+const gameAnalyticsBuild = (process.env.GAME_ANALYTICS_BUILD || '').trim();
+if (gameAnalyticsBuild.length > 32) {
+  throw new Error(
+    `GAME_ANALYTICS_BUILD must be at most 32 characters (got ${gameAnalyticsBuild.length}). `
+    + 'GameAnalytics silently ignores a longer label, so every event would be '
+    + 'tagged with the default build instead of this release.',
+  );
+}
+
 module.exports = {
   entry: "./bootstrap.ts",
   output: {
@@ -161,7 +193,7 @@ module.exports = {
       // machine, CI, and any fork — never loads the SDK. See ANALYTICS.md.
       'process.env.GAME_ANALYTICS_GAME_KEY': JSON.stringify(gameAnalyticsGameKey),
       'process.env.GAME_ANALYTICS_SECRET_KEY': JSON.stringify(gameAnalyticsSecretKey),
-      'process.env.GAME_ANALYTICS_BUILD': JSON.stringify(process.env.GAME_ANALYTICS_BUILD || ''),
+      'process.env.GAME_ANALYTICS_BUILD': JSON.stringify(gameAnalyticsBuild),
       'process.env.GAME_ANALYTICS_DISABLE_EMBEDDED': JSON.stringify(
         disableEmbeddedAnalytics ? 'true' : '',
       ),


### PR DESCRIPTION
## The bug

The production client has been reporting **nothing** to GameAnalytics since the integration landed. The client code was correct throughout — both keys simply compiled to the empty string.

This is the build config as served from snaketron.io today, recovered from the live bundle:

```js
mt = bt(""), gt = bt(""), mt && gt ? { … } : null    // → null
```

`ANALYTICS_BUILD_CONFIG` is `null`, the gate answers `notConfigured`, and the SDK chunk is never fetched. The keys were stored only on this repository, where they feed a CI build that is never deployed, and never on `snaketron-io`, which builds the bundle players actually load.

Nothing failed, because absent keys are a supported state — that is what keeps developer machines, CI, and forks out of the live game's numbers with no switch to remember.

## What this changes

**`GAME_ANALYTICS_REQUIRED=true` fails a keyless build.** It separates "no keys, and that's correct" from "no keys, and this is about to be distributed". Set by every path that ships a bundle. `GAME_ANALYTICS_DISABLE_EMBEDDED` still takes precedence, so a no-SDK portal submission is unaffected.

**`GAME_ANALYTICS_BUILD` is capped at 32 characters.** The SDK logs and keeps its default past that rather than failing, so the obvious `web-<full sha>` (44 chars) would have tagged every event with the wrong release — the same silent shape the key-length checks already existed to prevent. Labels are now short-SHA based.

**ANALYTICS.md** said the keys live on "the GitHub repository", which is what made storing them in one place look correct. It now names both repositories and which one players load, records that a secret is invisible across a `workflow_call` boundary unless declared and passed, and fixes a code-map entry pointing at `server/src/api/analytics.rs` (the file is `analytics_consent.rs`).

## Verification

Guard exercised in all four states:

| State | Result |
| --- | --- |
| no keys, not required | builds, `gameKey = ""` — dev/fork path preserved |
| no keys, `REQUIRED=true` | throws |
| keys set, `REQUIRED=true` | builds, key compiled in |
| label over 32 chars | throws |

A real `wasm-pack` + `npm run build:prod` with the deploy workflow's exact env now emits:

```js
mt = bt("6b0c9eba…"), gt = bt("0123…"),
  mt && gt ? { gameKey, secretKey, build: "web-274854f3837e" } : null
```

`npm run type-check` clean, 385/385 unit tests pass.

The workflow and script half of the fix is in the corresponding snaketron-io PR; neither is sufficient alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)