### PR TITLE
Give administrators a durable flag instead of an env allowlist

### DIFF
--- a/ANALYTICS.md
+++ b/ANALYTICS.md
@@ -155,7 +155,7 @@ signals do that, and **any one of them is enough**:
 | --- | --- | --- |
 | `?analytics=off` | Any browser, anywhere — phone, VPN, someone else's network | Visit the game once with the parameter |
 | Excluded address list | Every browser and device on your network, signed out, with no per-device setup | Set `SNAKETRON_ANALYTICS_EXCLUDED_IPS` on the server |
-| Administrator account | You, wherever you sign in | Already covered by `SNAKETRON_ADMIN_USER_IDS` |
+| Administrator account | You, wherever you sign in | Already covered once your account is an administrator |
 
 An excluded browser never downloads the SDK chunk, never opens a GameAnalytics
 session, and never contacts GameAnalytics at all.
@@ -206,8 +206,10 @@ never been excluded caches `counted` and is unaffected.
 
 ### The administrator account
 
-Any user in `SNAKETRON_ADMIN_USER_IDS` is excluded as soon as `/api/auth/me`
-resolves. Because that can happen after the session has already opened, signing
+Any administrator is excluded as soon as `/api/auth/me` resolves — whether the
+grant is the durable `isAdmin` flag on the account or an entry in
+`SNAKETRON_ADMIN_USER_IDS`. Because that can happen after the session has
+already opened, signing
 in both stops the live SDK and writes the local opt-out, so the *next* load in
 that browser is excluded before the SDK is ever fetched.
 

--- a/server/README.md
+++ b/server/README.md
@@ -68,7 +68,9 @@ Season schedule:
 
 Administration:
 
-- `SNAKETRON_ADMIN_USER_IDS`: Comma-separated durable numeric user IDs allowed to use `/api/admin/*`. Authorization is recalculated from the current database user on every authenticated request; guests and stress-test users are never administrators.
+- Administrative access to `/api/admin/*` comes from either of two independent grants, and is recalculated from the current database user on every authenticated request. Guests and stress-test users are never administrators, whichever grant claims otherwise.
+  - **The durable `isAdmin` flag on the account.** False by default and absent from accounts nobody has granted it. This is how a deployed environment gets an administrator: run `scripts/set-user-admin.sh --user-id <id> --apply` from the deployment repository. It writes the account row directly, so it takes effect on that user's next request with no deploy and no restart.
+  - **`SNAKETRON_ADMIN_USER_IDS`**: comma-separated durable numeric user IDs. Kept for local development and the Skin Factory tooling, which bootstrap an administrator from the environment against a throwaway database where there is no account to have flagged first. Changing it needs a process restart, so it is the wrong tool for a deployed environment.
 - Runtime announcements, provider-neutral pre-match ad policy, and history-retention settings are stored in DynamoDB and managed through `/api/admin/config`. The safe defaults disable every ad distribution with a one-game threshold and 10-minute durable interval, retain snapshots for 30 days, and retain compact summaries for 365 days.
 - Match-history projections are created by the immutable completion pipeline. Existing completed-game rows are not retroactively projected, so a deployment begins recording browseable history with the first completion processed after rollout; backfill requires an explicit migration from retained snapshots.
 

--- a/server/src/api/middleware.rs
+++ b/server/src/api/middleware.rs
@@ -32,13 +32,31 @@ pub const ADMIN_USER_IDS_ENV: &str = "SNAKETRON_ADMIN_USER_IDS";
 
 /// Resolve administrative access exclusively from the database-loaded user.
 ///
-/// Entries in `SNAKETRON_ADMIN_USER_IDS` are comma-separated durable numeric
-/// user IDs. Guests and stress-test users can never be administrators, even if
-/// their ID appears in the list.
+/// There are two independent grants, and either one is enough:
+///
+/// 1. The durable `is_admin` flag on the account itself, granted out of band
+///    with `scripts/set-user-admin.sh` in the deployment repository. This is
+///    the normal way to make somebody an administrator, because it takes
+///    effect on their next request without redeploying anything.
+/// 2. The `SNAKETRON_ADMIN_USER_IDS` process allowlist of comma-separated
+///    durable numeric user IDs. Kept because local development and the Skin
+///    Factory tooling bootstrap an administrator from the environment against
+///    a throwaway database, where there is no account to have flagged first.
+///
+/// Guests and stress-test users can never be administrators, whichever grant
+/// claims otherwise.
 pub fn is_admin_user(user: &User) -> bool {
-    std::env::var(ADMIN_USER_IDS_ENV)
-        .ok()
-        .is_some_and(|value| admin_allowlist_matches(&value, user))
+    admin_granted(user, std::env::var(ADMIN_USER_IDS_ENV).ok().as_deref())
+}
+
+/// The whole rule, with the process environment passed in so that it can be
+/// exercised without mutating global state from a parallel test.
+fn admin_granted(user: &User, allowlist: Option<&str>) -> bool {
+    if user.is_guest || user.is_stress_test {
+        return false;
+    }
+
+    user.is_admin || allowlist.is_some_and(|value| admin_allowlist_matches(value, user))
 }
 
 fn admin_allowlist_matches(value: &str, user: &User) -> bool {
@@ -337,6 +355,7 @@ mod tests {
             is_guest: false,
             guest_token: None,
             is_stress_test: false,
+            is_admin: false,
             auth_provider: None,
             crazygames_user_id: None,
             profile_picture_url: None,
@@ -371,5 +390,71 @@ mod tests {
         guest.is_guest = false;
         guest.is_stress_test = true;
         assert!(!admin_allowlist_matches("7", &guest));
+    }
+
+    /// The durable flag is the deployed grant: it has to work on its own,
+    /// because production sets no `SNAKETRON_ADMIN_USER_IDS` at all.
+    #[test]
+    fn the_durable_flag_grants_admin_without_any_allowlist() {
+        let mut flagged = user(7, "operator");
+        flagged.is_admin = true;
+
+        assert!(admin_granted(&flagged, None));
+        assert!(admin_granted(&flagged, Some("")));
+        assert!(admin_granted(&flagged, Some("11,12")));
+    }
+
+    #[test]
+    fn an_unflagged_account_is_not_an_admin() {
+        assert!(!admin_granted(&user(7, "ordinary"), None));
+        assert!(!admin_granted(&user(7, "ordinary"), Some("11,12")));
+    }
+
+    /// Either grant alone suffices, so the environment path keeps working for
+    /// local development and the Skin Factory tooling that depends on it.
+    #[test]
+    fn the_allowlist_still_grants_admin_to_an_unflagged_account() {
+        assert!(admin_granted(&user(7, "developer"), Some("7")));
+    }
+
+    /// The exclusion is on the decision, not on either grant, so no way of
+    /// setting the flag can make a guest or a load-test puppet an admin.
+    #[test]
+    fn the_durable_flag_cannot_promote_a_guest_or_stress_account() {
+        let mut guest = user(7, "guest");
+        guest.is_admin = true;
+        guest.is_guest = true;
+        assert!(!admin_granted(&guest, None));
+        assert!(!admin_granted(&guest, Some("7")));
+
+        let mut stress = user(7, "loadtest");
+        stress.is_admin = true;
+        stress.is_stress_test = true;
+        assert!(!admin_granted(&stress, None));
+        assert!(!admin_granted(&stress, Some("7")));
+    }
+
+    /// An account written before the flag existed has no `isAdmin` attribute,
+    /// which `get_user_by_id` reads as false. Serde has to agree, or every
+    /// user blob already sitting in the Valkey cache fails to deserialize on
+    /// the first request after deploy.
+    #[test]
+    fn a_user_serialized_without_the_flag_deserializes_as_not_admin() {
+        let mut flagged = user(7, "operator");
+        flagged.is_admin = true;
+        let json = serde_json::to_value(&flagged).expect("user serializes");
+
+        let mut legacy = json.clone();
+        legacy
+            .as_object_mut()
+            .expect("user is a JSON object")
+            .remove("is_admin")
+            .expect("the flag is serialized");
+
+        let restored: User = serde_json::from_value(legacy).expect("legacy blob deserializes");
+        assert!(!restored.is_admin);
+
+        let round_tripped: User = serde_json::from_value(json).expect("current blob deserializes");
+        assert!(round_tripped.is_admin);
     }
 }

--- a/server/src/db/dynamodb.rs
+++ b/server/src/db/dynamodb.rs
@@ -2692,6 +2692,7 @@ impl DynamoDatabase {
         item.insert("createdAt".to_string(), Self::av_s(now.to_rfc3339()));
         item.insert("isGuest".to_string(), Self::av_bool(false));
         item.insert("isStressTest".to_string(), Self::av_bool(false));
+        item.insert("isAdmin".to_string(), Self::av_bool(false));
         item.insert("authProvider".to_string(), Self::av_s("crazygames"));
         item.insert(
             "crazyGamesUserId".to_string(),
@@ -3180,6 +3181,7 @@ impl Database for DynamoDatabase {
         item.insert("createdAt".to_string(), Self::av_s(now.to_rfc3339()));
         item.insert("isGuest".to_string(), Self::av_bool(false));
         item.insert("isStressTest".to_string(), Self::av_bool(false));
+        item.insert("isAdmin".to_string(), Self::av_bool(false));
 
         self.client
             .put_item()
@@ -3202,6 +3204,7 @@ impl Database for DynamoDatabase {
             is_guest: false,
             guest_token: None,
             is_stress_test: false,
+            is_admin: false,
             auth_provider: None,
             crazygames_user_id: None,
             profile_picture_url: None,
@@ -3240,6 +3243,7 @@ impl Database for DynamoDatabase {
         item.insert("createdAt".to_string(), Self::av_s(now.to_rfc3339()));
         item.insert("isGuest".to_string(), Self::av_bool(true));
         item.insert("isStressTest".to_string(), Self::av_bool(is_stress_test));
+        item.insert("isAdmin".to_string(), Self::av_bool(false));
         item.insert("guestToken".to_string(), Self::av_s(guest_token));
 
         self.client
@@ -3268,6 +3272,7 @@ impl Database for DynamoDatabase {
             is_guest: true,
             guest_token: Some(guest_token.to_string()),
             is_stress_test,
+            is_admin: false,
             auth_provider: None,
             crazygames_user_id: None,
             profile_picture_url: None,
@@ -3451,6 +3456,10 @@ impl Database for DynamoDatabase {
                     is_guest: Self::extract_bool(&item, "isGuest").unwrap_or(false),
                     guest_token: Self::extract_string(&item, "guestToken"),
                     is_stress_test: Self::extract_bool(&item, "isStressTest").unwrap_or(false),
+                    // Absent on every account created before the flag existed,
+                    // and on every account nobody has ever granted it. Absence
+                    // is the default, not a fault.
+                    is_admin: Self::extract_bool(&item, "isAdmin").unwrap_or(false),
                     auth_provider: Self::extract_string(&item, "authProvider"),
                     crazygames_user_id: Self::extract_string(&item, "crazyGamesUserId"),
                     profile_picture_url: Self::extract_string(&item, "profilePictureUrl"),

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -34,6 +34,20 @@ pub struct User {
     pub guest_token: Option<String>,
     #[serde(default)]
     pub is_stress_test: bool,
+    /// Whether this account holds administrative authority.
+    ///
+    /// Durable and false by default: an account that has never been granted it
+    /// carries no `isAdmin` attribute at all, and an absent attribute reads as
+    /// false rather than as an error, so every account that predates this flag
+    /// is simply not an administrator. Granting it is an out-of-band operator
+    /// action (`scripts/set-user-admin.sh` in the deployment repository), not
+    /// something any request handler can do.
+    ///
+    /// This is a grant, not the decision. Guests and stress-test accounts are
+    /// refused administrative access whatever this says — ask
+    /// [`crate::api::middleware::is_admin_user`], never this field directly.
+    #[serde(default)]
+    pub is_admin: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auth_provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/server/tests/admin_flag_tests.rs
+++ b/server/tests/admin_flag_tests.rs
@@ -1,0 +1,178 @@
+//! The durable administrator flag, proved end to end against DynamoDB.
+//!
+//! The point of these tests is the seam that unit tests cannot cover: an
+//! operator writes `isAdmin` onto an account row out of band (with
+//! `scripts/set-user-admin.sh` in the deployment repository) and never touches
+//! the server, so the only thing that can carry the grant through is
+//! `get_user_by_id` actually reading the attribute back off the item.
+//!
+//! They write the attribute exactly the way that script does — a bare
+//! `UpdateItem` with `SET isAdmin = :admin` — rather than through any server
+//! API, because there deliberately is no server API for granting admin.
+
+use anyhow::Result;
+use aws_sdk_dynamodb::types::AttributeValue;
+use server::{
+    api::middleware::is_admin_user,
+    db::{Database, dynamodb::DynamoDatabase, dynamodb::dynamodb_client},
+};
+use std::sync::Arc;
+use uuid::Uuid;
+
+/// Each test rewrites the process-wide DynamoDB prefix, so this binary has to
+/// serialize setup and the database lifetime, exactly as the other DynamoDB
+/// integration binaries do.
+static TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+struct Fixture {
+    db: Arc<dyn Database>,
+    main_table: String,
+}
+
+async fn isolated_database() -> Result<Fixture> {
+    let prefix = format!("test_admin_flag_{}", Uuid::new_v4().simple());
+    // SAFETY: every test in this binary holds TEST_LOCK for its full lifetime.
+    unsafe { std::env::set_var("DYNAMODB_TABLE_PREFIX", &prefix) };
+
+    Ok(Fixture {
+        db: Arc::new(DynamoDatabase::new().await?) as Arc<dyn Database>,
+        main_table: format!("{prefix}-main"),
+    })
+}
+
+/// Flip `isAdmin` on an account row the way the operator script does: an
+/// `UpdateItem` against `USER#<id>` / `META`, touching nothing else.
+async fn write_admin_flag(main_table: &str, user_id: i32, is_admin: bool) -> Result<()> {
+    dynamodb_client()
+        .await
+        .update_item()
+        .table_name(main_table)
+        .key("pk", AttributeValue::S(format!("USER#{user_id}")))
+        .key("sk", AttributeValue::S("META".to_string()))
+        .update_expression("SET isAdmin = :admin")
+        .expression_attribute_values(":admin", AttributeValue::Bool(is_admin))
+        .send()
+        .await?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn a_new_account_is_not_an_administrator() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let fixture = isolated_database().await?;
+
+    let created = fixture.db.create_user("freshly-made", "hash", 1000).await?;
+    assert!(!created.is_admin, "a new account is never born an admin");
+
+    let loaded = fixture
+        .db
+        .get_user_by_id(created.id)
+        .await?
+        .expect("the account was just created");
+    assert!(!loaded.is_admin);
+    assert!(!is_admin_user(&loaded));
+
+    Ok(())
+}
+
+/// The whole point of the flag: it survives the round trip through DynamoDB
+/// and grants administrative access on the very next read, with no deploy, no
+/// restart, and no `SNAKETRON_ADMIN_USER_IDS` entry.
+#[tokio::test]
+async fn an_out_of_band_grant_is_read_back_and_honoured() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let fixture = isolated_database().await?;
+
+    let created = fixture.db.create_user("operator", "hash", 1000).await?;
+    write_admin_flag(&fixture.main_table, created.id, true).await?;
+
+    let promoted = fixture
+        .db
+        .get_user_by_id(created.id)
+        .await?
+        .expect("the account still exists");
+    assert!(promoted.is_admin, "the flag must survive the round trip");
+    assert!(is_admin_user(&promoted));
+
+    // And revoking is just as immediate.
+    write_admin_flag(&fixture.main_table, created.id, false).await?;
+    let demoted = fixture
+        .db
+        .get_user_by_id(created.id)
+        .await?
+        .expect("the account still exists");
+    assert!(!demoted.is_admin);
+    assert!(!is_admin_user(&demoted));
+
+    Ok(())
+}
+
+/// Granting the flag must not disturb anything else on the account row. The
+/// script uses `UpdateItem` rather than a full-item `PutItem` precisely so a
+/// promotion cannot cost somebody their rating or their progress.
+#[tokio::test]
+async fn a_grant_leaves_the_rest_of_the_account_alone() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let fixture = isolated_database().await?;
+
+    let created = fixture
+        .db
+        .create_user("intact", "secret-hash", 1234)
+        .await?;
+    fixture.db.add_user_xp(created.id, 77).await?;
+    let before = fixture
+        .db
+        .get_user_by_id(created.id)
+        .await?
+        .expect("the account exists");
+
+    write_admin_flag(&fixture.main_table, created.id, true).await?;
+
+    let after = fixture
+        .db
+        .get_user_by_id(created.id)
+        .await?
+        .expect("the account exists");
+    assert!(after.is_admin);
+    assert_eq!(after.username, before.username);
+    assert_eq!(after.password_hash, before.password_hash);
+    assert_eq!(after.mmr, before.mmr);
+    assert_eq!(after.ranked_mmr, before.ranked_mmr);
+    assert_eq!(after.casual_mmr, before.casual_mmr);
+    assert_eq!(after.xp, before.xp);
+    assert_eq!(after.games_played, before.games_played);
+    assert_eq!(after.created_at, before.created_at);
+    assert!(!after.is_guest);
+
+    Ok(())
+}
+
+/// The exclusion lives on the decision, not on the grant, so even a flag
+/// written straight onto a guest row buys nothing. The operator script refuses
+/// to write one — this proves the server would not honour it if anything else
+/// did.
+#[tokio::test]
+async fn a_flagged_guest_is_still_refused() -> Result<()> {
+    let _guard = TEST_LOCK.lock().await;
+    let fixture = isolated_database().await?;
+
+    let guest = fixture
+        .db
+        .create_guest_user("wandering-guest", "guest-token", 1000, false)
+        .await?;
+    write_admin_flag(&fixture.main_table, guest.id, true).await?;
+
+    let flagged = fixture
+        .db
+        .get_user_by_id(guest.id)
+        .await?
+        .expect("the guest exists");
+    assert!(flagged.is_guest);
+    assert!(flagged.is_admin, "the attribute is there on the row");
+    assert!(
+        !is_admin_user(&flagged),
+        "but a guest is never an administrator"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Why

The whole administrator surface already exists — `AdminRoute`, `/api/admin/*`, the skin review queue, operator analytics exclusion — but the only thing that could grant it was the `SNAKETRON_ADMIN_USER_IDS` process allowlist, which is set nowhere in the deployment repository's `cdk/` or workflows.

**Production has therefore had no administrators at all**, and the only way to get one was to redeploy the task definition — dropping every live WebSocket connection to hand one person a menu entry.

## What

`is_admin` becomes a durable, false-by-default flag on the account. An account nobody has granted it carries no `isAdmin` attribute, and an absent attribute reads as false rather than as an error, so every existing account is simply not an administrator.

`auth_middleware` already reloads the user from DynamoDB with a strongly consistent read on every authenticated request, so a grant written out of band takes effect on that user's **very next request** — no deploy, no restart, no dropped connections.

Granting is deliberately an operator action with no API behind it. `scripts/set-user-admin.sh` in the deployment repository writes the account row directly (lopatin/snaketron-io, opened alongside this).

### Decisions worth reviewing

- **The env allowlist stays**, as a second independent grant. Local development and the Skin Factory tooling bootstrap an administrator from the environment against a throwaway database, where there is no account to have flagged first.
- **The guest / stress-test exclusion moves onto the decision**, not into one grant, so no way of setting the flag can promote a guest or a load-test puppet. `admin_granted` takes the allowlist as an argument so the rule is testable without a parallel test mutating process environment.
- **`#[serde(default)]` on the field is load-bearing, not cosmetic.** `UserCache` deserializes `User` straight out of Valkey, so without it every cached blob would fail to parse on the first request after deploy. There is a test pinning exactly that.

## Blast radius

`get_user_by_id` is the only DynamoDB-item→`User` conversion, so one read site covers every reader. All three account-creation paths write `isAdmin: false` explicitly; every other `USER#/META` writer is an `UpdateItem` with `SET`/`ADD`, so none can clobber a granted flag. `User` is not a `ts-rs` wire type, so no generated TypeScript changes.

## Testing

- 7 new unit tests on the authorization rule, including the serde-default pin.
- 4 new LocalStack integration tests (`server/tests/admin_flag_tests.rs`) proving the round trip through real DynamoDB: default false, out-of-band grant read back and honoured, revoke, a grant leaving every other attribute intact, and a flagged guest still refused.
- Existing suites green: 917 lib tests, `auth_upgrade_tests`, `crazygames_account_tests`. `cargo fmt --check` and `cargo clippy --all-targets --all-features` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)